### PR TITLE
Exclude more files from Jest. Also fix a few imports on event definitions

### DIFF
--- a/docs/event_definitions/Nonprofit/Campaign/CampaignGift.ts
+++ b/docs/event_definitions/Nonprofit/Campaign/CampaignGift.ts
@@ -1,5 +1,5 @@
 // License: LGPL-3.0-or-later
-import type { HouID, HoudiniObject, HoudiniEvent, Amount, IdType} from '../../common';
+import type { HouID, HoudiniObject, HoudiniEvent, Amount, IDType} from '../../common';
 import type Nonprofit from '..';
 import type Campaign from '.';
 import type { CampaignGiftPurchase, CampaignGiftOption } from '.';
@@ -16,14 +16,14 @@ export interface TransactionAddress {
 export interface CampaignGift extends HoudiniObject<HouID> {
   address?: TransactionAddress;
   amount: Amount;
-  campaign: IdType | Campaign;
-  campaign_gift_option: IdType | CampaignGiftOption;
-  campaign_gift_purchase: IdType | CampaignGiftPurchase;
+  campaign: IDType | Campaign;
+  campaign_gift_option: IDType | CampaignGiftOption;
+  campaign_gift_purchase: IDType | CampaignGiftPurchase;
   deleted: boolean;
-  event: IdType | Event;
-  nonprofit: IdType | Nonprofit;
+  event: IDType | Event;
+  nonprofit: IDType | Nonprofit;
   object: 'campaign_gift';
-  supporter: IdType | Supporter;
+  supporter: IDType | Supporter;
 }
 
 export type CampaignGiftCreated = HoudiniEvent<'campaign_gift.created', CampaignGift>;

--- a/docs/event_definitions/Nonprofit/Campaign/CampaignGiftPurchase.ts
+++ b/docs/event_definitions/Nonprofit/Campaign/CampaignGiftPurchase.ts
@@ -1,5 +1,5 @@
 // License: LGPL-3.0-or-later
-import type { HouID, HoudiniObject, HoudiniEvent, Amount, IdType} from '../../common';
+import type { HouID, HoudiniObject, HoudiniEvent, Amount, IDType} from '../../common';
 import type Nonprofit from '..';
 import type Campaign from '.';
 import type { CampaignGift } from '.';
@@ -9,11 +9,11 @@ import { Transaction } from '../Supporter';
 
 export interface CampaignGiftPurchase extends HoudiniObject<HouID> {
   amount: Amount;
-  campaign: IdType | Campaign;
+  campaign: IDType | Campaign;
   campaign_gifts: HouID[] | CampaignGift[];
-  nonprofit: IdType | Nonprofit;
+  nonprofit: IDType | Nonprofit;
   object: 'campaign_gift_purchase';
-  supporter: IdType | Supporter;
+  supporter: IDType | Supporter;
   transaction: HouID | Transaction;
 }
 

--- a/docs/event_definitions/User.ts
+++ b/docs/event_definitions/User.ts
@@ -1,5 +1,5 @@
 // License: LGPL-3.0-or-later
-import { IDType, HoudiniObject } from './common';
+import { HoudiniObject } from './common';
 
 export interface User extends HoudiniObject {
   object: 'user';

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,6 +21,12 @@ module.exports =  {
 		"/node_modules/",
 		"/config/webpack/test.js",
 		"/vendor/",
+		"/tmp/",
+		"/public/",
+		"/storage/",
+		"/log/",
+		"/coverage/",
+		"/.vscode/",
 	],
 	"testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
 	"moduleFileExtensions": [


### PR DESCRIPTION
Jest tries to watch too many things if you have lots of files in the storage directory. This change excludes some directories like `storage` where we know a test will never be.