### PR TITLE
Have Money use BigNumber

### DIFF
--- a/NOTICE-js
+++ b/NOTICE-js
@@ -5857,6 +5857,37 @@ SOFTWARE.
 
 ------
 
+** bignumber.js; version 9.0.0 -- https://github.com/MikeMcl/bignumber.js#readme
+Copyright (c) 2019 Michael Mclaughlin
+Copyright (c) 2019 Michael Mclaughlin <M8ch88l@gmail.com>
+
+The MIT Licence.
+
+Copyright (c) 2019 Michael Mclaughlin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+------
+
 ** array.prototype.find; version 2.1.1 -- https://github.com/paulmillr/Array.prototype.find#readme
 (c) 2016 Paul Miller (http://paulmillr.com)
 Copyright (c) 2019 Paul Miller (https://paulmillr.com)
@@ -6695,36 +6726,6 @@ Copyright (c) 2017 Kent C. Dodds
 
 The MIT License (MIT)
 Copyright (c) 2017 Kent C. Dodds
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-------
-
-** case-sensitive-paths-webpack-plugin; version 2.3.0 -- https://github.com/Urthen/case-sensitive-paths-webpack-plugin#readme
-Copyright (c) 2016 Michael Pratt
-Copyright (c) 2018 Michael Pratt
-Copyright (c) 2015 Alexandre Kirszenberg
-
-The MIT License (MIT)
-
-Copyright (c) 2018 Michael Pratt
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -12092,6 +12093,36 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** case-sensitive-paths-webpack-plugin; version 2.3.0 -- https://github.com/Urthen/case-sensitive-paths-webpack-plugin#readme
+Copyright (c) 2016 Michael Pratt
+Copyright (c) 2018 Michael Pratt
+Copyright (c) 2015 Alexandre Kirszenberg
+
+The MIT License (MIT)
+
+Copyright (c) 2018 Michael Pratt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+------
+
 ** chokidar; version 2.1.8 -- https://github.com/paulmillr/chokidar
 Copyright (c) 2012-2019 Paul Miller (https://paulmillr.com) & Elan Shanker
 ** circular-json-es6; version 2.0.2 -- https://github.com/yyx990803/circular-json-es6#readme
@@ -13487,32 +13518,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** extsprintf; version 1.3.0 -- https://github.com/davepacheco/node-extsprintf
-Copyright (c) 2012, Joyent, Inc.
-
-Copyright (c) 2012, Joyent, Inc. All rights reserved.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE
-
-
-------
-
 ** deep-equal; version 1.1.1 -- https://github.com/substack/node-deep-equal#readme
 Copyright (c) 2012, 2013, 2014 James Halliday <mail@substack.net> , 2009 Thomas Robinson <280north.com>
 
@@ -14305,9 +14310,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 Copyright 2012-2015 Yahoo! Inc.
 Copyright 2012-2015, Yahoo Inc.
 ** istanbul-lib-instrument; version 4.0.3 -- https://istanbul.js.org/
-Copyright 2012-2015 Yahoo! Inc.
-Copyright 2012-2015, Yahoo Inc.
-** istanbul-lib-report; version 3.0.0 -- https://istanbul.js.org/
 Copyright 2012-2015 Yahoo! Inc.
 Copyright 2012-2015, Yahoo Inc.
 
@@ -17937,6 +17939,32 @@ SOFTWARE.
 
 ------
 
+** extsprintf; version 1.3.0 -- https://github.com/davepacheco/node-extsprintf
+Copyright (c) 2012, Joyent, Inc.
+
+Copyright (c) 2012, Joyent, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE
+
+
+------
+
 ** fast-json-parse; version 1.0.3 -- https://github.com/mcollina/fast-json-parse#readme
 Copyright (c) 2016 Matteo Collina
 
@@ -18775,6 +18803,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
+** istanbul-lib-report; version 3.0.0 -- https://istanbul.js.org/
+Copyright 2012-2015 Yahoo! Inc.
+Copyright 2012-2015, Yahoo Inc.
 ** istanbul-reports; version 3.0.2 -- https://istanbul.js.org/
 (c) Sindre Sorhus
 Copyright 2012-2015 Yahoo! Inc.
@@ -21694,6 +21725,7 @@ SOFTWARE.
 ** jest-environment-jsdom; version 24.9.0 -- 
 Copyright (c) Facebook, Inc. and its affiliates.
 ** jest-pnp-resolver; version 1.2.2 -- https://github.com/arcanis/jest-pnp-resolver
+Copyright (c) 2016 Mael Nison
 ** jquery; version 1.11.1 -- http://jquery.com
 (c) 2013 jQuery Foundation, Inc.
 (c) 2005, 2014 jQuery Foundation, Inc.
@@ -21908,9 +21940,6 @@ Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 ** object-assign; version 4.1.1 -- https://github.com/sindresorhus/object-assign#readme
 (c) Sindre Sorhus
-(c) Sindre Sorhus (https://sindresorhus.com)
-Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
-** os-homedir; version 1.0.2 -- https://github.com/sindresorhus/os-homedir#readme
 (c) Sindre Sorhus (https://sindresorhus.com)
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
@@ -23429,67 +23458,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-** request; version 2.88.2 -- https://github.com/request/request#readme
-Copyright 2010-2012 Mikeal Rogers
-
-Apache License
-
-Version 2.0, January 2004
-
-http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
-
-"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
-
-"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-
-"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
-
-"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
-
-"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
-
-"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
-
-You must give any other recipients of the Work or Derivative Works a copy of this License; and
-
-You must cause any modified files to carry prominent notices stating that You changed the files; and
-
-You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
-
-If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-------
 
 ** phantomjs-prebuilt; version 2.1.16 -- https://github.com/Medium/phantomjs
 Copyright 2012 The Obvious Corporation.
@@ -27329,6 +27297,9 @@ IN THE SOFTWARE.
 
 ------
 
+** os-homedir; version 1.0.2 -- https://github.com/sindresorhus/os-homedir#readme
+(c) Sindre Sorhus (https://sindresorhus.com)
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 ** os-tmpdir; version 1.0.2 -- https://github.com/sindresorhus/os-tmpdir#readme
 (c) Sindre Sorhus (https://sindresorhus.com)
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
@@ -28717,6 +28688,8 @@ PERFORMANCE OF THIS SOFTWARE.
 
 ------
 
+** request; version 2.88.2 -- https://github.com/request/request#readme
+Copyright 2010-2012 Mikeal Rogers
 ** tunnel-agent; version 0.6.0 -- https://github.com/mikeal/tunnel-agent#readme
 ** typescript; version 4.0.2 -- https://www.typescriptlang.org/
 (c) by W3C
@@ -31977,34 +31950,6 @@ Copyright (c) 2017 Klaus Meinhardt
 The MIT License (MIT)
 
 Copyright (c) 2017 Klaus Meinhardt
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-
-------
-
-** v8-compile-cache; version 2.1.1 -- https://github.com/zertosh/v8-compile-cache#readme
-Copyright (c) 2019 Andres Suarez
-
-The MIT License (MIT)
-
-Copyright (c) 2019 Andres Suarez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -35908,6 +35853,34 @@ Copyright (c) 2017
 MIT License
 
 Copyright (c) 2017 webpack-contrib
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+------
+
+** v8-compile-cache; version 2.1.1 -- https://github.com/zertosh/v8-compile-cache#readme
+Copyright (c) 2019 Andres Suarez
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Andres Suarez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/app/javascript/common/money.spec.ts
+++ b/app/javascript/common/money.spec.ts
@@ -1,5 +1,6 @@
+import BigNumber from 'bignumber.js';
 // License: LGPL-3.0-or-later
-import { Money } from './money';
+import { Money, Operand, RoundingMode } from './money';
 
 describe("Money", () => {
 	describe('Money.fromCents', () => {
@@ -23,6 +24,17 @@ describe("Money", () => {
 			expect(result).toBeInstanceOf(Money);
 		});
 
+		it('succeeds from a stringy json', () => {
+			expect.hasAssertions();
+			const old = Money.fromCents(333, 'eur');
+
+			const result = Money.fromCents({ amount: '333', currency: 'eur' });
+			// eslint-disable-next-line jest/prefer-strict-equal
+			expect(result).toEqual(old);
+
+			expect(result).toBeInstanceOf(Money);
+		});
+
 		it('succeeds from function parameters', () => {
 			expect.hasAssertions();
 			const result = Money.fromCents(333, 'eur');
@@ -31,5 +43,197 @@ describe("Money", () => {
 
 			expect(result).toBeInstanceOf(Money);
 		});
+
+		it('succeeds from BigNumber', () => {
+			expect.hasAssertions();
+			const result = Money.fromCents(new BigNumber(333), 'eur');
+			// eslint-disable-next-line jest/prefer-strict-equal
+			expect(result).toEqual({ amount: 333, currency: 'eur' });
+		});
+
+		it('rejects if string is not an integer', () => {
+			expect.hasAssertions();
+			expect(() => {
+				Money.fromCents('3344.4', 'usd');
+			}).toThrow(TypeError);
+		});
+
+		it('rejects if BigNumber is not an integer', () => {
+			expect.hasAssertions();
+			expect(() => {
+				Money.fromCents(new BigNumber('3344.4'), 'usd');
+			}).toThrow(TypeError);
+		});
+
+		it('rejects if number is not an integer', () => {
+			expect.hasAssertions();
+			expect(() => {
+				Money.fromCents(444.333, 'usd');
+			}).toThrow(TypeError);
+		});
 	});
+	const cents1000 = Money.fromCents(1000, 'usd');
+	const cents500 = Money.fromCents(500, 'usd');
+
+	const euCents1000 = Money.fromCents(1000, 'eur');
+
+	const negative1000  = Money.fromCents(-1000, 'usd');
+
+	function verifyCurrency(func:(m:Money, other:Money) => unknown){
+		expect.assertions(1);
+		expect(() => func(cents1000, euCents1000)).toThrow(TypeError);
+	}
+
+	describe.each([
+		['add', (m:Money, other:Money) => m.add(other)],
+		['compare', (m:Money, other:Money) => m.compare(other)],
+		['divide', (m:Money, other:Money) => m.divide(other)],
+		['greaterThan', (m:Money, other:Money) => m.greaterThan(other)],
+		['greaterThanOrEqual', (m:Money, other:Money) => m.greaterThanOrEqual(other)],
+		['lessThan', (m:Money, other:Money) => m.lessThan(other)],
+		['lessThanOrEqual', (m:Money, other:Money) => m.lessThanOrEqual(other)],
+		['multiply', (m:Money, other:Money) => m.multiply(other)],
+		['subtract', (m:Money, other:Money) => m.subtract(other)],
+
+	])('.%s with %s', (_name, func) => {
+
+		it(`throw when currency doesn't match`, () => {
+			expect.assertions(1);
+			expect(() => func(cents1000, euCents1000)).toThrow(TypeError);
+		});
+	});
+
+
+	describe.each([
+		['add', (m:Money, other:Operand) => m.add(other)],
+		['subtract', (m:Money, other:Operand) => m.subtract(other)],
+	])('.%s with %s', (_name, func) => {
+
+		it(`throw when other is a decimal number`, () => {
+			expect.assertions(1);
+			expect(() => func(cents1000, 4.5)).toThrow(TypeError);
+		});
+
+		it(`throw when other is a decimal BigNumber`, () => {
+			expect.assertions(1);
+			expect(() => func(cents1000, new BigNumber('4.5'))).toThrow(TypeError);
+		});
+	});
+
+	it('.isZero', () => {
+		expect.assertions(1);
+		expect(cents1000.isZero()).toStrictEqual(false);
+	});
+
+	it('.isPositive', () => {
+		expect.assertions(1);
+		expect(cents1000.isPositive()).toStrictEqual(true);
+	});
+
+	it('.isNegative', () => {
+		expect.assertions(1);
+		expect(negative1000.isNegative()).toStrictEqual(true);
+	});
+
+	describe('.compare', () => {
+		describe('greater', () => {
+			describe('Money', () => {
+				it('same currency', () => {
+					expect.assertions(1);
+					expect(cents1000.compare(cents500)).toStrictEqual(1);
+				});
+
+				it('different currency', () => {
+					expect.assertions(1);
+					expect(() => {
+						cents1000.compare(euCents1000);
+					}).toThrow(TypeError);
+				});
+			});
+
+			describe('BigNumber', () => {
+				it('same currency', () => {
+					expect.assertions(1);
+					expect(cents1000.compare(cents500)).toStrictEqual(1);
+				});
+
+				it('different currency', () => {
+					expect.assertions(1);
+					expect(() => {
+						cents1000.compare(euCents1000);
+					}).toThrow(TypeError);
+				});
+			});
+		});
+	});
+
+	describe('.divide', () => {
+		it('divides 36 into 9', () => {
+			expect.assertions(1);
+			expect(Money.fromCents(36, 'usd').divide(9).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+		});
+
+		it('throws if the currencies do not match', () => {
+			expect.assertions(1);
+			verifyCurrency((m, other) => m.divide(other));
+		});
+
+		it('defaults to rounding to HalfUp', () => {
+			expect.assertions(3);
+			expect(Money.fromCents(40, 'usd').divide(Money.fromCents(9, 'usd')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+
+			expect(Money.fromCents(41, 'usd').divide(Money.fromCents(9, 'usd')).toJSON()).toStrictEqual({amount: 5, currency: 'usd'});
+
+			expect(Money.fromCents(7, 'usd').divide(Money.fromCents(2, 'usd')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+		});
+		it('rounds to floor if requested', () => {
+			expect.assertions(1);
+			expect(Money.fromCents(41, 'usd').divide(Money.fromCents(9, 'usd'), RoundingMode.Floor).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+		});
+
+		it('rounds to ceil if requested', () => {
+			expect.assertions(1);
+			expect(Money.fromCents(40, 'usd').divide(Money.fromCents(9, 'usd'), RoundingMode.Ceil).toJSON()).toStrictEqual({amount: 5, currency: 'usd'});
+		});
+	});
+
+	describe('.multiply', () => {
+		it('multiply 9 x 4', () => {
+			expect.assertions(1);
+			expect(Money.fromCents(9, 'usd').multiply(4).toJSON()).toStrictEqual({amount: 36, currency: 'usd'});
+		});
+
+		it('throws if the currencies do not match', () => {
+			expect.assertions(1);
+			verifyCurrency((m, other) => m.multiply(other));
+		});
+
+		it('handles multiplying by a decimal properly', () => {
+			expect.assertions(1);
+			expect(Money.fromCents('3', 'usd').multiply(new BigNumber('1.263')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+		});
+
+		it('defaults to rounding to HalfUp', () => {
+			expect.assertions(1);
+			expect(Money.fromCents(7, 'usd').multiply(new BigNumber('.5')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+		});
+
+		it('rounds to floor if requested', () => {
+			expect.assertions(1);
+			expect(Money.fromCents('3', 'usd').multiply('1.263', RoundingMode.Floor).toJSON()).toStrictEqual({amount: 3, currency: 'usd'});
+		});
+
+		it('rounds to ceil if requested', () => {
+			expect.assertions(1);
+			expect(Money.fromCents('3', 'usd').multiply('1.263', RoundingMode.Ceil).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+		});
+	});
+
+	describe('.toBigNumber', () => {
+		it('doesnt round to nearest integer', () => {
+			expect.assertions(1);
+			expect(cents1000.toBigNumber().plus('1.2').toString()).toStrictEqual('1001.2');
+		});
+	});
+
 });

--- a/app/javascript/components/intl/HoudiniIntl.tsx
+++ b/app/javascript/components/intl/HoudiniIntl.tsx
@@ -16,8 +16,8 @@ function rawFormatMoney(intl:IntlShapeParent, amount:Money, opts?:FormatMoneyOpt
 		currency: amount.currency.toUpperCase(),
 	});
 
-	const adjustedAmount = amount.amount / Math.pow(10, formatter.resolvedOptions().maximumFractionDigits);
-	return formatter.format(adjustedAmount);
+	const adjustedAmount = amount.toBigNumber().dividedBy(Math.pow(10, formatter.resolvedOptions().maximumFractionDigits));
+	return formatter.format(adjustedAmount.toNumber());
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "@material-ui/icons": "^4.9.1",
     "@rails/activestorage": "^6.0.2-2",
     "attr-binder": "0.3.1",
+    "bignumber.js": "^9.0.0",
     "chart.js": "2.1.4",
     "color": "^3.1.0",
     "commons.css": "0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4850,6 +4850,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
+  integrity sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==
+
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"


### PR DESCRIPTION
`Money` was previously using number for calculations. This was a problem when you multiply by a fractional amount. This change makes `Money` use `BigNumber` internally so calculations are always accurate.