### PR TITLE
Move nonprofit branding to a TS file

### DIFF
--- a/client/js/components/nonprofit-branding.js
+++ b/client/js/components/nonprofit-branding.js
@@ -1,16 +1,5 @@
 // License: LGPL-3.0-or-later
-const color = require('color')
+import nonprofitBranding from '../../../javascripts/src/lib/nonprofitBranding.ts';
 
-var brandColor = app.nonprofit.brand_color || '#5FB88D'
-
-module.exports = {
-  lightest: color(brandColor).lighten(0.8).hexString()
-, lighter: color(brandColor).lighten(0.7).hexString()
-, light: color(brandColor).lighten(0.5).hexString()
-, base: brandColor
-, dark: color(brandColor).darken(0.1).hexString()
-, darker: color(brandColor).darken(0.3).hexString()
-, grey: "#636363"
-, light_grey: "rgb(248, 248, 248)"
-}
+export default nonprofitBranding(app.nonprofit.brand_color)
 

--- a/client/js/recurring_donations/edit/custom-nonprofit-branding.es6
+++ b/client/js/recurring_donations/edit/custom-nonprofit-branding.es6
@@ -1,16 +1,4 @@
 // License: LGPL-3.0-or-later
-const color = require('color')
+import nonprofitBranding from '../../../../javascripts/src/lib/nonprofitBranding.ts';
 
-module.exports = (brand_color = null) => {
-    let brandColor = brand_color || '#5FB88D'
-    return {
-        lightest: color(brandColor).lighten(0.8).hexString()
-        , lighter: color(brandColor).lighten(0.7).hexString()
-        , light: color(brandColor).lighten(0.5).hexString()
-        , base: brandColor
-        , dark: color(brandColor).darken(0.1).hexString()
-        , darker: color(brandColor).darken(0.3).hexString()
-        , grey: "#636363"
-        , light_grey: "rgb(248, 248, 248)"
-    }
-}
+export default nonprofitBranding

--- a/javascripts/src/lib/nonprofitBranding.ts
+++ b/javascripts/src/lib/nonprofitBranding.ts
@@ -1,0 +1,30 @@
+// License: LGPL-3.0-or-later
+import color = require('color')
+import { Color } from 'csstype';
+
+interface CustomBrandColors {
+  lightest: Color,
+  lighter: Color,
+  light: Color,
+  base: Color,
+  dark: Color,
+  darker: Color,
+  grey: Color,
+  light_grey: Color
+}
+
+export default (brandColor?: Color): CustomBrandColors => {
+  if (!brandColor) {
+    brandColor = '#5FB88D'
+  }
+  return {
+    lightest: color(brandColor).lighten(0.8).hex()
+    , lighter: color(brandColor).lighten(0.7).hex()
+    , light: color(brandColor).lighten(0.5).hex()
+    , base: brandColor
+    , dark: color(brandColor).darken(0.1).hex()
+    , darker: color(brandColor).darken(0.3).hex()
+    , grey: "#636363"
+    , light_grey: "rgb(248, 248, 248)"
+  }
+}


### PR DESCRIPTION
There was a bug in the use of the color library. To assist in future work, we move the use of color library into a TS module.