### PR TITLE
Change event types for a ObjectEventHookConfig from text to jsonb

### DIFF
--- a/app/models/object_event_hook_config.rb
+++ b/app/models/object_event_hook_config.rb
@@ -6,15 +6,13 @@ class ObjectEventHookConfig < ApplicationRecord
 
   # :webhook_service, #str, webhook service to be called
   # :configuration, #jsonb, configuration needed to connect to the webhook
-  # :object_event_types, #text (array), a set of object event types
+  # :object_event_types, #jsonb, must be an array
 
   belongs_to :nonprofit
 
   validates :webhook_service, presence: true
   validates :configuration, presence: true
   validates :object_event_types, presence: true
-
-  serialize :object_event_types, Array
 
   def webhook
     Houdini::WebhookAdapter.build(webhook_service, configuration.symbolize_keys)

--- a/app/models/object_event_hook_config.rb
+++ b/app/models/object_event_hook_config.rb
@@ -12,7 +12,7 @@ class ObjectEventHookConfig < ApplicationRecord
 
   validates :webhook_service, presence: true
   validates :configuration, presence: true
-  validates :object_event_types, presence: true
+  validates :object_event_types, presence: true, length: {minimum: 1}
 
   def webhook
     Houdini::WebhookAdapter.build(webhook_service, configuration.symbolize_keys)

--- a/db/migrate/20210218191002_convert_list_of_object_event_types_to_jsonb.rb
+++ b/db/migrate/20210218191002_convert_list_of_object_event_types_to_jsonb.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class ConvertListOfObjectEventTypesToJsonb < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :object_event_hook_configs, :object_event_types, :text
+    add_column :object_event_hook_configs, :object_event_types, :jsonb, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_09_181808) do
+ActiveRecord::Schema.define(version: 2021_02_18_191002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
+  enable_extension "pgcrypto"
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
@@ -463,6 +464,20 @@ ActiveRecord::Schema.define(version: 2021_02_09_181808) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "good_jobs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.text "queue_name"
+    t.integer "priority"
+    t.jsonb "serialized_params"
+    t.datetime "scheduled_at"
+    t.datetime "performed_at"
+    t.datetime "finished_at"
+    t.text "error"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
+  end
+
   create_table "image_attachments", id: :serial, force: :cascade do |t|
     t.string "file", limit: 255
     t.integer "parent_id"
@@ -578,10 +593,10 @@ ActiveRecord::Schema.define(version: 2021_02_09_181808) do
   create_table "object_event_hook_configs", force: :cascade do |t|
     t.string "webhook_service", null: false
     t.jsonb "configuration", null: false
-    t.text "object_event_types", null: false
     t.bigint "nonprofit_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.jsonb "object_event_types", default: [], null: false
     t.index ["nonprofit_id"], name: "index_object_event_hook_configs_on_nonprofit_id"
   end
 

--- a/spec/models/object_event_hook_config_spec.rb
+++ b/spec/models/object_event_hook_config_spec.rb
@@ -8,6 +8,21 @@ RSpec.describe ObjectEventHookConfig, type: :model do
   let(:nonprofit) { create(:nm_justice) }
   let(:open_fn_config) { create(:open_fn_config, nonprofit_id: nonprofit.id) }
 
+  describe 'validation' do 
+    subject{ oehc = ObjectEventHookConfig.new(object_event_types:[]); oehc.validate; oehc}
+
+    it 'has an error for webhook_service missing' do 
+      expect(subject.errors[:webhook_service]).to_not be_nil
+    end
+
+    it 'has an error for configuraiton missing' do 
+      expect(subject.errors[:configuration]).to_not be_nil
+    end
+
+    it 'has an error for configuraition empty' do 
+      expect(subject.errors[:object_event_types]).to_not be_empty
+    end
+  end
   describe '.webhook' do
     it 'returns an instance of OpenFn webhook' do
       webhook = double


### PR DESCRIPTION
jsonb types in Postgres are queriable. If we change ObjectEventHookConfig.object_event_type, it's queriable. That's what we'll do.

﻿- Change list of events to jsonb
- Add validation for length of object_event_types

NOTE: You may have to rebuild your db after this commit.

cc: @clarissalimab 