### PR TITLE
Filtering by event or campaign will include refunds now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'font_assets'
 
 # Database (postgres)
 gem 'pg' # Postgresql
-gem 'qx', git: 'https://github.com/commitchange/ruby-qx.git'
+gem 'qx', git: 'https://github.com/ericschultz/ruby-qx.git'
 gem 'dalli'
 gem 'memcachier'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
       chronic
 
 GIT
-  remote: https://github.com/commitchange/ruby-qx.git
-  revision: 3582c9a3c5d03f23480bc9b8ff1948a351ed8d6c
-  specs:
-    qx (0.1.1)
-      activerecord (>= 3.0)
-      colorize (~> 0.8)
-
-GIT
   remote: https://github.com/commitchange/stripe-ruby-mock.git
   revision: ee4471a8f654672d5596218c2b68a2913ea3f4cc
   branch: 2.4.1
@@ -31,6 +23,14 @@ GIT
       devise (>= 2.2.8, < 4)
       grape (> 0.7)
       rails (> 3.2, < 5)
+
+GIT
+  remote: https://github.com/ericschultz/ruby-qx.git
+  revision: 179467cd4a8c791beb36428975c287acc11b98b2
+  specs:
+    qx (0.1.1)
+      activerecord (>= 3.0)
+      colorize (~> 0.8)
 
 GIT
   remote: https://github.com/ruby-grape/grape-entity.git

--- a/db/migrate/20180713213748_add_charge_id_indexes.rb
+++ b/db/migrate/20180713213748_add_charge_id_indexes.rb
@@ -1,0 +1,6 @@
+class AddChargeIdIndexes < ActiveRecord::Migration
+  def change
+    add_index :refunds, :charge_id
+  end
+
+end

--- a/db/migrate/20180713215825_add_payment_id_to_tickets.rb
+++ b/db/migrate/20180713215825_add_payment_id_to_tickets.rb
@@ -1,0 +1,5 @@
+class AddPaymentIdToTickets < ActiveRecord::Migration
+  def change
+    add_index :tickets, :payment_id
+  end
+end

--- a/db/migrate/20180713220028_add_indexes_to_refunds.rb
+++ b/db/migrate/20180713220028_add_indexes_to_refunds.rb
@@ -1,0 +1,5 @@
+class AddIndexesToRefunds < ActiveRecord::Migration
+  def change
+    add_index :refunds, :payment_id
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3163,6 +3163,20 @@ CREATE INDEX index_exports_on_user_id ON public.exports USING btree (user_id);
 
 
 --
+-- Name: index_refunds_on_charge_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_refunds_on_charge_id ON public.refunds USING btree (charge_id);
+
+
+--
+-- Name: index_refunds_on_payment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_refunds_on_payment_id ON public.refunds USING btree (payment_id);
+
+
+--
 -- Name: index_sessions_on_session_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3230,6 +3244,13 @@ CREATE INDEX index_supporters_on_name ON public.supporters USING btree (name);
 --
 
 CREATE INDEX index_tickets_on_event_id ON public.tickets USING btree (event_id);
+
+
+--
+-- Name: index_tickets_on_payment_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_tickets_on_payment_id ON public.tickets USING btree (payment_id);
 
 
 --
@@ -4299,4 +4320,10 @@ INSERT INTO schema_migrations (version) VALUES ('20180217124311');
 INSERT INTO schema_migrations (version) VALUES ('20180608205049');
 
 INSERT INTO schema_migrations (version) VALUES ('20180608212658');
+
+INSERT INTO schema_migrations (version) VALUES ('20180713213748');
+
+INSERT INTO schema_migrations (version) VALUES ('20180713215825');
+
+INSERT INTO schema_migrations (version) VALUES ('20180713220028');
 

--- a/lib/insert/insert_refunds.rb
+++ b/lib/insert/insert_refunds.rb
@@ -16,7 +16,7 @@ module InsertRefunds
   def self.with_stripe(charge, h)
     ParamValidation.new(charge, { 
       payment_id: {required: true, is_integer: true},
-      stripe_charge_id: {required: true, format: /^ch_.*$/},
+      stripe_charge_id: {required: true, format: /^(test_)?ch_.*$/},
       amount: {required: true, is_integer: true, min: 1},
       id: {required: true, is_integer: true},
       nonprofit_id: {required: true, is_integer: true},

--- a/spec/lib/insert/insert_donation_spec.rb
+++ b/spec/lib/insert/insert_donation_spec.rb
@@ -8,6 +8,10 @@ describe InsertDonation do
         Settings.payment_provider.stripe_connect = true
     }
 
+    after(:each) {
+      Settings.reload!
+    }
+
     include_context :shared_rd_donation_value_context
 
     describe 'param validation' do

--- a/spec/support/contexts/shared_donation_charge_context.rb
+++ b/spec/support/contexts/shared_donation_charge_context.rb
@@ -2,7 +2,7 @@
 require 'stripe_mock'
 
 RSpec.shared_context :shared_donation_charge_context do
-  let(:nonprofit) { force_create(:nonprofit, name: "nonprofit name")}
+  let(:nonprofit) { force_create(:nonprofit, name: "nonprofit name", slug: 'nonprofit_nameo')}
   let(:other_nonprofit) { force_create(:nonprofit)}
   let(:supporter) {force_create(:supporter, :nonprofit => nonprofit, locale: 'locale_one')}
   let(:other_nonprofit_supporter) { force_create(:supporter, nonprofit: other_nonprofit, locale: 'locale_two')}


### PR DESCRIPTION
When in the payment view, you can filter by event and campaign. Currently though, we don't include associated refunds with those events. This patch fixes that bug.