### PR TITLE
Add campaign_gift.* and campaign_gift_purchase.* events

### DIFF
--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -69,6 +69,7 @@ class Campaign < ApplicationRecord
   has_many :campaign_gifts, through: :campaign_gift_options
   has_many :supporters, through: :donations
   has_many :recurring_donations
+  has_many :campaign_gift_purchases
   has_many :roles,        as: :host, dependent: :destroy
   has_many :comments,     as: :host, dependent: :destroy
   has_many :activities,   as: :host, dependent: :destroy

--- a/app/models/campaign_gift.rb
+++ b/app/models/campaign_gift.rb
@@ -10,6 +10,7 @@ class CampaignGift < ApplicationRecord
 
   belongs_to :donation
   belongs_to :campaign_gift_option
+  has_one :modern_campaign_gift
 
   validates :donation, presence: true
   validates :campaign_gift_option, presence: true

--- a/app/models/campaign_gift_option.rb
+++ b/app/models/campaign_gift_option.rb
@@ -85,7 +85,10 @@ class CampaignGiftOption < ApplicationRecord
           json.currency desc[:amount][:currency]
           json.value_in_cents desc[:amount][:value_in_cents]
         end
-        json.recurrence(desc[:recurrence]) if desc[:recurrence]
+        json.recurrence do 
+          json.interval desc[:recurrence][:interval]
+          json.type desc[:recurrence][:type]
+        end if desc[:recurrence]
       end
     end
   end

--- a/app/models/campaign_gift_option.rb
+++ b/app/models/campaign_gift_option.rb
@@ -30,10 +30,9 @@ class CampaignGiftOption < ApplicationRecord
   after_update_commit :publish_updated
   after_destroy_commit :publish_deleted
 
-  add_builder_expansion :campaign
-  add_builder_expansion :nonprofit, 
-    to_attrib: -> (model) {model.campaign.nonprofit}
+  add_builder_expansion :campaign, :nonprofit
 
+  has_one :nonprofit, through: :campaign
 
 
   def total_gifts
@@ -82,7 +81,10 @@ class CampaignGiftOption < ApplicationRecord
       json.deleted !persisted?
 
       json.gift_option_amount gift_option_amount do |desc|
-        json.amount desc[:amount]
+        json.amount do 
+          json.currency desc[:amount][:currency]
+          json.value_in_cents desc[:amount][:value_in_cents]
+        end
         json.recurrence(desc[:recurrence]) if desc[:recurrence]
       end
     end

--- a/app/models/campaign_gift_purchase.rb
+++ b/app/models/campaign_gift_purchase.rb
@@ -4,8 +4,16 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class CampaignGiftPurchase < ApplicationRecord
   belongs_to :campaign
-
   has_many :campaign_gifts, class_name: 'ModernCampaignGift'
+
+  add_builder_expansion :nonprofit, :supporter, :campaign
+  add_builder_expansion :trx, 
+		json_attrib: :transaction
+		
+	has_one :transaction_assignment, as: :assignable
+	has_one :trx, through: :transaction_assignment
+	has_one :supporter, through: :trx
+	has_one :nonprofit, through: :supporter
 
   validates :amount, presence: true
   validates :campaign, presence: true

--- a/app/models/campaign_gift_purchase.rb
+++ b/app/models/campaign_gift_purchase.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class CampaignGiftPurchase < ApplicationRecord
+  belongs_to :campaign
+
+  has_many :campaign_gifts, class_name: 'ModernCampaignGift'
+
+  validates :amount, presence: true
+  validates :campaign, presence: true
+  validates :campaign_gifts, length: { minimum: 1 }
+  
+end

--- a/app/models/campaign_gift_purchase.rb
+++ b/app/models/campaign_gift_purchase.rb
@@ -3,6 +3,12 @@
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 class CampaignGiftPurchase < ApplicationRecord
+  include Model::Houidable
+  include Model::Jbuilder
+  include Model::Eventable
+
+  setup_houid :cgpur
+
   belongs_to :campaign
   has_many :campaign_gifts, class_name: 'ModernCampaignGift'
 
@@ -19,4 +25,23 @@ class CampaignGiftPurchase < ApplicationRecord
   validates :campaign, presence: true
   validates :campaign_gifts, length: { minimum: 1 }
   
+  def to_builder(*expand)
+    init_builder(*expand) do |json|
+      json.(self, :id, :deleted)
+      json.object 'campaign_gift_purchase'
+      
+      json.amount do
+        json.value_in_cents amount
+        json.currency nonprofit.currency
+      end
+
+      if expand.include? :campaign_gifts
+        json.campaign_gifts campaign_gifts do |gift|
+          gift.to_builder
+        end
+      else
+        json.campaign_gifts campaign_gifts.pluck(:id)
+      end
+    end
+  end
 end

