### PR TITLE
Concern for getting current_supporter

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -80,12 +80,4 @@ class ApplicationController < ActionController::Base
   def after_inactive_sign_up_path_for(_resource)
     profile_path(current_user.profile)
   end
-
-  # /devise config
-
-  private
-
-  def current_user_id
-    current_user&.id
-  end
 end

--- a/app/controllers/concerns/controllers/nonprofit/authorization.rb
+++ b/app/controllers/concerns/controllers/nonprofit/authorization.rb
@@ -7,6 +7,7 @@ module Controllers::Nonprofit::Authorization
     include Controllers::User::Authorization
 
     included do
+        helper_method :current_nonprofit_user?
         private
         def authenticate_nonprofit_user!(type: :web)
             reject_with_sign_in 'Please sign in' unless current_nonprofit_user?

--- a/app/controllers/concerns/controllers/nonprofit/current.rb
+++ b/app/controllers/concerns/controllers/nonprofit/current.rb
@@ -5,8 +5,6 @@
 module Controllers::Nonprofit::Current
     extend ActiveSupport::Concern
     included do
-        helper_method :current_nonprofit_user? 
-
         def current_nonprofit
             @nonprofit = current_nonprofit_without_exception
             raise ActionController::RoutingError, 'Nonprofit not found' if @nonprofit.nil?

--- a/app/controllers/concerns/controllers/supporter/current.rb
+++ b/app/controllers/concerns/controllers/supporter/current.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+module Controllers::Supporter::Current
+    include Controllers::Nonprofit::Current
+    extend ActiveSupport::Concern
+    included do
+        def current_supporter
+            current_nonprofit.supporters.find(params[:supporter_id] || params[:id])
+        end
+    end
+end

--- a/app/controllers/concerns/controllers/user/authorization.rb
+++ b/app/controllers/concerns/controllers/user/authorization.rb
@@ -75,5 +75,9 @@ module Controllers::User::Authorization
       key = "administered_nonprofit_user_#{current_user_id}_nonprofit"
       ::Nonprofit.where(id: QueryRoles.host_ids(current_user_id, %i[nonprofit_admin nonprofit_associate])).last
     end
+
+    def current_user_id
+      current_user&.id
+    end
   end
 end

--- a/spec/controllers/concerns/supporter/current_spec.rb
+++ b/spec/controllers/concerns/supporter/current_spec.rb
@@ -1,0 +1,47 @@
+#frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+describe 'Controllers::Supporter::Current', type: :controller do
+	let(:nonprofit) { force_create(:nm_justice)}
+	let(:supporter) { force_create(:supporter)}
+
+	class TestController < ApplicationController
+		include Controllers::User::Authorization
+		include Controllers::Supporter::Current
+	end
+	
+	
+
+	controller(TestController) do 
+		def index
+			render json: {
+				supporter: "supporters: #{current_supporter.id}", 
+				nonprofit: "nonprofit: #{current_nonprofit.id}"
+			}
+		end
+	end
+	
+	it 'handles situations where we use id' do
+		nonprofit
+		supporter
+		get :index, params: {nonprofit_id: nonprofit.id, id: supporter.id}
+		expect(JSON::parse(response.body)).to eq({ 
+			'supporter' => "supporters: #{supporter.id}", 
+			'nonprofit' => "nonprofit: #{nonprofit.id}"
+		})
+	end
+
+	it 'handles situations where we use supporter_id' do 
+		nonprofit
+		supporter
+
+		get :index, params: {nonprofit_id: nonprofit.id, supporter_id: supporter.id, id: 1}
+		expect(JSON::parse(response.body)).to eq({ 
+			'supporter' => "supporters: #{supporter.id}", 
+			'nonprofit' => "nonprofit: #{nonprofit.id}"
+		})
+	end
+end


### PR DESCRIPTION
Currently, there's no way to get automatically get the current supporter if running an action with a supporter defined in the path. As an example, if the following call is made:

`GET /nonprofits/1/supporters/2`

inside the `show` action, we'd want `current_supporter` to be the `Supporter` with the id of 2 from the `Nonprofit` with the id of 1.

This fix allows the developer to include a module which provides the `current_supporter` method to get that current supporter.

Important note: `Controllers::Nonprofit::Current` requires the `current_user` for some reason. I don't like this design so we should probably rearrange things.

Depends on #433 

If no comments, will merge around mid-day January 15 CST.