### PR TITLE
Setup linting of javascript used by node based build tools

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,38 @@
 // License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 // Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+const _ = require('lodash');
+
+const tsSpecBase = {
+	parser: '@typescript-eslint/parser',
+	plugins: [
+		'@typescript-eslint',
+		'jest'
+	],
+	extends: [
+		'eslint:recommended',
+		'plugin:@typescript-eslint/recommended',
+		'plugin:jest/all'
+	],
+	rules:{
+		"jest/lowercase-name": ["error", { "ignore": ["describe"]}]
+	}
+};
+
+const tsSpec = _.cloneDeep(tsSpecBase);
+tsSpec['files'] = ['**/*.spec.ts'];
 
 
 module.exports = {
 	root: true,
 
 	overrides: [
+		{
+			"files": ['*.js', 'config/webpack/**/*.js'],
+			extends: [
+				'eslint:recommended',
+				'plugin:node/recommended'
+			],
+		},
 		{
 			"files": ['**/*.ts'],
 			parser: '@typescript-eslint/parser',
@@ -17,22 +44,7 @@ module.exports = {
 				'plugin:@typescript-eslint/recommended',
 			]
 		},
-		{
-			"files": ['**/*.spec.ts'],
-			parser: '@typescript-eslint/parser',
-			plugins: [
-				'@typescript-eslint',
-				'jest'
-			],
-			extends: [
-				'eslint:recommended',
-				'plugin:@typescript-eslint/recommended',
-				'plugin:jest/all'
-			],
-			rules:{
-				"jest/lowercase-name": ["error", { "ignore": ["describe"]}]
-			}
-		}
+		tsSpec
 	],
 	"rules": {
 		"linebreak-style": [

--- a/NOTICE-js
+++ b/NOTICE-js
@@ -12566,6 +12566,8 @@ SOFTWARE.
 
 ------
 
+** eslint-plugin-es; version 3.0.1 -- https://github.com/mysticatea/eslint-plugin-es#readme
+Copyright (c) 2018 Toru Nagashima
 ** eslint-utils; version 2.1.0 -- https://github.com/mysticatea/eslint-utils#readme
 Copyright (c) 2018 Toru Nagashima
 ** regexpp; version 3.1.0 -- https://github.com/mysticatea/regexpp#readme
@@ -14928,6 +14930,35 @@ copyright header of example files e592c53 (https://github.com/http-party/node-ht
   LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------
+
+** eslint-plugin-node; version 11.1.0 -- https://github.com/mysticatea/eslint-plugin-node#readme
+Copyright (c) 2015 Toru Nagashima
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Toru Nagashima
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 
 ------

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "enzyme-to-json": "^3.3.3",
     "eslint": "^7.3.1",
     "eslint-plugin-jest": "^23.17.1",
+    "eslint-plugin-node": "^11.1.0",
     "fork-ts-checker-webpack-plugin": "^5.0.4",
     "jest": "^24.1.0",
     "jest-enzyme": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6455,12 +6455,32 @@ escodegen@^1.9.1:
   optionalDependencies:
     source-map "~0.6.1"
 
+eslint-plugin-es@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
 eslint-plugin-jest@^23.17.1:
   version "23.17.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-23.17.1.tgz#c0f39ba78e0f33b7ee1ce4ec92b773e39026ea3f"
   integrity sha512-/o36fw67qNbJGWbSBIBMfseMsNP/d88WUHAGHCi1xFwsNB3XXZGdvxbOw49j3iQz6MCW/yw8OeOsuQhi6mM5ZA==
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
+
+eslint-plugin-node@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
 
 eslint-scope@^4.0.3:
   version "4.0.3"
@@ -8129,6 +8149,11 @@ ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.1:
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
+  integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
 imagesloaded@4.1.1:
   version "4.1.1"
@@ -13496,7 +13521,7 @@ resolve@1.7.1:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@1.x, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@1.x, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -13780,7 +13805,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
ESlint, Babel and Webpack all use Javascript but, because they run in node, they require a different set of restrictions. This change does that.