### PR TITLE
Move to_event method into a concern

### DIFF
--- a/app/models/concerns/object_event/model_extensions.rb
+++ b/app/models/concerns/object_event/model_extensions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+module ObjectEvent::ModelExtensions
+    extend ActiveSupport::Concern
+    class_methods do
+        # Adds the to_event method to a model. Requires `to_builder` method for creating
+        # the Jbuilder object
+        def object_eventable
+            class_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def to_event(event_type, *expand)
+                    Jbuilder.new do |event|
+                        event.id SecureRandom.uuid
+                        event.object 'object_event'
+                        event.type event_type
+                        event.data do 
+                            event.object to_builder(*expand)
+                        end
+                    end
+                end
+
+                def to_builder(*expand)
+                    raise NotImplementedError.new("to_builder must be implemented in your model")
+                end
+            RUBY
+        end
+    end
+end

--- a/app/models/event_discount.rb
+++ b/app/models/event_discount.rb
@@ -3,6 +3,8 @@
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class EventDiscount < ApplicationRecord
+  include ObjectEvent::ModelExtensions
+  object_eventable
   # :code,
   # :event_id,
   # :name,
@@ -69,16 +71,5 @@ class EventDiscount < ApplicationRecord
 
   def publish_delete
     Houdini.event_publisher.announce(:event_discount_deleted, to_event('event_discount.deleted', :event, :nonprofit, :ticket_levels).attributes!)
-  end
-
-  def to_event(event_type, *expand)
-    Jbuilder.new do |event|
-      event.id SecureRandom.uuid
-      event.object 'object_event'
-      event.type event_type
-      event.data do 
-        event.object to_builder(*expand)
-      end
-    end
   end
 end

--- a/app/models/supporter_note.rb
+++ b/app/models/supporter_note.rb
@@ -11,4 +11,7 @@ class SupporterNote < ApplicationRecord
 
   validates :content, length: { minimum: 1 }
   validates :supporter_id, presence: true
+
+
+  
 end

--- a/app/models/tag_master.rb
+++ b/app/models/tag_master.rb
@@ -3,7 +3,8 @@
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class TagMaster < ApplicationRecord
-
+  include ObjectEvent::ModelExtensions
+  object_eventable
   # TODO replace with Discard gem
   define_model_callbacks :discard
 
@@ -59,17 +60,5 @@ private
 
   def publish_delete
     Houdini.event_publisher.announce(:tag_master_deleted, to_event('tag_master.deleted', :nonprofit).attributes!)
-  end
-  
-
-  def to_event(event_type, *expand)
-    Jbuilder.new do |event|
-      event.id SecureRandom.uuid
-      event.object 'object_event'
-      event.type event_type
-      event.data do 
-        event.object to_builder(*expand)
-      end
-    end
   end
 end

--- a/app/models/ticket_level.rb
+++ b/app/models/ticket_level.rb
@@ -3,6 +3,8 @@
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class TicketLevel < ApplicationRecord
+  include ObjectEvent::ModelExtensions
+  object_eventable
   # :amount, #integer
   # :amount_dollars, #accessor, string
   # :name, #string
@@ -96,16 +98,5 @@ class TicketLevel < ApplicationRecord
 
   def publish_delete
     Houdini.event_publisher.announce(:ticket_level_deleted, to_event('ticket_level.deleted', :event, :nonprofit, :event_discounts).attributes!)
-  end
-
-  def to_event(event_type, *expand)
-    Jbuilder.new do |event|
-      event.id SecureRandom.uuid
-      event.object 'object_event'
-      event.type event_type
-      event.data do 
-        event.object to_builder(*expand)
-      end
-    end
   end
 end

--- a/spec/models/concerns/object_event/model_extensions_spec.rb
+++ b/spec/models/concerns/object_event/model_extensions_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+RSpec.describe ObjectEvent::ModelExtensions do 
+
+	let(:event_type) {'model.event_name'}
+	class ClassWithoutToBuilder
+		include ObjectEvent::ModelExtensions
+		object_eventable
+	end
+
+	class ClassWithToBuilder
+		include ObjectEvent::ModelExtensions
+		object_eventable
+
+		def to_builder(*expand)
+			Jbuilder.new do |json|
+				json.id 1
+			end
+		end
+	end
+
+	it 'raises NotImplementedError when no to_builder is defined by developer' do 
+		obj = ClassWithoutToBuilder.new
+		expect { obj.to_event event_type}.to raise_error(NotImplementedError)
+	end
+
+	it 'returns an proper event when to_builder is defined by developer' do 
+		obj = ClassWithToBuilder.new
+		expect(obj.to_event event_type).to eq({
+			'id' => kind_of(String),
+			'object' => 'object_event',
+			'type' => event_type,
+			'data' => {
+				'object' => {
+					'id' => 1
+				}
+			}
+		})
+	end
+end


### PR DESCRIPTION
After the first few object_event implementations, it's clear there's an opportunity for reuse here. I've created a concern called `ObjectEvent::ModelExtensions`. By including this concern and calling `object_eventable`, your model receives a `to_event` method which creates a JBuilder representing a particular `object_event`. `to_event` requires a `to_builder` method in the object so it can create the data for the event.

I'm sure we can add things here like lifecycle methods, ways to simplify the to_builder method, etc and I'm not sure these are the best names for the method and module. That said, this seems like a reasonable start.

If there are comments, I'll merge around midday, January 15 CST.