--- a/app/models/modern_campaign_gift.rb
+++ b/app/models/modern_campaign_gift.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class ModernCampaignGift < ApplicationRecord
+	include Model::Houidable
+  include Model::Jbuilder
+  include Model::Eventable
+	setup_houid :cgift
+	
+	belongs_to :campaign_gift_purchase
+	belongs_to :legacy_campaign_gift,  class_name: 'CampaignGift', foreign_key: :campaign_gift_id, inverse_of: :modern_campaign_gift
+
+	validates :amount, presence: true
+	validates :legacy_campaign_gift, presence: true
+	validates :campaign_gift_purchase, presence: true
+	
+end

--- a/app/models/modern_campaign_gift.rb
+++ b/app/models/modern_campaign_gift.rb
@@ -7,7 +7,8 @@ class ModernCampaignGift < ApplicationRecord
   include Model::Jbuilder
   include Model::Eventable
 	setup_houid :cgift
-	add_builder_expansion :nonprofit, :supporter, :campaign, :campaign_gift_option
+	
+	add_builder_expansion :nonprofit, :supporter, :campaign, :campaign_gift_option, :campaign_gift_purchase
   add_builder_expansion :trx, 
 		json_attrib: :transaction
 
@@ -23,7 +24,7 @@ class ModernCampaignGift < ApplicationRecord
 	# TODO replace with Discard gem
 	define_model_callbacks :discard
 
-	after_discard :publish_deleted
+	# after_discard :publish_deleted
 
 	validates :amount, presence: true
 	validates :legacy_campaign_gift, presence: true
@@ -38,8 +39,8 @@ class ModernCampaignGift < ApplicationRecord
 	end
 	
 	def to_builder(*expand)
-		init_builder(*expand) do 
-			json.(self, :id, :name, :deleted)
+		init_builder(*expand) do |json|
+			json.(self, :id, :deleted)
 			json.object 'campaign_gift'
 			json.amount do
         json.value_in_cents amount
@@ -49,14 +50,14 @@ class ModernCampaignGift < ApplicationRecord
 	end
 
 	def publish_created
-    Houdini.event_publisher.announce(:campaign_gift_created, to_event('campaign_gift.created', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option).attributes!)
+    Houdini.event_publisher.announce(:campaign_gift_created, to_event('campaign_gift.created', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option, :campaign_gift_purchase).attributes!)
 	end
 	
 	def publish_updated
-		Houdini.event_publisher.announce(:campaign_gift_updated, to_event('campaign_gift.updated', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option).attributes!)
+		Houdini.event_publisher.announce(:campaign_gift_updated, to_event('campaign_gift.updated', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option, :campaign_gift_purchase).attributes!)
 	end
 
 	def publish_deleted
-		Houdini.event_publisher.announce(:campaign_gift_deleted, to_event('campaign_gift.deleted', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option).attributes!)
+		Houdini.event_publisher.announce(:campaign_gift_deleted, to_event('campaign_gift.deleted', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option, :campaign_gift_purchase).attributes!)
 	end
 end

--- a/app/models/modern_campaign_gift.rb
+++ b/app/models/modern_campaign_gift.rb
@@ -7,12 +7,56 @@ class ModernCampaignGift < ApplicationRecord
   include Model::Jbuilder
   include Model::Eventable
 	setup_houid :cgift
-	
+	add_builder_expansion :nonprofit, :supporter, :campaign, :campaign_gift_option
+  add_builder_expansion :trx, 
+		json_attrib: :transaction
+
 	belongs_to :campaign_gift_purchase
 	belongs_to :legacy_campaign_gift,  class_name: 'CampaignGift', foreign_key: :campaign_gift_id, inverse_of: :modern_campaign_gift
+
+	has_one :campaign_gift_option, through: :legacy_campaign_gift
+	has_one :trx, through: :campaign_gift_purchase
+	has_one :supporter, through: :campaign_gift_purchase
+	has_one :nonprofit, through: :campaign_gift_purchase
+	has_one :campaign, through: :campaign_gift_purchase
+
+	# TODO replace with Discard gem
+	define_model_callbacks :discard
+
+	after_discard :publish_deleted
 
 	validates :amount, presence: true
 	validates :legacy_campaign_gift, presence: true
 	validates :campaign_gift_purchase, presence: true
 	
