### PR TITLE
Add a webpack build to the PR actions

### DIFF
--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -201,3 +201,48 @@ jobs:
       run: bin/setup ci
     - name: run spec
       run: bin/rails spec
+  webpack:
+    needs: ['install_yarn', 'install_gems']
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [12]
+        ruby: [2.6.6]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup PostgreSQL with PostgreSQL extensions and unprivileged user
+      uses: Daniel-Marynicz/postgresql-action@0.1.0
+      with:
+        postgres_image_tag: 11-alpine
+        postgres_user: houdini_user
+        postgres_password: password
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
+    - name: Setup Node.js environment
+      uses: actions/setup-node@v1.4.2
+    - uses: actions/cache@v1
+      name: Use Gem cache
+      with:
+        path: vendor/bundle
+        key: bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          bundle-use-ruby-${{ matrix.os }}-${{ matrix.ruby }}-
+    - name: bundle setup
+      run: |
+        bundle config deployment true
+        bundle config path vendor/bundle
+    - uses: actions/cache@v1
+      name: Use Node package cache
+      with:
+        path: node_modules
+        key: bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          bundle-use-node-js-${{ matrix.os }}-${{ matrix.node }}-
+    - name: run setup
+      run: bin/setup ci
+    - name: Webpack compile everything
+      run: bin/webpack


### PR DESCRIPTION
We don't actually build and bundle the Typescript/Javascript on a PR. This addresses that by adding an action for Webpack build and bundling.