### PR TITLE
Create HoudIDs for stringy ids

### DIFF
--- a/app/models/campaign_gift_option.rb
+++ b/app/models/campaign_gift_option.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class CampaignGiftOption < ApplicationRecord
   include ObjectEvent::ModelExtensions
-	object_eventable
+	object_eventable :cgo
   # :amount_one_time, #int (cents)
   # :amount_recurring, #int (cents)
   # :amount_dollars, #str, gets converted to amount

--- a/app/models/concerns/object_event/model_extensions.rb
+++ b/app/models/concerns/object_event/model_extensions.rb
@@ -4,14 +4,21 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 module ObjectEvent::ModelExtensions
     extend ActiveSupport::Concern
+
     class_methods do
+        
         # Adds the to_event method to a model. Requires `to_builder` method for creating
         # the Jbuilder object
-        def object_eventable
+        def object_eventable(prefix)
             class_eval <<-RUBY, __FILE__, __LINE__ + 1
+                def object_prefix
+                    :#{prefix.to_s}
+                end
+                
+
                 def to_event(event_type, *expand)
                     Jbuilder.new do |event|
-                        event.id SecureRandom.uuid
+                        event.id "objevt_" + SecureRandom.alphanumeric(22)
                         event.object 'object_event'
                         event.type event_type
                         event.data do 

--- a/app/models/event_discount.rb
+++ b/app/models/event_discount.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class EventDiscount < ApplicationRecord
   include ObjectEvent::ModelExtensions
-  object_eventable
+  object_eventable :evtdisc
   # :code,
   # :event_id,
   # :name,

--- a/app/models/supporter.rb
+++ b/app/models/supporter.rb
@@ -180,7 +180,7 @@ class Supporter < ApplicationRecord
   # we do something custom here since Supporter and SupporterAddress are in the same model
   def to_event(event_type, *expand)
     Jbuilder.new do |event|
-        event.id SecureRandom.uuid
+        event.id "objevt_" + SecureRandom.alphanumeric(22)
         event.object 'object_event'
         event.type event_type
         event.data do 

--- a/app/models/supporter_note.rb
+++ b/app/models/supporter_note.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class SupporterNote < ApplicationRecord
   include ObjectEvent::ModelExtensions
-	object_eventable
+	object_eventable :suppnote
   # :content,
   # :supporter_id, :supporter
 

--- a/app/models/tag_master.rb
+++ b/app/models/tag_master.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class TagMaster < ApplicationRecord
   include ObjectEvent::ModelExtensions
-  object_eventable
+  object_eventable :tagmstr
   # TODO replace with Discard gem
   define_model_callbacks :discard
 

--- a/app/models/ticket_level.rb
+++ b/app/models/ticket_level.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class TicketLevel < ApplicationRecord
   include ObjectEvent::ModelExtensions
-  object_eventable
+  object_eventable :tktlvl
   # :amount, #integer
   # :amount_dollars, #accessor, string
   # :name, #string

--- a/docs/event_definitions/Nonprofit/Transaction.ts
+++ b/docs/event_definitions/Nonprofit/Transaction.ts
@@ -1,9 +1,9 @@
 // License: LGPL-3.0-or-later
-import type { Amount, HoudiniObject, IdType, UuidType } from "../common";
+import type { Amount, HoudiniObject, IdType, HoudID } from "../common";
 import type Nonprofit from './';
 
 
