### PR TITLE
Extends webpacker dev proxy timeout

### DIFF
--- a/app/javascript/i18n.js.erb
+++ b/app/javascript/i18n.js.erb
@@ -1,7 +1,7 @@
 const I18n = require('i18n-js');
 
 I18n.translations = I18n.translations || {};
-<% I18n::JS::translations.each do |k,v| %>
+<% I18n::JS::translations.select{|k,v| Houdini.intl.available_locales.map{|i| i.to_s}.include?(k.to_s)}.each do |k,v| %>
 I18n.translations['<%= k %>'] = I18n.extend((I18n.translations['<%= k %>'] || {}),<%= JSON.generate(v) %>);
 <% end %>
 module.exports = I18n;

--- a/config/application.rb
+++ b/config/application.rb
@@ -112,5 +112,18 @@ module Commitchange
     config.active_storage.variant_processor = :vips
 
     config.action_mailer.default_options = {from: "Default Org Team <hi@defaultorg.com>"}
+
+    # this works around a bug where the the webpacker proxy
+    # only waits 60 seconds for a compilation to happen. That's not 
+    # fast enough on startup and Webpacker doesn't allow us to override.
+    # 
+    # TODO: figure out how to delete the first instance of DevServerProxy
+    initializer "houdini.webpacker.proxy" do |app|
+      insert_middleware = Webpacker.config.dev_server.present? rescue nil
+      if insert_middleware
+        app.middleware.insert_before 0,
+             Webpacker::DevServerProxy, ssl_verify_none: true, read_timeout: 500
+      end
+    end
   end
 end


### PR DESCRIPTION
There is a [bug](https://github.com/rails/webpacker/issues/2632) in Webpacker which makes long Webpacker compilations, like those in Houdini, fail . This is a temporary workaround for that.

Depends on #290