### PR TITLE
Provide support for a maintenance mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
 	def redirect_to_maintenance
 		if (Settings&.maintenance&.maintenance_mode && !current_user)
 			unless (self.class == Users::SessionsController &&
-							(params[:maintenance_token] == Settings.maintenance.maintenance_token || params[:format] == 'json'))
+							((Settings.maintenance.maintenance_token && params[:maintenance_token] == Settings.maintenance.maintenance_token) || params[:format] == 'json'))
 				redirect_to Settings.maintenance.maintenance_page
 			end
 		end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 # License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
 class ApplicationController < ActionController::Base
-	before_filter :set_locale
+	before_filter :set_locale, :redirect_to_maintenance
 
 	protect_from_forgery
 
@@ -16,6 +16,15 @@ class ApplicationController < ActionController::Base
 			I18n.locale = params[:locale]
 		else
 	  	I18n.locale = Settings.language
+		end
+	end
+
+	def redirect_to_maintenance
+		if (Settings&.maintenance&.maintenance_mode && !current_user)
+			unless (self.class == Users::SessionsController &&
+							(params[:maintenance_token] == Settings.maintenance.maintenance_token || params[:format] == 'json'))
+				redirect_to Settings.maintenance.maintenance_page
+			end
 		end
 	end
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -268,6 +268,20 @@ Config.schema do
     end
   end
 
+  # the settings to get into maintenance_mode
+  optional(:maintenance).schema do
+    # true if you want to be in maintenance mode, otherwise false
+    required(:maintenance_mode).filled(:bool?)
+
+    # the token you pass into /users/sign_in to actually get to
+    # a signin page during maintenance mode
+    optional(:maintenance_token).filled(:str?)
+
+    # the url, absolute or relative, that visitors should be redirected to
+    optional(:maintenance_page).filled(:str?)
+
+  end
+
 end
 
 Settings.reload!

--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -2,7 +2,7 @@
 Config.setup do |config|
   # Name of the constant exposing loaded settings
   config.const_name = 'Settings'
-
+  config.use_env = true
   # Ability to remove elements of the array set in earlier loaded settings file. For example value: '--'.
   #
   # config.knockout_prefix = nil

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -26,7 +26,6 @@
   <div class="dialog">
 		<h1 class='logo'><a href='/'>Houdini Project</a></h1>
     <h1>We're down for maintenance.</h1>
-		<p>All of our hamsters needed a break from running in their wheels all day.</p>
 		<p>We're sorry for the inconvenience. Please check back soon.</p>
   </div>
 </body>

--- a/spec/requests/maintenance_spec.rb
+++ b/spec/requests/maintenance_spec.rb
@@ -1,0 +1,105 @@
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+require 'rails_helper'
+require 'controllers/support/shared_user_context'
+
+describe 'Maintenance Mode' do
+  page = "http://commet"
+  token = "thoathioa"
+  include_context :shared_user_context
+  around(:each) do |example|
+    example.run
+    Settings.reload!
+  end
+
+  describe OnboardController, type: :controller do
+    describe '(Onboard is just a basic example controller)'
+    it 'not in maintenance mode' do
+      get :index
+      assert_response 200
+    end
+
+    describe 'in maintenance' do
+      before(:each) do
+        Settings.merge!({maintenance:
+                             {maintenance_mode: true,
+                              maintenance_token: token,
+                              maintenance_page: page}})
+      end
+
+      it 'redirects for onboard' do
+        get :index
+        assert_redirected_to page
+      end
+
+      it 'allows access to non-sign_in pages if youre logged in' do
+        sign_in user_as_np_associate
+        get :index
+        assert_response 200
+      end
+    end
+  end
+
+  describe Users::SessionsController, type: :controller do
+    describe 'in maintenance' do
+      include_context :shared_user_context
+      around(:each) do |example|
+        example.run
+        Settings.reload!
+      end
+
+      before(:each) do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+      end
+
+      describe 'in maintenance' do
+        before(:each) do
+          Settings.merge!({maintenance:
+                               {maintenance_mode: true,
+                                maintenance_token: token,
+                                maintenance_page: page}})
+        end
+
+        it 'redirects sign_in if the token is wrong' do
+          get(:new, {maintenance_token: "#{token}3"})
+          expect(response.code).to eq "302"
+          expect(response.location).to eq page
+        end
+
+        it 'redirects for login' do
+          get(:new)
+          expect(response.code).to eq "302"
+          expect(response.location).to eq page
+        end
+
+
+        it 'redirects sign_in if the token is passed in wrong param' do
+          get(:new, {maintnancerwrwer_token: "#{token}"})
+          expect(response.code).to eq "302"
+          expect(response.location).to eq page
+        end
+
+        it 'allows sign_in if the token is passed' do
+          get(:new, {maintenance_token: "#{token}"})
+          expect(response.code).to eq '200'
+        end
+
+        it 'allows sign_in.json' do
+          get(:new, {maintenance_token: "#{token}", format: 'json'})
+          expect(response.code).to eq '406'
+        end
+      end
+    end
+
+  end
+
+  # it 'redirect to general user' do
+  #   nonprofit
+  #   unauth_user.create_profile
+  #   sign_in unauth_user
+  #   get(:index)
+  #   expect(response).to redirect_to profile_url(unauth_user.profile.id)
+  # end
+
+
+end
+

--- a/spec/requests/maintenance_spec.rb
+++ b/spec/requests/maintenance_spec.rb
@@ -90,6 +90,24 @@ describe 'Maintenance Mode' do
       end
     end
 
+    describe 'in maintenance without maintenance_token set' do
+      before(:each) do
+        @request.env["devise.mapping"] = Devise.mappings[:user]
+      end
+      before(:each) do
+        Settings.merge!({maintenance:
+                             {maintenance_mode: true,
+                              maintenance_token: nil,
+                              maintenance_page: page}})
+      end
+
+      it 'redirects sign_in if the token is nil' do
+        get(:new)
+        expect(response.code).to eq "302"
+        expect(response.location).to eq page
+      end
+    end
+
   end
 
   # it 'redirect to general user' do

--- a/spec/requests/maintenance_spec.rb
+++ b/spec/requests/maintenance_spec.rb
@@ -109,15 +109,5 @@ describe 'Maintenance Mode' do
     end
 
   end
-
-  # it 'redirect to general user' do
-  #   nonprofit
-  #   unauth_user.create_profile
-  #   sign_in unauth_user
-  #   get(:index)
-  #   expect(response).to redirect_to profile_url(unauth_user.profile.id)
-  # end
-
-
 end
 


### PR DESCRIPTION
Maintenance is inevitable. Sometimes during maintenance, you need to shut down your Houdini instance and keep the system in a consistent state and guarantee you are the only one who can access it. That's where maintenance mode comes in.

Maintenance mode is feature which directs all non-asset requests to a maintenance page. If someone tries to access your Houdini instance without being logged in, they will receive a 302 redirect to the url in `Settings.maintenance.maintenance_page`. (Note: relative URLs are fine)

Additionally, you can log in yourself by going to `https://example.houdini.domain.to.use/users/sign_in?maintenance_token=MAINTENANCE_TOKEN` where MAINTENANCE_TOKEN is the value of `Settings.maintenance.maintenance_token`

Notably, in maintenance mode, your embedded forms will still display your maintenance page. This gives your visitors a solid experience.