### PR TITLE
Fix typo in generated license comments

### DIFF
--- a/gems/houdini_upgrade/lib/generators/cw_to_activestorage/templates/initializers/carrierwave.rb.tt
+++ b/gems/houdini_upgrade/lib/generators/cw_to_activestorage/templates/initializers/carrierwave.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 
 CarrierWave.configure do |config|
     config.storage = :aws

--- a/lib/generators/overrides/rails/plugin/templates/Rakefile.tt
+++ b/lib/generators/overrides/rails/plugin/templates/Rakefile.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 require "bundler/setup"
 <% if engine? && !options[:skip_active_record] && with_dummy_app? -%>
 

--- a/lib/generators/overrides/rails/plugin/templates/app/controllers/%namespaced_name%/application_controller.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/app/controllers/%namespaced_name%/application_controller.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules <<~rb
   class ApplicationController < ActionController::#{api? ? "API" : "Base"}
     #{ api? ? '# ' : '' }protect_from_forgery with: :exception

--- a/lib/generators/overrides/rails/plugin/templates/app/helpers/%namespaced_name%/application_helper.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/app/helpers/%namespaced_name%/application_helper.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules <<~rb
   module ApplicationHelper
   end

--- a/lib/generators/overrides/rails/plugin/templates/app/jobs/%namespaced_name%/application_job.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/app/jobs/%namespaced_name%/application_job.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules <<~rb
   class ApplicationJob < ActiveJob::Base
   end

--- a/lib/generators/overrides/rails/plugin/templates/app/mailers/%namespaced_name%/application_mailer.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/app/mailers/%namespaced_name%/application_mailer.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules <<~rb
   class ApplicationMailer < ActionMailer::Base
     default from: 'from@example.com'

--- a/lib/generators/overrides/rails/plugin/templates/app/models/%namespaced_name%/application_record.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/app/models/%namespaced_name%/application_record.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules <<~rb
   class ApplicationRecord < ActiveRecord::Base
     self.abstract_class = true

--- a/lib/generators/overrides/rails/plugin/templates/lib/%namespaced_name%.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/lib/%namespaced_name%.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <% if engine? -%>
 require "<%= namespaced_name %>/engine"
 <% else -%>

--- a/lib/generators/overrides/rails/plugin/templates/lib/%namespaced_name%/engine.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/lib/%namespaced_name%/engine.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules <<~rb
   class Engine < ::Rails::Engine
   #{mountable? ? '  isolate_namespace ' + camelized_modules : ' '}

--- a/lib/generators/overrides/rails/plugin/templates/lib/%namespaced_name%/version.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/lib/%namespaced_name%/version.rb.tt
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 <%= wrap_in_modules "VERSION = '0.1.0'" %>

--- a/lib/generators/overrides/rails/plugin/templates/lib/tasks/%namespaced_name%_tasks.rake.tt
+++ b/lib/generators/overrides/rails/plugin/templates/lib/tasks/%namespaced_name%_tasks.rake.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 # desc "Explaining what the task does"
 # task :<%= underscored_name %> do
 #   # Task goes here

--- a/lib/generators/overrides/rails/plugin/templates/rails/application.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/rails/application.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 require_relative "boot"
 
 <% if include_all_railties? -%>

--- a/lib/generators/overrides/rails/plugin/templates/rails/boot.rb.tt
+++ b/lib/generators/overrides/rails/plugin/templates/rails/boot.rb.tt
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
-Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../../Gemfile', __dir__)
 


### PR DESCRIPTION
There was a typo in the license header comments from various trails generators. The last line isn't properly commented so Ruby thinks it's actual code. This fix addresses that.
