### PR TITLE
Improve docker-compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,8 @@ You will likely need to logout and log back in again.
 #### Build your docker-container and start it up for initial set up.
 We'll keep this running in the console we'll call **console 1**
 ```
-cd docker/debug
-docker-compose build
-docker-compose up
+./dc build
+./dc up
 ```
 #### System configuration
 There are a number of steps for configuring your Houdini instance for startup
@@ -97,7 +96,7 @@ If you need help setting up your mailer, visit `config/environment.rb` where the
 ##### Switch back to console 1 and run `Ctrl-c` to end the session.
 
 ##### In console 1, restart the containers
-`docker-compose up`
+`./dc up`
 
 ##### In console 2, run:
 `./run npm run watch`
@@ -115,7 +114,7 @@ nonprofits, which is located at `/admin` url.
   
 To create the super user, go to the rails console by calling:
 
-`docker-compose run web rails console`
+`./dc run web rails console`
 
 In the console, run the following:
  

--- a/dc
+++ b/dc
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+current_commit=$( git rev-parse HEAD )
+current_branch=$( git rev-parse --abbrev-ref HEAD )
+
+
+docker-compose -f docker/debug/docker-compose.yml -p "${PWD}_-_-${current_branch}" $@

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -11,17 +11,15 @@ COPY script/build/debian/java.sh myapp/script/build/debian/java.sh
 RUN myapp/script/build/debian/java.sh
 COPY gems /myapp/gems/
 WORKDIR /myapp
-RUN groupadd -r -g 1000 $USER
-RUN useradd -r -m -g $USER -u 1000 $USER
-RUN chown -R $USER /usr/local/bundle
-RUN chgrp -R $USER /usr/local/bundle
-RUN chown -R $USER /myapp
-RUN chgrp -R $USER /myapp
-RUN chown -R $USER /usr/lib/node_modules
-RUN chgrp -R $USER /usr/lib/node_modules
 COPY Gemfile /myapp/Gemfile
 COPY Gemfile.lock /myapp/Gemfile.lock
 RUN bundle install
+RUN groupadd -r -g 1000 $USER
+RUN useradd -r -m -g $USER -u 1000 $USER
+RUN chown -R $USER /usr/lib/node_modules
+RUN chgrp -R $USER /usr/lib/node_modules
+RUN chown -R $USER /myapp
+RUN chgrp -R $USER /myapp
 RUN chown -R $USER /myapp/Gemfile
 RUN chgrp -R $USER /myapp/Gemfile.lock
 RUN chown -R $USER /usr/local/bundle

--- a/run
+++ b/run
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose -f docker/debug/docker-compose.yml run web $@
+./dc run web $@


### PR DESCRIPTION
Previously we'd have issues with docker-compose name conflicts. We now address it by adding a `dc` script (short for docker-compose) which uses a project name based upon the directory of the repo as well as the branch name.