+	# TODO replace with discard gem
+  def discard!
+    run_callbacks(:discard) do
+      self.deleted = true
+      save!
+    end
+	end
+	
+	def to_builder(*expand)
+		init_builder(*expand) do 
+			json.(self, :id, :name, :deleted)
+			json.object 'campaign_gift'
+			json.amount do
+        json.value_in_cents amount
+        json.currency nonprofit.currency
+      end
+		end
+	end
+
+	def publish_created
+    Houdini.event_publisher.announce(:campaign_gift_created, to_event('campaign_gift.created', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option).attributes!)
+	end
+	
+	def publish_updated
+		Houdini.event_publisher.announce(:campaign_gift_updated, to_event('campaign_gift.updated', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option).attributes!)
+	end
+
+	def publish_deleted
+		Houdini.event_publisher.announce(:campaign_gift_deleted, to_event('campaign_gift.deleted', :nonprofit, :supporter, :trx, :campaign, :campaign_gift_option).attributes!)
+	end
 end

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -17,6 +17,7 @@ class Transaction < ApplicationRecord
 
 	has_many :donations, through: :transaction_assignments, source: :assignable, source_type: 'ModernDonation'
 	has_many :ticket_purchases, through: :transaction_assignments, source: :assignable, source_type: 'TicketPurchase'
+	has_many :campaign_gift_purchases, through: :transaction_assignments, source: :assignable, source_type: 'CampaignGiftPurchase'
 
 	validates :supporter, presence: true
 

--- a/db/migrate/20210208211655_create_campaign_gift_purchases.rb
+++ b/db/migrate/20210208211655_create_campaign_gift_purchases.rb
@@ -1,0 +1,11 @@
+class CreateCampaignGiftPurchases < ActiveRecord::Migration[6.1]
+  def change
+    create_table :campaign_gift_purchases, id: :string  do |t|
+      t.boolean :deleted, null: false, default: false
+      t.integer :amount, null: false
+      t.references :campaign, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210208212655_create_modern_campaign_gifts.rb
+++ b/db/migrate/20210208212655_create_modern_campaign_gifts.rb
@@ -1,0 +1,12 @@
+class CreateModernCampaignGifts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :modern_campaign_gifts, id: :string do |t|
+      t.boolean :deleted, null: false, default: false
+      t.references :campaign_gift, null: false, foreign_key: true
+      t.integer :amount, null: false, default: 0
+      t.references :campaign_gift_purchase, type: :string, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -399,6 +399,20 @@ ALTER SEQUENCE public.campaign_gift_options_id_seq OWNED BY public.campaign_gift
 
 
 --
