### PR TITLE
Change to HouID because it's closer to GUID and easier to say.

### DIFF
--- a/docs/event_definitions/Nonprofit/Transaction.ts
+++ b/docs/event_definitions/Nonprofit/Transaction.ts
@@ -1,9 +1,9 @@
 // License: LGPL-3.0-or-later
-import type { Amount, HoudiniObject, IdType, HoudID } from "../common";
+import type { Amount, HoudiniObject, IdType, HouID } from "../common";
 import type Nonprofit from './';
 
 
-export interface Transaction extends HoudiniObject<HoudID> {
+export interface Transaction extends HoudiniObject<HouID> {
   amount: Amount;
 	nonprofit: IdType | Nonprofit;
 	object: 'transaction';

--- a/docs/event_definitions/common.ts
+++ b/docs/event_definitions/common.ts
@@ -9,7 +9,7 @@ export type IdType = number;
 /**
  * an identifier for HoudiniObjects which is unique among all HoudiniObjects.
  */
-export type HoudID = string;
+export type HouID = string;
 
 /**
  * Describes a monetary value in the minimum unit for this current. Corresponds to Money class in
@@ -60,7 +60,7 @@ export type RecurrenceRule = {
  * Every object controlled by the Houdini event publisher must meet this standard interface
  * and will inherit from it.
  */
-export interface HoudiniObject<Id extends IdType|HoudID=IdType> {
+export interface HoudiniObject<Id extends IdType|HouID=IdType> {
 	/**
 	 * An IdType which unique which uniquely identifies this object
 	 * from all other similar objects
@@ -73,7 +73,7 @@ export interface HoudiniObject<Id extends IdType|HoudID=IdType> {
 }
 
 
-type HoudiniObjectOfAllIds = HoudiniObject<IdType> | HoudiniObject<HoudID>;
+type HoudiniObjectOfAllIds = HoudiniObject<IdType> | HoudiniObject<HouID>;
 /**
  * An event published by Houdini
  *
@@ -90,9 +90,9 @@ export interface HoudiniEvent<EventType extends string, DataObject extends Houdi
 		object: DataObject;
 	};
 	/**
-	 * A HoudID uniquely representing the event
+	 * A HouID uniquely representing the event
 	 */
-	id: HoudID;
+	id: HouID;
 	object: 'object_event';
 	/** The type of event that this is */
 	type: EventType;


### PR DESCRIPTION
Change the name of our stringy IDs to HouID. This is easier to say and it sounds closer to GUID.
