### PR TITLE
Event Publisher Support - TagMaster

### DIFF
--- a/app/controllers/nonprofits/tag_masters_controller.rb
+++ b/app/controllers/nonprofits/tag_masters_controller.rb
@@ -5,7 +5,7 @@
 module Nonprofits
   class TagMastersController < ApplicationController
     include Controllers::Nonprofit::Current
-  include Controllers::Nonprofit::Authorization
+    include Controllers::Nonprofit::Authorization
     before_action :authenticate_nonprofit_user!
 
     def index
@@ -25,7 +25,7 @@ module Nonprofits
 
     def destroy
       tag_master = current_nonprofit.tag_masters.find(params[:id])
-      tag_master.update_attribute(:deleted, true)
+      tag_master.discard!
       tag_master.tag_joins.destroy_all
       render json: {}, status: :ok
     end

--- a/app/models/tag_join.rb
+++ b/app/models/tag_join.rb
@@ -13,7 +13,7 @@ class TagJoin < ApplicationRecord
 
   def name
     tag_master.name
-end
+  end
 
   def self.create_with_name(nonprofit, h)
     tm = nonprofit.tag_masters.find_by_name(h['name'])

--- a/app/models/tag_master.rb
+++ b/app/models/tag_master.rb
@@ -68,7 +68,7 @@ private
   def to_event(event_type, *expand)
     Jbuilder.new do |event|
       event.id SecureRandom.uuid
-      event.object 'event'
+      event.object 'object_event'
       event.type event_type
       event.data do 
         event.object to_builder(*expand)

