### PR TITLE
Improvements to builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "url": "https://github.com/houdiniproject/houdini"
   },
   "scripts": {
-    "watch": "npm run export-button-config && npm run export-i18n && npm run generate-api-js && npx webpack --watch",
-    "build": "npm run export-button-config && npm run export-i18n && npm run generate-api-js && NODE_ENV=production npx webpack -p",
+    "watch": "HOUDINI_WATCH=1 script/build.sh",
+    "build": "script/build.sh",
     "build-all": "script/compile-assets.sh && npm run build",
     "test": "rake spec && npm run build && npx jest",
     "export-button-config": "bundle exec rake settings:generate_json",

--- a/script/build.sh
+++ b/script/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+
+(
+echo $HOUDINI_WATCH
+set -e
+set -o pipefail
+export DATABASE_URL=${BUILD_DATABASE_URL:-postgres://admin:password@db/commitchange_development}
+echo $DATABASE_URL
+npm run export-button-config && npm run export-i18n && npm run generate-api-js
+
+if [ -z "$HOUDINI_WATCH"} ];
+then
+    npx webpack --watch
+else
+    NODE_ENV=production npx webpack -p
+fi
+)

--- a/script/compile-assets.sh
+++ b/script/compile-assets.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-(source .env; RAILS_ENV=production bundle exec rake assets:precompile)
+( RAILS_ENV=${RAILS_ENV:-production} DATABASE_URL=${BUILD_DATABASE_URL:-postgres://admin:password@db/commitchange_development} bundle exec rake assets:precompile )


### PR DESCRIPTION
So there are issues with builds as it relates to non dev instances. The main problem is that when you run a build for environment x, you need access to a development db for environment x. This is inconvenient as the db isn't actually used in any of the builds, it's just required to start rails for the build tasks.

This fix allows us to build for an environment without having that environment's database setup ahead of time. To set the environment x at the command line for a build (or watch), you run the following:

`RAILS_ENV=x npm run build`

The development database has to be available to the build machine. As a work around, you can provide the database via the command line by setting the `BUILD_DATABASE_URL` which sets the `DATABASE_URL` used by the rails build process. By default, it just used the default `BUILD_DATABASE_URL=postgres://admin:password@db/commitchange_development` if `BUILD_DATABASE_URL` isn't set.