### PR TITLE
Add non-compile feature - Fix for CVE-2018-3780

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,8 +81,7 @@ Commitchange::Application.configure do
 	# with SQLite, MySQL, and PostgreSQL)
 	# config.active_record.auto_explain_threshold_in_seconds = 0.5
 
-	# Facebook application ID and secret auth token. Found in the CommitChange
-	# app dashboard.
+  config.assets.compile = false
 
 	# Compress json
 	# config.middleware.use Rack::Deflater


### PR DESCRIPTION
Applying the workaround for CVE-2018-3780. Should be best practice anyways.

https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k