### PR TITLE
Remove unused attributes from Supporter

### DIFF
--- a/db/migrate/20210223202458_remove_old_unused_supporter_attributes.rb
+++ b/db/migrate/20210223202458_remove_old_unused_supporter_attributes.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+class RemoveOldUnusedSupporterAttributes < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :supporters, :fields, :text
+    remove_column :supporters, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_18_191002) do
+ActiveRecord::Schema.define(version: 2021_02_23_202458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -783,8 +783,6 @@ ActiveRecord::Schema.define(version: 2021_02_18_191002) do
   create_table "supporters", id: :serial, force: :cascade do |t|
     t.integer "profile_id"
     t.integer "nonprofit_id"
-    t.text "fields"
-    t.text "notes"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", limit: 255


### PR DESCRIPTION
Supporter has both a fields and notes attribute. I think these were legacy and they're not used in the code currently so they'll be removed.
