### PR TITLE
Reorder the actions on push

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -116,7 +116,7 @@ jobs:
         run: |
             bin/rails notice:js:verify
   main_build:
-    needs: ['notice_js', 'notice_ruby']
+    needs: ['install_yarn', 'install_gems']
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -115,6 +115,26 @@ jobs:
       - name: run notice:js:verify
         run: |
             bin/rails notice:js:verify
+  jest:
+    needs:  ['install_yarn']
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.2
+    - uses: actions/cache@v1
+      name: Use Node package cache
+      with:
+        path: node_modules
+        key: bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-
+    - name: run jest
+      run: yarn jest
   main_build:
     needs: ['install_yarn', 'install_gems']
     runs-on: ${{ matrix.os }}
@@ -160,5 +180,3 @@ jobs:
       run: bin/setup ci
     - name: run spec
       run: bin/rails spec
-    - name: run jest
-      run: yarn jest


### PR DESCRIPTION
Reorganizing allows us to speed up our builds since we can do more concurrently