### PR TITLE
Turn on proper model property naming

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "export-i18n": "bundle exec rake settings:combine_translations",
     "generate-openapi": "rake oapi:gen",
     "get-codegen-cli": "script/download_codegen_cli.sh",
-    "generate-api-js": "rm -rf javascripts/api && npm run get-codegen-cli && npm run generate-openapi && java -jar .bin/swagger-codegen-cli.jar generate -l 'typescript-jquery' -i tmp/openapi.json -o javascripts/api -t lib/swagger-typescript-jquery"
+    "generate-api-js": "rm -rf javascripts/api && npm run get-codegen-cli && npm run generate-openapi && java -jar .bin/swagger-codegen-cli.jar generate -l 'typescript-jquery' -i tmp/openapi.json -o javascripts/api  --config 'swagger.json' -t lib/swagger-typescript-jquery"
   },
   "devDependencies": {
     "@types/enzyme": "^3.1.9",

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,3 @@
+{
+    "modelPropertyNaming": "original"
+}


### PR DESCRIPTION
Codegen'ed model properties were previously always turned to camelCase. This change makes properties snake_case.