### PR TITLE
Adds a Webhook adapter and includes OpenFn support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,7 @@ PATH
   specs:
     bess (0.1.0)
       rails (~> 6.0)
+      rest-client
       wisper (~> 2.0)
       wisper-activejob (~> 1.0.0)
 

--- a/gems/bess/bess.gemspec
+++ b/gems/bess/bess.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", "~> 6.0"
   spec.add_dependency 'wisper', '~> 2.0'
   spec.add_dependency 'wisper-activejob', '~> 1.0.0'
+  spec.add_dependency 'rest-client'
 
   spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'rspec-rails', '~> 4.0.0'

--- a/gems/bess/lib/houdini.rb
+++ b/gems/bess/lib/houdini.rb
@@ -12,6 +12,7 @@ module Houdini
   autoload :Intl
   autoload :PaymentProvider
   autoload :EventPublisher
+  autoload :WebhookAdapter
 
   mattr_accessor :intl, :maintenance, :ccs
 
@@ -38,4 +39,6 @@ module Houdini
   mattr_accessor :core_classes, default: {supporter: 'Supporter', nonprofit: 'Nonprofit'}
 
   mattr_accessor :event_publisher, default: Houdini::EventPublisher.new
+
+  mattr_accessor :webhook_adapter
 end

--- a/gems/bess/lib/houdini/webhook_adapter.rb
+++ b/gems/bess/lib/houdini/webhook_adapter.rb
@@ -1,0 +1,22 @@
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class Houdini::WebhookAdapter
+  extend ActiveSupport::Autoload
+  include ActiveModel::AttributeAssignment
+
+  autoload :OpenFn
+
+  attr_accessor :url, :auth_headers
+  def initialize(attributes={})
+    assign_attributes(attributes) if attributes
+  end
+
+  def post(payload)
+    RestClient::Request.execute(
+      method: :post,
+      url: url,
+      payload: payload,
+      headers: auth_headers
+    )
+  end
+end

--- a/gems/bess/lib/houdini/webhook_adapter/open_fn.rb
+++ b/gems/bess/lib/houdini/webhook_adapter/open_fn.rb
@@ -1,0 +1,4 @@
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class Houdini::WebhookAdapter::OpenFn < Houdini::WebhookAdapter
+end


### PR DESCRIPTION
As part 1 of #453, adds a webhook that allows triggering jobs or workflows from external tools, with support to OpenFn ([see the documentation](https://docs.openfn.org/)).

## Instructions

### OpenFn side
1. Navigate to [OpenFn](https://www.openfn.org/signup) and sign up;
2. Set up an authentication method on `Access and Security` option, by clicking on `Add new security protocol`. Choose the API Key auth type;
3. Create a trigger of "Message Trigger" type and define which filter should be in your trigger payload:
![image](https://user-images.githubusercontent.com/15739610/107134444-e76b7e80-68d0-11eb-852e-f24dd091ce28.png)
4. Navigate to the project view and copy your inbox link.

#### Creating a job that sends an e-mail using Mailgun

1. Create an account on [Mailgun](https://signup.mailgun.com/new/signup) (for the sake of testing, a free account is enough);
2. For using the sandbox domain Mailgun provides for testing, add your e-mail as an authorized recipients:
![image](https://user-images.githubusercontent.com/15739610/107160074-c8bdc400-6972-11eb-89d6-4fd05f9eb249.png)
3. On OpenFn, set up your Mailgun credentials on `Credentials`;
4. Create a new job on `Jobs`, by clicking the `+` icon and connect to the corresponding trigger;
5. Add the script that the job is going to execute on `Execution`. An example for Mailgun could be:

``` javascript
send({
  from: '<someemail>@gmail.com',
  to: '<youremail>@gmail.com',
  subject: 'Update event',
  text: 'An event of update type has happened. Additional details: ' + dataValue('data')(state),
})
```
> To access your payload data from your job, you can use `dataValue('someKey')(state)`

### Application side

To send the trigger request to your inbox, run the following commands:

``` bash
$ rails c
```

``` ruby
> url = <your inbox URL> 
> # besides the filter for the trigger itself, some more data can be passed in the payload
> payload = { 'eventType': 'Update', 'data': 'Some more information about the event' }
> auth_headers = { 'x-api-key': <your api key> }
> Houdini::WebhookAdapter::OpenFn.new(url: url, auth_headers: auth_headers).post(payload)
```

If everything goes well, you should see a 200 response on your console. The OpenFn inbox is going to show a successful run for your job, and on the run details you'll be able to see that the mail sending was enqueued, and in a few instants you'll have received an e-mail.