### PR TITLE
Add solargraph so it works in any tools that use it

### DIFF
--- a/.solargraph.yml
+++ b/.solargraph.yml
@@ -1,0 +1,16 @@
+---
+include:
+- "**/*.rb"
+exclude:
+- spec/**/*
+- test/**/*
+- vendor/**/*
+- ".bundle/**/*"
+require: []
+domains: []
+reporters:
+- rubocop
+- require_not_found
+plugins: []
+require_paths: []
+max_files: 5000


### PR DESCRIPTION
Solargraph is used for Ruby autocomplete in a number of editors, including VSCode and Atom.