### PR TITLE
Fix bug where we don't percent encode parts of the widget iframe URL

### DIFF
--- a/app/javascript/legacy/widget/donate-button.v2.js
+++ b/app/javascript/legacy/widget/donate-button.v2.js
@@ -81,7 +81,7 @@ commitchange.createIframe = (source) => {
   let i = document.createElement('iframe')
   const url = document.location.href
   i.setAttribute('class', 'commitchange-closed commitchange-iframe')
-  i.src = source + "&origin=" + url
+  i.src = encodeURI(source + "&origin=" + url)
   return i
 }
 
@@ -158,7 +158,7 @@ commitchange.appendMarkup = () => {
         let btn_iframe = document.createElement('iframe')
         let btn_src = fullHost + "/nonprofits/" + nonprofitID + "/btn"
         if(elem.hasAttribute('data-fixed')) { btn_src += '?fixed=t' }
-        btn_iframe.src = btn_src
+        btn_iframe.src = encodeURI(btn_src)
         btn_iframe.className = 'commitchange-btn-iframe'
         btn_iframe.setAttribute('scrolling', 'no')
         btn_iframe.setAttribute('seamless', 'seamless')


### PR DESCRIPTION
The widget iframe URL is not correctly percent-encoded. If you include a character in your data-description attribute for your button, you'll create an invalid URL and the server will return a 500 error. This fix properly percent-encodes the URL.