### PR TITLE
Fixing Supporter and Supporter Note creation

### DIFF
--- a/app/controllers/campaigns/supporters_controller.rb
+++ b/app/controllers/campaigns/supporters_controller.rb
@@ -5,7 +5,7 @@
 module Campaigns
   class SupportersController < ApplicationController
     include Controllers::Campaign::Current
-  include Controllers::Campaign::Authorization
+    include Controllers::Campaign::Authorization
 
     before_action :authenticate_campaign_editor!, only: [:index]
 
@@ -21,5 +21,5 @@ module Campaigns
         format.html
       end
     end
-    end
+  end
 end

--- a/app/controllers/nonprofits/supporter_notes_controller.rb
+++ b/app/controllers/nonprofits/supporter_notes_controller.rb
@@ -11,13 +11,13 @@ class Nonprofits::SupporterNotesController < ApplicationController
 
   # post /nonprofits/:nonprofit_id/supporters/:supporter_id/supporter_notes
   def create
-    render_json { InsertSupporterNotes.create(supporter_params[:supporter_note]) }
+    render_json { InsertSupporterNotes.create(supporter_params) }
   end
 
   # put /nonprofits/:nonprofit_id/supporters/:supporter_id/supporter_notes/:id
   def update
     render_json { UpdateSupporterNotes.update(current_supporter_note,
-      supporter_params[:supporter_note].merge({user_id: current_user&.id})) }
+      supporter_note_content.merge({user_id: current_user&.id})) }
   end
 
   # delete /nonprofits/:nonprofit_id/supporters/:supporter_id/supporter_notes/:id
@@ -32,6 +32,14 @@ class Nonprofits::SupporterNotesController < ApplicationController
   end
 
   def supporter_params
+    {
+      content: supporter_note_content,
+      supporter: current_supporter,
+      user: current_user
+    }
+  end
+
+  def supporter_note_content
     params.require(:supporter_note).require(:content)
   end
 end

--- a/app/controllers/nonprofits/supporters_controller.rb
+++ b/app/controllers/nonprofits/supporters_controller.rb
@@ -76,7 +76,7 @@ module Nonprofits
 
     # post /nonprofits/:nonprofit_id/supporters
     def create
-      render_json { InsertSupporter.create_or_update(nonprofit, create_supporter_params.to_h) }
+      render_json { InsertSupporter.create_or_update(current_nonprofit, create_supporter_params.to_h) }
     end
 
     # put /nonprofits/:nonprofit_id/supporters/:id

--- a/lib/insert/insert_supporter_notes.rb
+++ b/lib/insert/insert_supporter_notes.rb
@@ -13,7 +13,7 @@ module InsertSupporterNotes
     inserted = nil
     ActiveRecord::Base.transaction do 
       inserted = note_supporter_users.map do |nsu|
-        nsu[:supporter].supporter_notes.create(nsu[:note].merge({user: nsu[:user]}))
+        nsu[:supporter].supporter_notes.create!(content: nsu[:content], user: nsu[:user])
       end
       InsertActivities.for_supporter_notes(inserted)
     end

--- a/lib/pay_recurring_donation.rb
+++ b/lib/pay_recurring_donation.rb
@@ -93,7 +93,7 @@ module PayRecurringDonation
       rd.save!
       result['recurring_donation'] = rd
       Houdini.event_publisher.announce(:recurring_donation_payment_failed, donation)
-      InsertSupporterNotes.create({supporter:Supporter.find(donation['supporter_id']), user: User.find(540), note:{ content: "This supporter had a payment failure for their recurring donation with ID #{rd_id}"}})
+      InsertSupporterNotes.create({supporter:Supporter.find(donation['supporter_id']), user: User.find(540), content: "This supporter had a payment failure for their recurring donation with ID #{rd_id}"})
     end
     result
   end

--- a/lib/update/update_recurring_donations.rb
+++ b/lib/update/update_recurring_donations.rb
@@ -96,7 +96,7 @@ module UpdateRecurringDonations
       .where('id=$id', id: rd_id.to_i)
     )
     rd = QueryRecurringDonations.fetch_for_edit(rd_id)['recurring_donation']
-    InsertSupporterNotes.create({ supporter: Supporter.find(rd['supporter_id']), user: nil, note: {content: "This supporter's recurring donation for $#{Format::Currency.cents_to_dollars(rd['amount'])} was cancelled by #{rd['cancelled_by']} on #{Format::Date.simple(rd['cancelled_at'])}"}})
+    InsertSupporterNotes.create({ supporter: Supporter.find(rd['supporter_id']), user: nil, content: "This supporter's recurring donation for $#{Format::Currency.cents_to_dollars(rd['amount'])} was cancelled by #{rd['cancelled_by']} on #{Format::Date.simple(rd['cancelled_at'])}"})
     unless dont_notify_nonprofit
       RecurringDonationCancelledJob.perform_later(Donation.find(rd['donation_id']))
     end

--- a/spec/lib/insert/insert_supporter_notes_spec.rb
+++ b/spec/lib/insert/insert_supporter_notes_spec.rb
@@ -11,8 +11,8 @@ describe InsertSupporterNotes do
   let(:sn_first) {SupporterNote.first }
   let(:sn_last) {SupporterNote.last }
   it '.create' do
-    InsertSupporterNotes.create({supporter:supporter, user: user, note: {content: content}}, 
-      {supporter:supporter, user: user, note: {content: content_2}})
+    InsertSupporterNotes.create({supporter: supporter, user: user, content: content}, 
+      {supporter: supporter, user: user, content: content_2})
     expect(SupporterNote.count).to eq 2
     expect(sn_first.attributes.except('id')).to eq({
       'content' => content,

--- a/spec/lib/update/update_recurring_donations_spec.rb
+++ b/spec/lib/update/update_recurring_donations_spec.rb
@@ -8,7 +8,7 @@ describe UpdateRecurringDonations do
   # deactivate a recurring donation
   describe '.cancel' do
 
-    let(:np) { force_create(:nm_justice) }
+    let!(:np) { force_create(:nm_justice) }
     let(:s) { force_create(:supporter, nonprofit: np) }
     let(:donation) { force_create(:donation, nonprofit_id: np.id, supporter_id: s.id) }
     let(:email) { 'test@test.com' }


### PR DESCRIPTION
## Supporter creation

The supporter creation controller had a bug where it tried to access a nonexisting value for `nonprofit` on its controller. It caused this problem on the supporter creation modal: 

![image](https://user-images.githubusercontent.com/15739610/108003890-e9b99100-6fd2-11eb-8391-87834d9f9f9f.png)


To fix it, I accessed the `current_nonprofit` value instead.

## Supporter note creation

The wrong parameters were being passed to the `InsertSupporterNotes.create` method. It expected a `Supporter`, a `User` and a `content`, from the note to be created. It also had a problem trying to access a symbol that did not exist, as `supporter_params` was a method that returned a string, originally.