+-- Name: campaign_gift_purchases; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.campaign_gift_purchases (
+    id character varying NOT NULL,
+    deleted boolean DEFAULT false NOT NULL,
+    amount integer NOT NULL,
+    campaign_id bigint,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
+
+
+--
 -- Name: campaign_gifts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1434,6 +1448,21 @@ CREATE SEQUENCE public.miscellaneous_np_infos_id_seq
 --
 
 ALTER SEQUENCE public.miscellaneous_np_infos_id_seq OWNED BY public.miscellaneous_np_infos.id;
+
+
+--
+-- Name: modern_campaign_gifts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.modern_campaign_gifts (
+    id character varying NOT NULL,
+    deleted boolean DEFAULT false NOT NULL,
+    campaign_gift_id bigint NOT NULL,
+    amount integer DEFAULT 0 NOT NULL,
+    campaign_gift_purchase_id character varying NOT NULL,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
+);
 
 
 --
@@ -2860,6 +2889,14 @@ ALTER TABLE ONLY public.campaign_gift_options
 
 
 --
+-- Name: campaign_gift_purchases campaign_gift_purchases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_gift_purchases
+    ADD CONSTRAINT campaign_gift_purchases_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: campaign_gifts campaign_gifts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3073,6 +3110,14 @@ ALTER TABLE ONLY public.email_lists
 
 ALTER TABLE ONLY public.miscellaneous_np_infos
     ADD CONSTRAINT miscellaneous_np_infos_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: modern_campaign_gifts modern_campaign_gifts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.modern_campaign_gifts
+    ADD CONSTRAINT modern_campaign_gifts_pkey PRIMARY KEY (id);
 
 
 --
@@ -3382,6 +3427,13 @@ CREATE INDEX index_activities_on_supporter_id ON public.activities USING btree (
 
 
 --
+-- Name: index_campaign_gift_purchases_on_campaign_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_campaign_gift_purchases_on_campaign_id ON public.campaign_gift_purchases USING btree (campaign_id);
+
+
+--
 -- Name: index_campaign_gifts_on_campaign_gift_option_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -3442,6 +3494,20 @@ CREATE INDEX index_exports_on_user_id ON public.exports USING btree (user_id);
 --
 
 CREATE INDEX index_import_requests_on_nonprofit_id ON public.import_requests USING btree (nonprofit_id);
+
+
+--
+-- Name: index_modern_campaign_gifts_on_campaign_gift_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_modern_campaign_gifts_on_campaign_gift_id ON public.modern_campaign_gifts USING btree (campaign_gift_id);
+
+
+--
+-- Name: index_modern_campaign_gifts_on_campaign_gift_purchase_id; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_modern_campaign_gifts_on_campaign_gift_purchase_id ON public.modern_campaign_gifts USING btree (campaign_gift_purchase_id);
 
 
 --
@@ -3768,6 +3834,14 @@ ALTER TABLE ONLY public.ticket_to_legacy_tickets
 
 
 --
+-- Name: modern_campaign_gifts fk_rails_0757cd7020; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.modern_campaign_gifts
+    ADD CONSTRAINT fk_rails_0757cd7020 FOREIGN KEY (campaign_gift_id) REFERENCES public.campaign_gifts(id);
+
+
+--
 -- Name: ticket_purchases fk_rails_28d2157787; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -3816,11 +3890,27 @@ ALTER TABLE ONLY public.active_storage_attachments
 
 
 --
+-- Name: modern_campaign_gifts fk_rails_df25dd1768; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.modern_campaign_gifts
+    ADD CONSTRAINT fk_rails_df25dd1768 FOREIGN KEY (campaign_gift_purchase_id) REFERENCES public.campaign_gift_purchases(id);
+
+
+--
 -- Name: ticket_purchases fk_rails_e2eb419f70; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.ticket_purchases
     ADD CONSTRAINT fk_rails_e2eb419f70 FOREIGN KEY (event_discount_id) REFERENCES public.event_discounts(id);
+
+
+--
+-- Name: campaign_gift_purchases fk_rails_e393cdf757; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.campaign_gift_purchases
+    ADD CONSTRAINT fk_rails_e393cdf757 FOREIGN KEY (campaign_id) REFERENCES public.campaigns(id);
 
 
 --
@@ -4317,6 +4407,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20210204172319'),
 ('20210204174909'),
 ('20210204210627'),
-('20210204223643');
+('20210204223643'),
+('20210208211655'),
+('20210208212655');
 
 

--- a/docs/event_definitions/Nonprofit/Campaign/CampaignGift.ts
+++ b/docs/event_definitions/Nonprofit/Campaign/CampaignGift.ts
@@ -1,0 +1,31 @@
+// License: LGPL-3.0-or-later
+import type { HouID, HoudiniObject, HoudiniEvent, Amount, IdType} from '../../common';
+import type Nonprofit from '..';
+import type Campaign from '.';
+import type { CampaignGiftPurchase, CampaignGiftOption } from '.';
+import type Supporter from '../Supporter';
+
+export interface TransactionAddress {
+  address: string;
+  city: string;
+  country: string;
+  state_code: string;
+  zip_code: string;
+}
+
+export interface CampaignGift extends HoudiniObject<HouID> {
+  address?: TransactionAddress;
+  amount: Amount;
+  campaign: IdType | Campaign;
+  campaign_gift_option: IdType | CampaignGiftOption;
+  campaign_gift_purchase: IdType | CampaignGiftPurchase;
+  deleted: boolean;
+  event: IdType | Event;
+  nonprofit: IdType | Nonprofit;
+  object: 'campaign_gift';
+  supporter: IdType | Supporter;
+}
+
+export type CampaignGiftCreated = HoudiniEvent<'campaign_gift.created', CampaignGift>;
+export type CampaignGiftUpdated = HoudiniEvent<'campaign_gift.updated', CampaignGift>;
+export type CampaignGiftDeleted = HoudiniEvent<'campaign_gift.deleted', CampaignGift>;

--- a/docs/event_definitions/Nonprofit/Campaign/CampaignGiftPurchase.ts
+++ b/docs/event_definitions/Nonprofit/Campaign/CampaignGiftPurchase.ts
@@ -18,6 +18,6 @@ export interface CampaignGiftPurchase extends HoudiniObject<HouID> {
 }
 
 
-export type TicketPurchaseCreated = HoudiniEvent<'ticket_purchase.created', TicketPurchase>;
-export type TicketPurchaseUpdated = HoudiniEvent<'ticket_purchase.updated', TicketPurchase>;
-export type TicketPurchaseDeleted = HoudiniEvent<'ticket_purchase.deleted', TicketPurchase>;
+export type CampaignGiftPurchaseCreated = HoudiniEvent<'campaign_gift_purchase.created', CampaignGiftPurchase>;
+export type CampaignGiftPurchaseUpdated = HoudiniEvent<'campaign_gift_purchase.updated', CampaignGiftPurchase>;
+export type CampaignGiftPurchaseDeleted = HoudiniEvent<'campaign_gift_purchase.deleted', CampaignGiftPurchase>;

--- a/docs/event_definitions/Nonprofit/Campaign/CampaignGiftPurchase.ts
+++ b/docs/event_definitions/Nonprofit/Campaign/CampaignGiftPurchase.ts
@@ -1,0 +1,23 @@
+// License: LGPL-3.0-or-later
+import type { HouID, HoudiniObject, HoudiniEvent, Amount, IdType} from '../../common';
+import type Nonprofit from '..';
+import type Campaign from '.';
+import type { CampaignGift } from '.';
+import Supporter from '../Supporter';
+import { Transaction } from '../Supporter';
+
+
+export interface CampaignGiftPurchase extends HoudiniObject<HouID> {
+  amount: Amount;
+  campaign: IdType | Campaign;
+  campaign_gifts: HouID[] | CampaignGift[];
+  nonprofit: IdType | Nonprofit;
+  object: 'campaign_gift_purchase';
+  supporter: IdType | Supporter;
+  transaction: HouID | Transaction;
+}
+
+
+export type TicketPurchaseCreated = HoudiniEvent<'ticket_purchase.created', TicketPurchase>;
+export type TicketPurchaseUpdated = HoudiniEvent<'ticket_purchase.updated', TicketPurchase>;
+export type TicketPurchaseDeleted = HoudiniEvent<'ticket_purchase.deleted', TicketPurchase>;

--- a/docs/event_definitions/Nonprofit/Campaign/index.ts
+++ b/docs/event_definitions/Nonprofit/Campaign/index.ts
@@ -9,3 +9,5 @@ export default interface Campaign extends HoudiniObject {
 }
 
 export * from './CampaignGiftOption';
+export * from './CampaignGiftPurchase';
+export * from './CampaignGift';

--- a/spec/factories/campaign_gift_purchases.rb
+++ b/spec/factories/campaign_gift_purchases.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+FactoryBot.define do
+  factory :campaign_gift_purchase do
+    deleted { false }
+    amount { 1 }
+    campaign { nil }
+  end
+end

--- a/spec/factories/campaign_gift_purchases.rb
+++ b/spec/factories/campaign_gift_purchases.rb
@@ -4,8 +4,5 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 FactoryBot.define do
   factory :campaign_gift_purchase do
-    deleted { false }
-    amount { 1 }
-    campaign { nil }
   end
 end

--- a/spec/factories/modern_campaign_gifts.rb
+++ b/spec/factories/modern_campaign_gifts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+FactoryBot.define do
+  factory :modern_campaign_gift do
+    deleted { false }
+    campaign_gift { "" }
+    amount { 1 }
+  end
+end

--- a/spec/models/campaign_gift_option_spec.rb
+++ b/spec/models/campaign_gift_option_spec.rb
@@ -4,7 +4,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
 require 'rails_helper'
 
-RSpec.describe CampaignGiftOption, type: :model do
+RSpec.describe CampaignGiftOption, 'type' => :model do
   include_context :shared_donation_charge_context
   let(:name) {"CUSTOM GIFT OPTION"}
   let(:amount_one_time) { 400}
@@ -57,10 +57,10 @@ RSpec.describe CampaignGiftOption, type: :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {value_in_cents:amount_one_time, currency: nonprofit.currency}},
+              {'amount' => {'value_in_cents'=> amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {value_in_cents:amount_recurring, currency: nonprofit.currency},
-                'recurrence' => { interval: 1, type: 'monthly'}
+                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
             'id'=> kind_of(Numeric),
@@ -98,10 +98,10 @@ RSpec.describe CampaignGiftOption, type: :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {value_in_cents:amount_one_time, currency: nonprofit.currency}},
+              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {value_in_cents:amount_recurring, currency: nonprofit.currency},
-                'recurrence' => { interval: 1, type: 'monthly'}
+                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
             'id'=> kind_of(Numeric),
@@ -161,8 +161,8 @@ RSpec.describe CampaignGiftOption, type: :model do
             'description' => description,
             'gift_option_amount' => [
               {
-                'amount' => {value_in_cents:amount_recurring, currency: nonprofit.currency},
-                'recurrence' => { interval: 1, type: 'monthly'}
+                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
             'id'=> kind_of(Numeric),
@@ -205,7 +205,7 @@ RSpec.describe CampaignGiftOption, type: :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {value_in_cents:amount_one_time, currency: nonprofit.currency}},
+              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
             ],
             'id'=> kind_of(Numeric),
             'hide_contributions' => false,
@@ -252,10 +252,10 @@ RSpec.describe CampaignGiftOption, type: :model do
             'deleted' => true,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {value_in_cents:amount_one_time, currency: nonprofit.currency}},
+              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {value_in_cents:amount_recurring, currency: nonprofit.currency},
-                'recurrence' => { interval: 1, type: 'monthly'}
+                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
             'id'=> kind_of(Numeric),
@@ -299,10 +299,10 @@ RSpec.describe CampaignGiftOption, type: :model do
             'deleted' => true,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {value_in_cents:amount_one_time, currency: nonprofit.currency}},