--- a/db/migrate/20210107210143_set_tag_deleted_to_default_false.rb
+++ b/db/migrate/20210107210143_set_tag_deleted_to_default_false.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class SetTagDeletedToDefaultFalse < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :tag_masters, :deleted, from: nil, to: false
+    change_column_null :tag_masters, :deleted, false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2170,7 +2170,7 @@ CREATE TABLE public.tag_masters (
     id integer NOT NULL,
     name character varying(255),
     nonprofit_id integer,
-    deleted boolean,
+    deleted boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -4154,6 +4154,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20200423222447'),
 ('20200901214156'),
 ('20210105192021'),
-('20210105192022');
+('20210105192022'),
+('20210107210143');
 
 

--- a/docs/event_definitions/Nonprofit/TagMaster.ts
+++ b/docs/event_definitions/Nonprofit/TagMaster.ts
@@ -1,0 +1,20 @@
+// License: LGPL-3.0-or-later
+
+import type { HoudiniEvent, HoudiniObject, IdType } from "../common";
+import type Nonprofit from './';
+
+export interface TagMaster extends HoudiniObject {
+	deleted: boolean;
+	name: string;
+	nonprofit: IdType | Nonprofit;
+	object: 'tag_master';
+}
+
+/** POST /nonprofits/:id/tag_masters */
+export interface CreateTagMaster {
+	name: string;
+}
+
+export type TagMasterCreated = HoudiniEvent<'tag_master.created', TagMaster>;
+
+export type TagMasterDeleted = HoudiniEvent<'tag_master.deleted', TagMaster>;

--- a/docs/event_definitions/Nonprofit/index.ts
+++ b/docs/event_definitions/Nonprofit/index.ts
@@ -1,0 +1,10 @@
+// License: LGPL-3.0-or-later
+import type { HoudiniObject } from '../common';
+
+/**
+ * A single nonprofit organization on Houdini.
+ */
+export default interface Nonprofit extends HoudiniObject {
+	name: string;
+	object: "nonprofit";
+}

--- a/docs/event_definitions/common.ts
+++ b/docs/event_definitions/common.ts
@@ -41,7 +41,7 @@ export interface HoudiniEvent<EventType extends string, DataObject extends Houdi
 	 * A UUID uniquely representing the event
 	 */
 	id: string;
-	object: 'event';
+	object: 'object_event';
 	/** The type of event that this is */
 	type: EventType;
 

--- a/docs/event_definitions/common.ts
+++ b/docs/event_definitions/common.ts
@@ -1,0 +1,48 @@
+// License: LGPL-3.0-or-later
+
+/**
+ * the main identifier for HoudiniObjects which is unique between all other HoudiniObjects with the same object value.
+ * Currently just an integer but we could reevaluate later;
+ */
+export type IdType = number;
+
+/**
+ * Every object controlled by the Houdini event publisher must meet this standard interface
+ * and will inherit from it.
+ */
+export interface HoudiniObject {
+	/**
+	 * An IdType which unique which uniquely identifies this object
+	 * from all other similar objects
+	 */
+	id: IdType;
+	/**
+	 * the type of object. Roughly corresponds to the object's class in Rails
+	 */
+	object: string;
+}
+
+/**
+ * An event published by Houdini
+ *
+ * Generics:
+ * * EventType a snake-cased string of the format: "<object_type>.<event_name>". As an example
+ * 		tag_master.created means the event fired by when a tag_master was created
+ * * DataObject: the interface representing the actual object which the event occurred on. An object of that type is
+ * on the 'data' attribute
+ */
+export interface HoudiniEvent<EventType extends string, DataObject extends HoudiniObject> {
+	/** data for the event. We wrap the object inside becuase we might want to provide some sort of   */
+	data: {
+		/** the object after the event has occurred */
+		object: DataObject;
+	};
+	/**
+	 * A UUID uniquely representing the event
+	 */
+	id: string;
+	object: 'event';
+	/** The type of event that this is */
+	type: EventType;
+
+}

--- a/gems/bess/lib/houdini/event_publisher.rb
+++ b/gems/bess/lib/houdini/event_publisher.rb
@@ -4,20 +4,64 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 require 'wisper'
 require 'wisper/activejob'
+
+###
+# @description: An event publisher in Houdini for calling listening to async events or responding to them
+# Normally, you would use `Houdini.event_publisher` to access the active event publisher after initialization
+#
+# If you want to add an event listener as part of initialization (which is normally what you want to do),
+# you should push your listener class to Rails.application.config.houdini.listeners, which is an array.
+#
+# Example: Rails.application.config.houdini.listeners.push(PaymentCreationEventListener)
+#
+# Listener classes have the methods with the name of every event they want to listen to
+# as class methods. As an example the if the listener class SupporterListener wanted to run
+# some code when the `supporter_create`, or `supporter_merge` event was announced, 
+# Supporter Listener would look like so:
+#
+#	class SupporterListener
+# 	def self.supporter_create(supporter)
+#   	# run some code
+# 	end
+#
+#		def self.supporter_merge(*supporters)
+#			# run some code
+#		end
+# end
+# 
+# Currently, all listeners are called asynchronously using ActiveJob. This may change soonish.
+###
 class Houdini::EventPublisher
-    include Wisper::Publisher
+	include Wisper::Publisher
 
-    def announce(event, *args)
-        broadcast(event, *args)
-    end
+	###
+	# @description: announce a new event to all of the listeners listening for `event_type`
+		# @param event_type {symbol}: the type of event being announced.
+		# @param args {array}: the arguments to be passed to the event listeners.
+	###
+	def announce(event_type, *args)
+		broadcast(event_type, *args)
+	end
 
-    def subscribe_async(listener, options = {})
-        subscribe(listener, options.merge(async: true))
-    end
+	###
+	# @description: asynchronously listen for an event to occur
+	# Normally, you don't call this directly, you'll push an listener class to the
+	# Rails.application.config.houdini.listeners array in an initializer
+	# @param listener {Class}: the listener class 
+	###
+	def subscribe_async(listener, options = {})
+		subscribe(listener, options.merge(async: true))
+	end
 
-    def subscribe_all(listeners, options = {})
-        listeners.each do |listener|
-            subscribe(listener, options.merge(async: true))
-        end
-    end
+	###
+	# @description: having an array of listeners
+	# Normally, you don't call this directly, you'll push a set of listener classes
+	# to Rails.application.config.houdini.listeners array in an initializer
+	# @param listeners {Array}: an array of listener classes
+	###
+	def subscribe_all(listeners, options = {})
+		listeners.each do |listener|
+			subscribe(listener, options.merge(async: true))
+		end
+	end
 end

--- a/spec/models/tag_master_spec.rb
+++ b/spec/models/tag_master_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+RSpec.describe TagMaster, type: :model do
+  include_context :shared_donation_charge_context
+  let(:name) { "TAGNAME"}
+
+  let(:tag_master) { nonprofit.tag_masters.create(name: name) }
+  it 'creates' do 
+    expect(tag_master.errors).to be_empty
+  end
+
+  it 'announces create' do
+    expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_created, {
+      'id' => kind_of(String),
+      'object' => 'event',
+      'type' => 'tag_master.created',
+      'data' => {
+        'object' => {
+          'id'=> kind_of(Numeric),
+          'deleted' => false,
+          'name' => name,
+          'nonprofit'=> nonprofit.id,
+          'object' => 'tag_master'
+        }
+      }
+    })
+
+    tag_master
+  end
+  
+  it 'announces deleted' do
+    expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_created, anything).ordered
+    expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_deleted, {
+      'id' => kind_of(String),
+      'object' => 'event',
+      'type' => 'tag_master.deleted',
+      'data' => {
+        'object' => {
+          'id'=> kind_of(Numeric),
+          'deleted' => true,
+          'name' => name,
+          'nonprofit'=> nonprofit.id,
+          'object' => 'tag_master'
+        }
+      }
+    }).ordered
+    
+    tag_master.discard!
+
+  end
+end

--- a/spec/models/tag_master_spec.rb
+++ b/spec/models/tag_master_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TagMaster, type: :model do
   it 'announces create' do
     expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_created, {
       'id' => kind_of(String),
-      'object' => 'event',
+      'object' => 'object_event',
       'type' => 'tag_master.created',
       'data' => {
         'object' => {
@@ -36,7 +36,7 @@ RSpec.describe TagMaster, type: :model do
     expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_created, anything).ordered
     expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_deleted, {
       'id' => kind_of(String),
-      'object' => 'event',
+      'object' => 'object_event',
       'type' => 'tag_master.deleted',
       'data' => {
         'object' => {


### PR DESCRIPTION
This adds support for events related on TagMaster, specifically tag_master.created and tag_master.deleted

﻿- Set TagMaster.deleted to false
- Add documentation to Houdini::EventPublisher
- EventPublisher Support for TagMaster events

Closes #407

Contributes to #408
