### PR TITLE
Remove parallel_tests

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,2 +1,0 @@
---format progress
---format ParallelTests::RSpec::SummaryLogger --out tmp/spec_summary.log

--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ group :development, :ci, :test do
   gem 'standard', '~> 0.1.2'
   gem 'rspec-rails', '~> 4.0.0'
   gem 'rspec', '~> 3.9.0'
-  gem 'parallel_tests', '~> 2.32'
   gem 'factory_bot_rails', '~> 5.0', '>= 5.0.2'
   gem 'factory_bot', '~> 5.0', '>= 5.0.2'
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,8 +234,6 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
-    parallel_tests (2.32.0)
-      parallel
     parser (3.0.0.0)
       ast (~> 2.4.1)
     pg (1.2.3)
@@ -445,7 +443,6 @@ DEPENDENCIES
   mail_view (~> 2.0)
   money (~> 6.13)
   nearest_time_zone (~> 0.0.4)
-  parallel_tests (~> 2.32)
   param_validation!
   pg (~> 1.1)
   pry (~> 0.12.2)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -2989,7 +2989,6 @@ Copyright (c) 2007,2008,2009,2010,2011,2016,2019 Marc Alexander Lehmann <libev@s
 Copyright (c) 2007,2008,2009,2010,2011,2012,2013,2019 Marc Alexander Lehmann <libev@schmorp.de>
 Copyright (c) 2007,2008,2009,2010,2011,2016,2017,2019 Marc Alexander Lehmann <libev@schmorp.de>
 Copyright (c) 2007,2008,2009,2010,2011,2012,2013,2016,2019 Marc Alexander Lehmann <libev@schmorp.de>
-** parallel_tests; version 2.32.0 -- 
 ** qx; version 0.1.1 -- 
 ** rack; version 2.2.3 -- 
 Copyright (c) 2009-2018 Michael Fellinger <m.fellinger@gmail.com>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,7 +60,4 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  #recommended by https://github.com/grosser/parallel_tests/wiki
-  config.cache_store = :file_store, Rails.root.join("tmp", "cache", "paralleltests#{ENV['TEST_ENV_NUMBER']}")
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,4 @@ RSpec.configure do |config|
   end
 
   config.include(Wisper::RSpec::BroadcastMatcher)
-
-   # mute noise for parallel tests
-   config.silence_filter_announcements = true if ENV['TEST_ENV_NUMBER']
 end


### PR DESCRIPTION
Parallel tests were a nice idea but ﻿they don't really work well; the output gets so mucked up that it's basically unusable. There's some work being done at https://github.com/rspec/rspec-rails/issues/2104 and https://github.com/ioquatix/turbo_test but nothing is done yet. We should investigate that in the future but until then, let's remove this code and simplify our lives.
