### PR TITLE
Add merged_into association for Supporter

### DIFF
--- a/app/models/supporter.rb
+++ b/app/models/supporter.rb
@@ -48,6 +48,7 @@ class Supporter < ActiveRecord::Base
   has_many :tag_masters, through: :tag_joins
   has_many :custom_field_joins, dependent: :destroy
   has_many :custom_field_masters, through: :custom_field_joins
+  belongs_to :merged_into, class_name: 'Supporter', :foreign_key => 'merged_into'
 
   validates :nonprofit, :presence => true
   scope :not_deleted, -> {where(deleted: false)}


### PR DESCRIPTION
There wasn't an easy way to follow a merged supporter to the supporter it was merged into. Now we have it.