### PR TITLE
Fixes for IE11

### DIFF
--- a/app/assets/stylesheets/common/minimal.css.scss
+++ b/app/assets/stylesheets/common/minimal.css.scss
@@ -4,7 +4,7 @@
   height: 90px;
 
   .container {
-    display: flex;
+    padding-top: 20px;
     height: 100%;
 
     img {
@@ -19,7 +19,7 @@
   background-color: whitesmoke;
   height:70px;
   .container {
-    display: flex;
+    padding-top: 24px;
     height: 100%;
 
     > * {
@@ -35,7 +35,7 @@
 }
 
 .site-content {
-  flex: 1;
+  flex: 1 0 auto;
 }
 
 body.minimal {

--- a/app/views/layouts/apified.html.erb
+++ b/app/views/layouts/apified.html.erb
@@ -5,7 +5,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= "#{yield(:title)} - #{Settings.general.name}" %></title>
-
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,Intl.~locale.en"></script>
   <%= IncludeAsset.js '/client/js/i18n.js' %>
   <script>
       I18n.defaultLocale = "<%= I18n.default_locale %>"
@@ -25,6 +25,7 @@
 </head>
 <body class="<%= @theme == 'minimal' ? 'minimal' : nil %>">
 <%= render 'layouts/apified_header' %>
+<%= IncludeAsset.js '/app/polyfill.js' %>
 <%= IncludeAsset.js '/app/loading_indicator.js' %>
 <%= IncludeAsset.js '/app/react.js' %>
 <%= IncludeAsset.js '/app/react-dom.js' %>

--- a/app/views/layouts/static.html.erb
+++ b/app/views/layouts/static.html.erb
@@ -5,6 +5,7 @@
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title><%= "#{yield(:title)} - #{Settings.general.name}" %></title>
+  <script src="https://cdn.polyfill.io/v2/polyfill.js?features=default,Intl.~locale.en"></script>
   <%= render 'layouts/stylesheets' %>
   <%= IncludeAsset.css '/client/css/global/page.css' %>
   <%= IncludeAsset.css '/client/css/bootstrap.css' %>
@@ -14,6 +15,7 @@
   <%= favicon_link_tag %>
 </head>
 <body class="<%= @theme == 'minimal' ? 'minimal' : nil %>">
+<%= IncludeAsset.js '/app/polyfill.js' %>
 <%= render 'layouts/apified_header' %>
 <div class="site-content">
   <%= yield %>

--- a/javascripts/app/loading_indicator.ts
+++ b/javascripts/app/loading_indicator.ts
@@ -40,7 +40,10 @@ const pp: PageProgressBar = new PageProgressBar();
 
 (window as any).pageProgress = pp
 
-pp.beginPageLoad()
+let ua = window.navigator.userAgent
+if (ua.indexOf('MSIE ') <= 0 && ua.indexOf('Trident/') <= 0) {
+  pp.beginPageLoad()
+}
 
 
 


### PR DESCRIPTION
The React pages are not working well on IE. This fix makes them work acceptably on IE11, if not ideally. IE10 and, potentially, IE9 should also be supported.