+              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {value_in_cents:amount_recurring, currency: nonprofit.currency},
-                'recurrence' => { interval: 1, type: 'monthly'}
+                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
             'id'=> kind_of(Numeric),

--- a/spec/models/campaign_gift_purchase_spec.rb
+++ b/spec/models/campaign_gift_purchase_spec.rb
@@ -5,5 +5,192 @@
 require 'rails_helper'
 
 RSpec.describe CampaignGiftPurchase, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include_context :shared_donation_charge_context
+  # TODO Why are we manually setting everything here? It's not clear what order things should
+  # go in for a transaction. Therefore, we don't assume the order for now and just make sure the
+  # the output of to_builder is right
+  let(:trx) { force_create(:transaction, supporter: supporter, amount: 400)}
+
+  let(:campaign_gift_purchase) {trx.campaign_gift_purchases.create(campaign: campaign, amount: 400, campaign_gifts: [ModernCampaignGift.new(amount: 400, legacy_campaign_gift:lcg)])}
+  let(:lcg) { CampaignGift.create(
+    donation: supporter.donations.create(amount: 400, campaign: campaign, nonprofit: nonprofit, supporter:supporter),
+    campaign_gift_option: campaign_gift_option
+  )}
+  let(:campaign_gift_option) { create(:campaign_gift_option, amount_one_time: 400, campaign: campaign)}
+  let(:campaign_gift) { campaign_gift_purchase.campaign_gifts.first}
+
+  let(:campaign_builder_expanded) do 
+    {
+      'id' => kind_of(Numeric),
+      'name' => campaign.name,
+      'object' =>  "campaign",
+      'nonprofit' =>  nonprofit.id
+    }
+  end
+
+  let(:cgo_builder_expanded) do 
+    {
+      'id' => kind_of(Numeric),
+      'name' => campaign_gift_option.name,
+      'description' => campaign_gift_option.description,
+      'hide_contributions' => campaign_gift_option.hide_contributions,
+      'order' => campaign_gift_option.order,
+      'to_ship' => campaign_gift_option.to_ship,
+      'object' => 'campaign_gift_option',
+      'deleted' => false,
+      'gift_option_amount' => [{
+        'amount' => {
+          'value_in_cents' => 400,
+          'currency' => 'usd'
+        },
+      }],
+      'campaign' => kind_of(Numeric),
+      'nonprofit' => kind_of(Numeric)
+    }
+  end
+
+  let(:np_builder_expanded) do 
+    {
+      'id' => nonprofit.id,
+      'name' => nonprofit.name,
+      'object' => 'nonprofit'
+    }
+  end
+
+  let(:supporter_builder_expanded) do 
+    supporter_to_builder_base.merge({'name'=> 'Fake Supporter Name'})
+  end
+
+  let(:transaction_builder_expanded) do 
+    { 
+      'id' => match_houid('trx'),
+      'object' => 'transaction',
+      'amount' => {
+        'value_in_cents' => trx.amount,
+        'currency' => 'usd'
+      },
+      'supporter' => kind_of(Numeric),
+      'nonprofit' => kind_of(Numeric)
+    }
+  end
+  
+  let(:cgp_builder_expanded) do
+    { 
+      'id' => match_houid('cgpur'),
+      'campaign' => kind_of(Numeric),
+      'object' => 'campaign_gift_purchase',
+      'campaign_gifts' => [modern_campaign_gift_builder],
+      'amount' => {
+        'value_in_cents' => trx.amount,
+        'currency' => 'usd'
+      },
+      'supporter' => supporter_builder_expanded,
+      'nonprofit' => np_builder_expanded,
+      'transaction' => transaction_builder_expanded,
+      'deleted' => false
+    }
+  end
+  
+  let(:modern_campaign_gift_builder) {
+    {
+      'amount' => {
+        'value_in_cents' => 400,
+        'currency' => 'usd'
+      },
+      'campaign' => kind_of(Numeric),
+      'campaign_gift_option' => kind_of(Numeric),
+      'campaign_gift_purchase' => match_houid('cgpur'),
+      'deleted' => false,
+      'id' => match_houid('cgift'),
+      'nonprofit'=> kind_of(Numeric),
+      'object' => 'campaign_gift',
+      'supporter' => kind_of(Numeric),
+      'transaction' => match_houid('trx')
+    }
+  }
+  
+
+  
+
+  it 'announces created properly when called' do
+    allow(Houdini.event_publisher).to receive(:announce)
+    expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_purchase_created, {
+      'id' => match_houid('objevt'),
+      'object' => 'object_event',
+      'type' => 'campaign_gift_purchase.created',
+      'data' => {
+        'object' => {
+          'id' => match_houid('cgpur'),
+          'campaign' => campaign_builder_expanded,
+          'object' => 'campaign_gift_purchase',
+          'campaign_gifts' => [modern_campaign_gift_builder],
+          'amount' => {
+            'value_in_cents' => trx.amount,
+            'currency' => 'usd'
+          },
+          'supporter' => supporter_builder_expanded,
+          'nonprofit' => np_builder_expanded,
+          'transaction' => transaction_builder_expanded,
+          'deleted' => false
+        }
+      }
+    })
+
+    campaign_gift_purchase.publish_created
+  end
+
+  it 'announces updated properly when called' do
+    allow(Houdini.event_publisher).to receive(:announce)
+    expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_purchase_updated, {
+      'id' => match_houid('objevt'),
+      'object' => 'object_event',
+      'type' => 'campaign_gift_purchase.updated',
+      'data' => {
+        'object' => {
+          'id' => match_houid('cgpur'),
+          'campaign' => campaign_builder_expanded,
+          'object' => 'campaign_gift_purchase',
+          'campaign_gifts' => [modern_campaign_gift_builder],
+          'amount' => {
+            'value_in_cents' => trx.amount,
+            'currency' => 'usd'
+          },
+          'supporter' => supporter_builder_expanded,
+          'nonprofit' => np_builder_expanded,
+          'transaction' => transaction_builder_expanded,
+          'deleted' => false
+        }
+      }
+    })
+
+    campaign_gift_purchase.publish_updated
+  end
+
+  it 'announces updated deleted properly when called' do
+    allow(Houdini.event_publisher).to receive(:announce)
+    expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_purchase_deleted, {
+      'id' => match_houid('objevt'),
+      'object' => 'object_event',
+      'type' => 'campaign_gift_purchase.deleted',
+      'data' => {
+        'object' => {
+          'id' => match_houid('cgpur'),
+          'campaign' => campaign_builder_expanded,
+          'object' => 'campaign_gift_purchase',
+          'campaign_gifts' => [modern_campaign_gift_builder],
+          'amount' => {
+            'value_in_cents' => trx.amount,
+            'currency' => 'usd'
+          },
+          'supporter' => supporter_builder_expanded,
+          'nonprofit' => np_builder_expanded,
+          'transaction' => transaction_builder_expanded,
+          'deleted' => true
+        }
+      }
+    })
+
+    campaign_gift_purchase.discard!
+    campaign_gift_purchase.publish_deleted
+  end
 end