-export interface Transaction extends HoudiniObject<UuidType> {
+export interface Transaction extends HoudiniObject<HoudID> {
   amount: Amount;
 	nonprofit: IdType | Nonprofit;
 	object: 'transaction';

--- a/docs/event_definitions/common.ts
+++ b/docs/event_definitions/common.ts
@@ -9,7 +9,7 @@ export type IdType = number;
 /**
  * an identifier for HoudiniObjects which is unique among all HoudiniObjects.
  */
-export type UuidType = string;
+export type HoudID = string;
 
 /**
  * Describes a monetary value in the minimum unit for this current. Corresponds to Money class in
@@ -60,7 +60,7 @@ export type RecurrenceRule = {
  * Every object controlled by the Houdini event publisher must meet this standard interface
  * and will inherit from it.
  */
-export interface HoudiniObject<Id extends IdType|UuidType=IdType> {
+export interface HoudiniObject<Id extends IdType|HoudID=IdType> {
 	/**
 	 * An IdType which unique which uniquely identifies this object
 	 * from all other similar objects
@@ -73,7 +73,7 @@ export interface HoudiniObject<Id extends IdType|UuidType=IdType> {
 }
 
 
-type HoudiniObjectOfAllIds = HoudiniObject<IdType> | HoudiniObject<UuidType>;
+type HoudiniObjectOfAllIds = HoudiniObject<IdType> | HoudiniObject<HoudID>;
 /**
  * An event published by Houdini
  *
@@ -90,9 +90,9 @@ export interface HoudiniEvent<EventType extends string, DataObject extends Houdi
 		object: DataObject;
 	};
 	/**
-	 * A UUID uniquely representing the event
+	 * A HoudID uniquely representing the event
 	 */
-	id: string;
+	id: HoudID;
 	object: 'object_event';
 	/** The type of event that this is */
 	type: EventType;

--- a/spec/models/campaign_gift_option_spec.rb
+++ b/spec/models/campaign_gift_option_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe CampaignGiftOption, type: :model do
     it 'announces create for first example' do
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_created, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'campaign_gift_option.created',
         'data' => {
@@ -84,7 +84,7 @@ RSpec.describe CampaignGiftOption, type: :model do
     it 'announces create for second example' do
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_created, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'campaign_gift_option.created',
         'data' => {
@@ -146,7 +146,7 @@ RSpec.describe CampaignGiftOption, type: :model do
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_updated, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'campaign_gift_option.updated',
         'data' => {
@@ -191,7 +191,7 @@ RSpec.describe CampaignGiftOption, type: :model do
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_updated, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'campaign_gift_option.updated',
         'data' => {
@@ -238,7 +238,7 @@ RSpec.describe CampaignGiftOption, type: :model do
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_deleted, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'campaign_gift_option.deleted',
         'data' => {
@@ -285,7 +285,7 @@ RSpec.describe CampaignGiftOption, type: :model do
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_option_deleted, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'campaign_gift_option.deleted',
         'data' => {

--- a/spec/models/concerns/object_event/model_extensions_spec.rb
+++ b/spec/models/concerns/object_event/model_extensions_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe ObjectEvent::ModelExtensions do
 	let(:event_type) {'model.event_name'}
 	class ClassWithoutToBuilder
 		include ObjectEvent::ModelExtensions
-		object_eventable
+		object_eventable :cwotb
 	end
 
 	class ClassWithToBuilder
 		include ObjectEvent::ModelExtensions
-		object_eventable
+		object_eventable :cwtb
 
 		def to_builder(*expand)
 			Jbuilder.new do |json|
@@ -22,16 +22,20 @@ RSpec.describe ObjectEvent::ModelExtensions do
 			end
 		end
 	end
+	
+	
 
 	it 'raises NotImplementedError when no to_builder is defined by developer' do 
 		obj = ClassWithoutToBuilder.new
+		expect(obj.object_prefix).to eq :cwotb
 		expect { obj.to_event event_type}.to raise_error(NotImplementedError)
 	end
 
 	it 'returns an proper event when to_builder is defined by developer' do 
 		obj = ClassWithToBuilder.new
+		expect(obj.object_prefix).to eq :cwtb
 		expect(obj.to_event event_type).to eq({
-			'id' => kind_of(String),
+			'id' => match(/objevt_[a-zA-Z0-9]{22}/),
 			'object' => 'object_event',
 			'type' => event_type,
 			'data' => {
@@ -40,5 +44,20 @@ RSpec.describe ObjectEvent::ModelExtensions do
 				}
 			}
 		})
+	end
+
+	it 'raises without object_prefix' do
+		expect do
+			class ClassWithoutEventablePrefix
+				include ObjectEvent::ModelExtensions
+				object_eventable
+		
+				def to_builder(*expand)
+					Jbuilder.new do |json|
+						json.id 1
+					end
+				end
+			end
+		end.to raise_error(ArgumentError)
 	end
 end

--- a/spec/models/event_discount_spec.rb
+++ b/spec/models/event_discount_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe EventDiscount, type: :model do
     it 'announces create' do
       expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:event_discount_created, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'event_discount.created',
         'data' => {
@@ -116,7 +116,7 @@ RSpec.describe EventDiscount, type: :model do
       expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:event_discount_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:event_discount_updated, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'event_discount.updated',
         'data' => {
@@ -179,7 +179,7 @@ RSpec.describe EventDiscount, type: :model do
       expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:event_discount_created, anything).ordered
       expect(Houdini.event_publisher).to receive(:announce).with(:event_discount_deleted, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'event_discount.deleted',
         'data' => {

--- a/spec/models/supporter_note_spec.rb
+++ b/spec/models/supporter_note_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SupporterNote, type: :model do
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_created, anything)
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_created, anything)
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_note_created, {
-      'id' => kind_of(String),
+      'id' => match(/objevt_[a-zA-Z0-9]{22}/),
       'object' => 'object_event',
       'type' => 'supporter_note.created',
       'data' => {
@@ -65,7 +65,7 @@ RSpec.describe SupporterNote, type: :model do
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_created, anything)
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_note_created, anything).ordered
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_note_updated, {
-      'id' => kind_of(String),
+      'id' => match(/objevt_[a-zA-Z0-9]{22}/),
       'object' => 'object_event',
       'type' => 'supporter_note.updated',
       'data' => {
@@ -98,7 +98,7 @@ RSpec.describe SupporterNote, type: :model do
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_created, anything)
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_note_created, anything).ordered
     expect(Houdini.event_publisher).to receive(:announce).with(:supporter_note_deleted, {
-      'id' => kind_of(String),
+      'id' => match(/objevt_[a-zA-Z0-9]{22}/),
       'object' => 'object_event',
       'type' => 'supporter_note.deleted',
       'data' => {

--- a/spec/models/supporter_spec.rb
+++ b/spec/models/supporter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Supporter, type: :model do
 			})
 
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_created, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'supporter.created',
         'data' => {
@@ -89,7 +89,7 @@ RSpec.describe Supporter, type: :model do
 			})
 
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_deleted, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'supporter.deleted',
         'data' => {
@@ -111,7 +111,7 @@ RSpec.describe Supporter, type: :model do
 
 
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_created, {
-				'id' => kind_of(String),
+				'id' => match(/objevt_[a-zA-Z0-9]{22}/),
 				'object' => 'object_event',
 				'type' => 'supporter_address.created',
 				'data' => {
@@ -139,7 +139,7 @@ RSpec.describe Supporter, type: :model do
 			})
 
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_deleted, {
-        'id' => kind_of(String),
+        'id' => match(/objevt_[a-zA-Z0-9]{22}/),
         'object' => 'object_event',
         'type' => 'supporter_address.deleted',
         'data' => {
@@ -157,7 +157,8 @@ RSpec.describe Supporter, type: :model do
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_created, anything).ordered
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_created, anything).ordered
 			
-			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_updated, {	'id' => kind_of(String),
+			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_updated, {	
+			'id' => match(/objevt_[a-zA-Z0-9]{22}/),
 			'object' => 'object_event',
 			'type' => 'supporter.updated',
 			'data' => {
@@ -180,7 +181,7 @@ RSpec.describe Supporter, type: :model do
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_created, anything).ordered
 			
 			expect(Houdini.event_publisher).to receive(:announce).with(:supporter_address_updated, {	
-			'id' => kind_of(String),
+			'id' => match(/objevt_[a-zA-Z0-9]{22}/),
 			'object' => 'object_event',
 			'type' => 'supporter_address.updated',
 			'data' => {

--- a/spec/models/tag_master_spec.rb
+++ b/spec/models/tag_master_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TagMaster, type: :model do
 
   it 'announces create' do
     expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_created, {
-      'id' => kind_of(String),
+      'id' => match(/objevt_[a-zA-Z0-9]{22}/),
       'object' => 'object_event',
       'type' => 'tag_master.created',
       'data' => {
@@ -35,7 +35,7 @@ RSpec.describe TagMaster, type: :model do
   it 'announces deleted' do
     expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_created, anything).ordered
     expect(Houdini.event_publisher).to receive(:announce).with(:tag_master_deleted, {
-      'id' => kind_of(String),
+      'id' => match(/objevt_[a-zA-Z0-9]{22}/),
       'object' => 'object_event',
       'type' => 'tag_master.deleted',
       'data' => {

--- a/spec/models/ticket_level_spec.rb
+++ b/spec/models/ticket_level_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe TicketLevel, type: :model do
 
       it 'announces create' do
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, {
-          'id' => kind_of(String),
+          'id' => match(/objevt_[a-zA-Z0-9]{22}/),
           'object' => 'object_event',
           'type' => 'ticket_level.created',
           'data' => {
@@ -85,7 +85,7 @@ RSpec.describe TicketLevel, type: :model do
 
       it 'announces create' do
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, {
-          'id' => kind_of(String),
+          'id' => match(/objevt_[a-zA-Z0-9]{22}/),
           'object' => 'object_event',
           'type' => 'ticket_level.created',
           'data' => {
@@ -131,7 +131,7 @@ RSpec.describe TicketLevel, type: :model do
       it 'announces updated' do
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_updated, {
-          'id' => kind_of(String),
+          'id' => match(/objevt_[a-zA-Z0-9]{22}/),
           'object' => 'object_event',
           'type' => 'ticket_level.updated',
           'data' => {
@@ -177,7 +177,7 @@ RSpec.describe TicketLevel, type: :model do
       it 'announces updated' do
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_updated, {
-          'id' => kind_of(String),
+          'id' => match(/objevt_[a-zA-Z0-9]{22}/),
           'object' => 'object_event',
           'type' => 'ticket_level.updated',
           'data' => {
@@ -226,7 +226,7 @@ RSpec.describe TicketLevel, type: :model do
       it 'announces deleted' do
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_deleted, {
-          'id' => kind_of(String),
+          'id' => match(/objevt_[a-zA-Z0-9]{22}/),
           'object' => 'object_event',
           'type' => 'ticket_level.deleted',
           'data' => {
@@ -268,7 +268,7 @@ RSpec.describe TicketLevel, type: :model do
       it 'announces deleted' do
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_created, anything).ordered
         expect(Houdini.event_publisher).to receive(:announce).with(:ticket_level_deleted, {
-          'id' => kind_of(String),
+          'id' => match(/objevt_[a-zA-Z0-9]{22}/),
           'object' => 'object_event',
           'type' => 'ticket_level.deleted',
           'data' => {


### PR DESCRIPTION
Some of the Houdini event objects will need a stringy id like a UUID. At the same time, it would be nice to have IDs that communicate what type of object it is, like Stripe does. I've create a form of string ID called HoudIDs which consists of a prefix, an underscore and then 22 random alphanumeric characters. (22 is the number you get when converting a UUID to base 62)

In this PR, they are only used for object events and have the format: "objevt_aBc9..."

