### PR TITLE
Add JS Money Type

### DIFF
--- a/NOTICE-js
+++ b/NOTICE-js
@@ -16220,6 +16220,35 @@ SOFTWARE.
 
 ------
 
+** js-money; version 0.6.3 -- https://github.com/davidkalosi/js-money#readme
+Copyright (c) 2014 David Kalosi
+Copyright (c) 2014 David Kalosi http://davidkalosi.com/ (http://davidkalosi.com/)
+
+Copyright (c) 2014 David Kalosi
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+------
+
 ** webpack-assets-manifest; version 3.1.1 -- https://github.com/webdeveric/webpack-assets-manifest
 Copyright (c) 2016 Eric King
 

--- a/app/javascript/common/money.ts
+++ b/app/javascript/common/money.ts
@@ -30,10 +30,11 @@ export class Money {
 
   protected constructor(readonly amountInCents: number, currency: string) {
     this.currency = currency.toLowerCase()
-    [this.equals, this.add, this.subtract, this.multiply, this.divide, this.allocate,
+    const methodsToBind = [this.equals, this.add, this.subtract, this.multiply, this.divide, this.allocate,
       this.compare, this.greaterThan, this.greaterThanOrEqual, this.lessThan,
       this.lessThanOrEqual, this.isZero, this.isPositive, this.isNegative,
-      this.toJSON].forEach((func) => Object.bind(func))
+      this.toJSON]
+      methodsToBind.forEach((func:Function) => Object.bind(func))
     
     Object.freeze(this);
   }
@@ -107,7 +108,7 @@ export class Money {
    * @returns {Money}
    */
   multiply(multiplier: number, fn?: Function): Money {
-    if (!lodash.isFunction(fn))
+    if (!isFunction(fn))
       fn = Math.round;
 
     assertOperand(multiplier);
@@ -124,7 +125,7 @@ export class Money {
    * @returns {Money}
    */
   divide(divisor: number, fn?: (x: number) => number): Money {
-    if (!lodash.isFunction(fn))
+    if (!isFunction(fn))
       fn = Math.round;
 
     assertOperand(divisor);

--- a/app/javascript/common/money.ts
+++ b/app/javascript/common/money.ts
@@ -1,0 +1,264 @@
+// License: LGPL-3.0-or-later
+// based upon https://github.com/davidkalosi/js-money
+import isFunction from 'lodash/isFunction'
+
+const assertSameCurrency = function (left: any, right: any) {
+  if (left.currency !== right.currency)
+    throw new Error('Different currencies');
+};
+
+const assertType = function (other: any) {
+  if (!(other instanceof Money))
+    throw new TypeError('Instance of Money required');
+};
+
+const assertOperand = function (operand: any) {
+  if (isNaN(parseFloat(operand)) && !isFinite(operand))
+    throw new TypeError('Operand must be a number');
+};
+
+/**
+ * Represents a monetary amount. For safety, all Money objects are immutable. All of the functions in this class create a new Money object.
+ * 
+ * To create a new Money object is to use the `fromCents` function.
+ * @export
+ * @class Money
+ */
+export class Money {
+
+  readonly currency:string
+
+  protected constructor(readonly amountInCents: number, currency: string) {
+    this.currency = currency.toLowerCase()
+    [this.equals, this.add, this.subtract, this.multiply, this.divide, this.allocate,
+      this.compare, this.greaterThan, this.greaterThanOrEqual, this.lessThan,
+      this.lessThanOrEqual, this.isZero, this.isPositive, this.isNegative,
+      this.toJSON].forEach((func) => Object.bind(func))
+    
+    Object.freeze(this);
+  }
+
+  /**
+   * Create a `Money` object with the given number of cents and the ISO currency unit
+   * @static
+   * @param  {number} amountInCents 
+   * @param  {string} currency 
+   * @return Money 
+   * @memberof Money
+   */
+  static fromCents(amountInCents: number, currency: string): Money {
+    return new Money(amountInCents, currency)
+  }
+
+  /**
+   * Create a `Money` object with the given number if smallest monetary units and the ISO currency. Another name for the `fromCents` function.
+   * @static
+   * @memberof Money
+   */
+  static fromSMU=Money.fromCents
+
+  /**
+  * Returns true if the two instances of Money are equal, false otherwise.
+  *
+  * @param {Money} other
+  * @returns {Boolean}
+  */
+  equals(other: Money): boolean {
+    var self = this;
+    assertType(other);
+
+    return self.amountInCents === other.amountInCents &&
+      self.currency === other.currency;
+  };
+
+  /**
+   * Adds the two objects together creating a new Money instance that holds the result of the operation.
+   *
+   * @param {Money} other
+   * @returns {Money}
+   */
+  add(other: Money): Money {
+    var self = this;
+    assertType(other);
+    assertSameCurrency(self, other);
+
+    return new Money(self.amountInCents + other.amountInCents, self.currency);
+  };
+
+  /**
+   * Subtracts the two objects creating a new Money instance that holds the result of the operation.
+   *
+   * @param {Money} other
+   * @returns {Money}
+   */
+  subtract(other: Money): Money {
+    var self = this;
+    assertType(other);
+    assertSameCurrency(self, other);
+
+    return new Money(self.amountInCents - other.amountInCents, self.currency);
+  };
+
+  /**
+   * Multiplies the object by the multiplier returning a new Money instance that holds the result of the operation.
+   *
+   * @param {Number} multiplier
+   * @param {(x:number) => number} [fn=Math.round]
+   * @returns {Money}
+   */
+  multiply(multiplier: number, fn?: Function): Money {
+    if (!lodash.isFunction(fn))
+      fn = Math.round;
+
+    assertOperand(multiplier);
+    var amount = fn(this.amountInCents * multiplier);
+
+    return new Money(amount, this.currency);
+  };
+
+  /**
+   * Divides the object by the multiplier returning a new Money instance that holds the result of the operation.
+   *
+   * @param {Number} divisor
+   * @param {(x:number) => number} [fn=Math.round]
+   * @returns {Money}
+   */
+  divide(divisor: number, fn?: (x: number) => number): Money {
+    if (!lodash.isFunction(fn))
+      fn = Math.round;
+
+    assertOperand(divisor);
+    var amount = fn(this.amountInCents / divisor);
+
+    return new Money(amount, this.currency);
+  };
+
+  /**
+   * Allocates fund bases on the ratios provided returing an array of objects as a product of the allocation.
+   *
+   * @param {Array} other
+   * @param {Money[]}
+   */
+  allocate(ratios: number[]): Money[] {
+    var self = this;
+    var remainder = self.amountInCents;
+    var results: Money[] = [];
+    var total = 0;
+
+    ratios.forEach(function (ratio) {
+      total += ratio;
+    });
+
+    ratios.forEach(function (ratio) {
+      var share = Math.floor(self.amountInCents * ratio / total)
+      results.push(new Money(share, self.currency));
+      remainder -= share;
+    });
+
+    for (var i = 0; remainder > 0; i++) {
+      results[i] = new Money(results[i].amountInCents + 1, results[i].currency);
+      remainder--;
+    }
+
+    return results;
+  };
+
+  /**
+   * Compares two instances of Money.
+   *
+   * @param {Money} other
+   * @returns {Number}
+   */
+  compare(other: Money): number {
+    var self = this;
+
+    assertType(other);
+    assertSameCurrency(self, other);
+
+    if (self.amountInCents === other.amountInCents)
+      return 0;
+
+    return self.amountInCents > other.amountInCents ? 1 : -1;
+  };
+
+  /**
+   * Checks whether the value represented by this object is greater than the other.
+   *
+   * @param {Money} other
+   * @returns {boolean}
+   */
+  greaterThan(other: Money): boolean {
+    return 1 === this.compare(other);
+  };
+
+  /**
+   * Checks whether the value represented by this object is greater or equal to the other.
+   *
+   * @param {Money} other
+   * @returns {boolean}
+   */
+  greaterThanOrEqual(other: Money): boolean {
+    return 0 <= this.compare(other);
+  };
+
+  /**
+   * Checks whether the value represented by this object is less than the other.
+   *
+   * @param {Money} other
+   * @returns {boolean}
+   */
+  lessThan(other: Money): boolean {
+    return -1 === this.compare(other);
+  };
+
+  /**
+   * Checks whether the value represented by this object is less than or equal to the other.
+   *
+   * @param {Money} other
+   * @returns {boolean}
+   */
+  lessThanOrEqual(other: Money): boolean {
+    return 0 >= this.compare(other);
+  };
+
+  /**
+   * Returns true if the amount is zero.
+   *
+   * @returns {boolean}
+   */
+  isZero(): boolean {
+    return this.amountInCents === 0;
+  };
+
+  /**
+   * Returns true if the amount is positive.
+   *
+   * @returns {boolean}
+   */
+  isPositive(): boolean {
+    return this.amountInCents > 0;
+  };
+
+  /**
+   * Returns true if the amount is negative.
+   *
+   * @returns {boolean}
+   */
+  isNegative(): boolean {
+    return this.amountInCents < 0;
+  };
+
+  /**
+   * Returns a serialised version of the instance.
+   *
+   * @returns {{amount: number, currency: string}}
+   */
+  toJSON(): { amountInCents: number; currency: string; } {
+    return {
+      amountInCents: this.amountInCents,
+      currency: this.currency
+    };
+  };
+
+
+}

--- a/included.json
+++ b/included.json
@@ -1,0 +1,9 @@
+{
+    "__explanation": "packages where code was included from but isn't an NPM dependency. 'packages' is the list of packages",
+    "packages": [
+        {
+            "name": "js-money",
+            "version": "0.6.3"
+        }
+    ]
+}


### PR DESCRIPTION
Currently, money is handled as numbers and strings on the front end. This is error prone and makes it difficult to internationalize our UI. To improve the situation, I've added a new Javascript class to Houdini to represent monetary values. It is based on the [js-money](https://github.com/davidkalosi/js-money) package.

Money has the following features:

* Holds the monetary value in the smallest monetary unit, i.e. US dollars are recorded in cents so the values are in an integer.
* Has support for basic arithmetic of multiple money objects, like: `value1.add(value2)`
* Money objects are immutable. In the above example, `value1.add(value2)` creates a new object.
* Has support for comparisons, like: `value1.greaterThan(value2)`
* Prevents operations between two objects with different currencies. As an example, adding Money object in US dollars and a Money object in Euros will throw an error.