--- a/spec/models/campaign_gift_purchase_spec.rb
+++ b/spec/models/campaign_gift_purchase_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+RSpec.describe CampaignGiftPurchase, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/modern_campaign_gift_spec.rb
+++ b/spec/models/modern_campaign_gift_spec.rb
@@ -5,5 +5,177 @@
 require 'rails_helper'
 
 RSpec.describe ModernCampaignGift, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  include_context :shared_donation_charge_context
+  # TODO Why are we manually setting everything here? It's not clear what order things should
+  # go in for a transaction. Therefore, we don't assume the order for now and just make sure the
+  # the output of to_builder is right
+  let(:trx) { force_create(:transaction, supporter: supporter, amount: 400)}
+
+  let(:campaign_gift_purchase) {trx.campaign_gift_purchases.create(campaign: campaign, amount: 400, campaign_gifts: [ModernCampaignGift.new(amount: 400, legacy_campaign_gift:lcg)])}
+  let(:lcg) { CampaignGift.create(
+    donation: supporter.donations.create(amount: 400, campaign: campaign, nonprofit: nonprofit, supporter:supporter),
+    campaign_gift_option: campaign_gift_option
+  )}
+  let(:campaign_gift_option) { create(:campaign_gift_option, amount_one_time: 400, campaign: campaign)}
+  let(:campaign_gift) { campaign_gift_purchase.campaign_gifts.first}
+
+  let(:campaign_builder_expanded) do 
+    {
+      'id' => kind_of(Numeric),
+      'name' => campaign.name,
+      'object' =>  "campaign",
+      'nonprofit' =>  nonprofit.id
+    }
+  end
+
+  let(:cgo_builder_expanded) do 
+    {
+      'id' => kind_of(Numeric),
+      'name' => campaign_gift_option.name,
+      'description' => campaign_gift_option.description,
+      'hide_contributions' => campaign_gift_option.hide_contributions,
+      'order' => campaign_gift_option.order,
+      'to_ship' => campaign_gift_option.to_ship,
+      'object' => 'campaign_gift_option',
+      'deleted' => false,
+      'gift_option_amount' => [{
+        'amount' => {
+          'value_in_cents' => 400,
+          'currency' => 'usd'
+        },
+      }],
+      'campaign' => kind_of(Numeric),
+      'nonprofit' => kind_of(Numeric)
+    }
+  end
+
+  let(:np_builder_expanded) do 
+    {
+      'id' => nonprofit.id,
+      'name' => nonprofit.name,
+      'object' => 'nonprofit'
+    }
+  end
+
+  let(:supporter_builder_expanded) do 
+    supporter_to_builder_base.merge({'name'=> 'Fake Supporter Name'})
+  end
+
+  let(:transaction_builder_expanded) do 
+    { 
+      'id' => match_houid('trx'),
+      'object' => 'transaction',
+      'amount' => {
+        'value_in_cents' => trx.amount,
+        'currency' => 'usd'
+      },
+      'supporter' => kind_of(Numeric),
+      'nonprofit' => kind_of(Numeric)
+    }
+  end
+  
+  let(:cgp_builder_expanded) do
+    { 
+      'id' => match_houid('cgpur'),
+      'campaign' => kind_of(Numeric),
+      'object' => 'campaign_gift_purchase',
+      'campaign_gifts' => [match_houid('cgift')],
+      'amount' => {
+        'value_in_cents' => trx.amount,
+        'currency' => 'usd'
+      },
+      'supporter' => kind_of(Numeric),
+      'nonprofit' => kind_of(Numeric),
+      'transaction' => match_houid('trx'),
+      'deleted' => false
+    }
+  end
+  
+
+  
+
+  it 'announces created properly when called' do
+    allow(Houdini.event_publisher).to receive(:announce)
+    expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_created, {
+      'id' => match_houid('objevt'),
+      'object' => 'object_event',
+      'type' => 'campaign_gift.created',
+      'data' => {
+        'object' => {
+          'amount' => {
+            'value_in_cents' => 400,
+            'currency' => 'usd'
+          },
+          'campaign' => campaign_builder_expanded,
+          'campaign_gift_option' => cgo_builder_expanded,
+          'campaign_gift_purchase' => cgp_builder_expanded,
+          'deleted' => false,
+          'id' => match_houid('cgift'),
+          'nonprofit'=> np_builder_expanded,
+          'object' => 'campaign_gift',
+          'supporter' => supporter_builder_expanded,
+          'transaction' => transaction_builder_expanded
+        }
+      }
+    })
+
+    campaign_gift.publish_created
+  end
+
+  it 'announces updated properly when called' do
+    allow(Houdini.event_publisher).to receive(:announce)
+    expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_updated, {
+      'id' => match_houid('objevt'),
+      'object' => 'object_event',
+      'type' => 'campaign_gift.updated',
+      'data' => {
+        'object' => {
+          'amount' => {
+            'value_in_cents' => 400,
+            'currency' => 'usd'
+          },
+          'campaign' => campaign_builder_expanded,
+          'campaign_gift_option' => cgo_builder_expanded,
+          'campaign_gift_purchase' => cgp_builder_expanded,
+          'deleted' => false,
+          'id' => match_houid('cgift'),
+          'nonprofit'=> np_builder_expanded,
+          'object' => 'campaign_gift',
+          'supporter' => supporter_builder_expanded,
+          'transaction' => transaction_builder_expanded
+        }
+      }
+    })
+
+    campaign_gift.publish_updated
+  end
+
+  it 'announces updated deleted properly when called' do
+    allow(Houdini.event_publisher).to receive(:announce)
+    expect(Houdini.event_publisher).to receive(:announce).with(:campaign_gift_deleted, {
+      'id' => match_houid('objevt'),
+      'object' => 'object_event',
+      'type' => 'campaign_gift.deleted',
+      'data' => {
+        'object' => {
+          'amount' => {
+            'value_in_cents' => 400,
+            'currency' => 'usd'
+          },
+          'campaign' => campaign_builder_expanded,
+          'campaign_gift_option' => cgo_builder_expanded,
+          'campaign_gift_purchase' => cgp_builder_expanded,
+          'deleted' => true,
+          'id' => match_houid('cgift'),
+          'nonprofit'=> np_builder_expanded,
+          'object' => 'campaign_gift',
+          'supporter' => supporter_builder_expanded,
+          'transaction' => transaction_builder_expanded
+        }
+      }
+    })
+
+    campaign_gift.discard!
+    campaign_gift.publish_deleted
+  end
 end

--- a/spec/models/modern_campaign_gift_spec.rb
+++ b/spec/models/modern_campaign_gift_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+require 'rails_helper'
+
+RSpec.describe ModernCampaignGift, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Depends on #469

Closes #475
Closes #420


NOTE: While the object event functionality is here, nothing currently fires these events. This requires the rewrite of the transaction creation mechanism.

Currently, setting the campaign gift is a separate API call after the campaign gift purchase which would be known as not great design. Because of that, it's not really possible to separate out campaign gift purchases and donations.

