### PR TITLE
Correct blocklist/allowlist language

### DIFF
--- a/app/javascript/donate-button/donate-button.v2.ts
+++ b/app/javascript/donate-button/donate-button.v2.ts
@@ -16,13 +16,13 @@ function on_ios11() {
   , modalIframe: null
   }
   const commitchange = windowAsAny.commitchange;
-  commitchange.getParamsFromUrl = (whitelist:any) => {
+  commitchange.getParamsFromUrl = (allowlist:any) => {
       var result:any = {},
           tmp = [];
       var items = location.search.substr(1).split("&");
       for (var index = 0; index < items.length; index++) {
           tmp = items[index].split("=");
-          if (whitelist.indexOf(tmp[0])) result[tmp[0]] = decodeURIComponent(tmp[1]);
+          if (allowlist.indexOf(tmp[0])) result[tmp[0]] = decodeURIComponent(tmp[1]);
       }
       return result;
   }

--- a/app/javascript/legacy/widget/donate-button.v2.js
+++ b/app/javascript/legacy/widget/donate-button.v2.js
@@ -23,13 +23,13 @@ window.commitchange = {
 , modalIframe: null
 }
 
-commitchange.getParamsFromUrl = (whitelist) => {
+commitchange.getParamsFromUrl = (allowlist) => {
     var result = {},
         tmp = [];
     var items = location.search.substr(1).split("&");
     for (var index = 0; index < items.length; index++) {
         tmp = items[index].split("=");
-        if (whitelist.indexOf(tmp[0])) result[tmp[0]] = decodeURIComponent(tmp[1]);
+        if (allowlist.indexOf(tmp[0])) result[tmp[0]] = decodeURIComponent(tmp[1]);
     }
     return result;
 }

--- a/app/javascript/legacy_react/src/components/create_offsite_payment_pane/CreateOffsitePaymentPane.tsx
+++ b/app/javascript/legacy_react/src/components/create_offsite_payment_pane/CreateOffsitePaymentPane.tsx
@@ -18,7 +18,7 @@ import {ApiManager} from "../../lib/api_manager";
 import * as CustomAPIS from "../../lib/apis";
 import {CSRFInterceptor} from "../../lib/csrf_interceptor";
 import {CreateOffsiteDonation, CreateOffsiteDonationModel} from "../../lib/api/create_offsite_donation";
-import blacklist from "validator/lib/blacklist";
+import blocklist from "validator/lib/blacklist";
 import * as _ from 'lodash';
 import moment from 'moment';
 import { castToUndefinedIfBlank } from '../../lib/utils';
@@ -140,14 +140,9 @@ class CreateNewOffsitePaymentPane extends React.Component<CreateOffsitePaymentPa
       'gross_amount': createFieldDefinition({name: 'gross_amount', 
         label: 'Gross Amount',
         input: (amount:number) => centsToDollars(amount),
-        output: (dollarString:string) => parseFloat(blacklist(dollarString, '$,')),
+        output: (dollarString:string) => parseFloat(blocklist(dollarString, '$,')),
         value: 0
       }),
-      // 'fee_total': createFieldDefinition({name: 'fee_total', label: 'Fees',
-      //   input: (amount:number) => centsToDollars(amount),
-      //   output: (dollarString:string) => parseFloat(blacklist(dollarString, '$,')),
-      //   value: 0
-      // }),
       'date': createFieldDefinition({name: 'date', label: 'Date',
         input: (isoTime:string) => this.nonprofitTimezonedDates.readable_date(isoTime),
         output:(date:string) =>  this.nonprofitTimezonedDates.readable_date_time_to_iso(date),

--- a/app/javascript/legacy_react/src/components/edit_payment_pane/EditPaymentPane.tsx
+++ b/app/javascript/legacy_react/src/components/edit_payment_pane/EditPaymentPane.tsx
@@ -17,7 +17,7 @@ import {TwoColumnFields} from "../common/layout";
 import {Validations} from "../../lib/vjf_rules";
 import * as _ from 'lodash'
 import {Dedication, parseDedication, serializeDedication} from '../../lib/dedication';
-import blacklist from "validator/lib/blacklist";
+import blocklist from "validator/lib/blacklist";
 import {createFieldDefinition} from "../../lib/mobx_utils";
 import Modal from "../common/Modal";
 import ReactInput from "../common/form/ReactInput";
@@ -186,12 +186,12 @@ class EditPaymentPane extends React.Component<EditPaymentPaneProps & WrappedComp
       'gross_amount': createFieldDefinition({
         name: 'gross_amount', label: 'Gross Amount', value: this.props.data.gross_amount,
         input: (amount: number) => centsToDollars(amount),
-        output: (dollarString: string) => parseFloat(blacklist(dollarString, '$,'))
+        output: (dollarString: string) => parseFloat(blocklist(dollarString, '$,'))
       }),
       'fee_total': createFieldDefinition({
         name: 'fee_total', label: 'Fees', value: this.props.data.fee_total,
         input: (amount: number) => centsToDollars(amount),
-        output: (dollarString: string) => parseFloat(blacklist(dollarString, '$,'))
+        output: (dollarString: string) => parseFloat(blocklist(dollarString, '$,'))
       }),
       'date': createFieldDefinition({
         name: 'date', label: 'Date',

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,12 +68,6 @@ module Commitchange
     # like if you have constraints or database-specific column types
     config.active_record.schema_format = :sql
 
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    # config.active_record.whitelist_attributes = true
-
     # Enable the asset pipeline
     config.assets.enabled = true
 


### PR DESCRIPTION
Previously we used the offensive terms "blacklist" and "whitelist" instad of "blocklist" and "allowlist". This change corrects this regretable oversight.

As a leader in the Houdini Project, I apologize for this unintentional but unacceptable oversight and anyone harmed by this.

--

One thing to note is that we use NPM package, validator, which uses the term "blacklist" as part of its api for a blocklist.
I believe it would be best to replace that package but I have no done so yet as I haven't had the time. I will create an
issue to track that change being done.
