### PR TITLE
Reorganize workflow so we reuse more between steps

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -1,8 +1,13 @@
 name: Houdini build
 on: [push, pull_request]
 jobs:
-  notice_ruby:
-    runs-on: ubuntu-latest
+  install_gems:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+        ruby: [2.6.6]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -14,20 +19,72 @@ jobs:
         name: Use Gem cache
         with:
           path: vendor/bundle
-          key: bundle-use-ruby-ubuntu-latest-2.6.6-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            bundle-use-ruby-ubuntu-latest-2.6.6-
+            bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
       - name: bundle install
         run: |
           bundle config deployment true
           bundle config path vendor/bundle
           bundle install --jobs 4
+  install_yarn:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+        ruby: [2.6.6]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v1.4.2
+      - uses: actions/cache@v1
+        name: Use Node package cache
+        with:
+          path: node_modules
+          key: bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-
+      - name: install node packages
+        run: yarn install --frozen-lockfile
+
+  notice_ruby:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+        ruby: [2.6.6]
+    needs: ['install_gems']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+      # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      # uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+      - uses: actions/cache@v1
+        name: Use Gem cache
+        with:
+          path: vendor/bundle
+          key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
+      - name: bundle setup
+        run: |
+          bundle config deployment true
+          bundle config path vendor/bundle
       - name: run notice:ruby:verify
         run: |
             bin/rails notice:ruby:verify
   notice_js:
-    runs-on: ubuntu-latest
-    needs: notice_ruby
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+        ruby: [2.6.6]
+    needs: ['install_gems', 'install_yarn']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Ruby
@@ -41,28 +98,25 @@ jobs:
         name: Use Node package cache
         with:
           path: node_modules
-          key: bundle-use-node-js-ubuntu-latest-12-${{ hashFiles('**/yarn.lock') }}
+          key: bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            bundle-use-node-js-ubuntu-latest-12-
+            bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-
       - uses: actions/cache@v1
         name: Use Gem cache
         with:
           path: vendor/bundle
-          key: bundle-use-ruby-ubuntu-latest-2.6.6-${{ hashFiles('**/Gemfile.lock') }}
+          key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            bundle-use-ruby-ubuntu-latest-2.6.6-
-      - name: bundle install
+            bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
+      - name: bundle setup
         run: |
           bundle config deployment true
           bundle config path vendor/bundle
-          bundle install --jobs 4
-      - name: install node packages
-        run: yarn install --frozen-lockfile
       - name: run notice:js:verify
         run: |
             bin/rails notice:js:verify
   main_build:
-    needs: [notice_js]
+    needs: ['notice_js', 'notice_ruby']
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -91,11 +145,10 @@ jobs:
         key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
-    - name: bundle install
+    - name: bundle setup
       run: |
         bundle config deployment true
         bundle config path vendor/bundle
-        bundle install --jobs 4
     - uses: actions/cache@v1
       name: Use Node package cache
       with:

--- a/bin/setup
+++ b/bin/setup
@@ -13,17 +13,16 @@ FileUtils.chdir APP_ROOT do
   # This script is a way to setup or update your development environment automatically.
   # This script is idempotent, so that you can run it at anytime and get an expectable outcome.
   # Add necessary setup steps to this file.
+  
+  # we don't install dependencies on ci because it's been done already
+  if ARGV.length == 0 || (ARGV.length > 0 && ARGV[0] != 'ci')
+    puts '== Installing dependencies (Ruby) =='
+    system! 'gem install bundler --conservative'
+    system('bundle check') || system!('bundle install')
 
-  puts '== Installing dependencies (Ruby) =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
-
-  puts "\n== Installing dependencies (JS) =="
-  yarn_cmd = 'yarn -s'
-  if ARGV.length > 0 && ARGV[0] == 'ci'
-    yarn_cmd += " --frozen-lockfile"
+    puts "\n== Installing dependencies (JS) =="
+    system!('yarn -s')
   end
-  system!('yarn -s')
 
 
   if ARGV.length == 0 || (ARGV.length > 0 && ARGV[0] != 'ci')


### PR DESCRIPTION
This change makes it so we only need to run yarn install and bundle install a single time and we cache the results. We then reuse the cache in multiple places but don't run yarn and bundle install a bunch of times. That should make the workflow slightly faster.