### PR TITLE
Migrate to use Money as the base of all monetary values in the event work

### DIFF
--- a/app/models/campaign_gift_option.rb
+++ b/app/models/campaign_gift_option.rb
@@ -51,7 +51,7 @@ class CampaignGiftOption < ApplicationRecord
     if amount_one_time
       gift_option_amount.push({
         amount:{
-          value_in_cents: amount_one_time, 
+          amount: amount_one_time, 
           currency: campaign.nonprofit.currency
         }
       })
@@ -60,7 +60,7 @@ class CampaignGiftOption < ApplicationRecord
     if amount_recurring
       gift_option_amount.push({
         amount:{
-          value_in_cents: amount_recurring, 
+          amount: amount_recurring, 
           currency: campaign.nonprofit.currency
         },
         recurrence: {
@@ -83,7 +83,7 @@ class CampaignGiftOption < ApplicationRecord
       json.gift_option_amount gift_option_amount do |desc|
         json.amount do 
           json.currency desc[:amount][:currency]
-          json.value_in_cents desc[:amount][:value_in_cents]
+          json.amount desc[:amount][:amount]
         end
         json.recurrence do 
           json.interval desc[:recurrence][:interval]

--- a/app/models/campaign_gift_purchase.rb
+++ b/app/models/campaign_gift_purchase.rb
@@ -33,7 +33,7 @@ class CampaignGiftPurchase < ApplicationRecord
       json.(self, :deleted)
       
       json.amount do
-        json.value_in_cents amount
+        json.amount amount
         json.currency nonprofit.currency
       end
 

--- a/app/models/modern_campaign_gift.rb
+++ b/app/models/modern_campaign_gift.rb
@@ -43,7 +43,7 @@ class ModernCampaignGift < ApplicationRecord
 			json.(self, :deleted)
 			json.object 'campaign_gift'
 			json.amount do
-        json.value_in_cents amount
+        json.amount amount
         json.currency nonprofit.currency
       end
 		end

--- a/app/models/modern_donation.rb
+++ b/app/models/modern_donation.rb
@@ -29,7 +29,7 @@ class ModernDonation < ApplicationRecord
 			# TODO the line above is a hacky solution
 
       json.amount do
-        json.value_in_cents amount
+        json.amount amount
         json.currency nonprofit.currency
       end
     end

--- a/app/models/ticket_level.rb
+++ b/app/models/ticket_level.rb
@@ -62,7 +62,7 @@ class TicketLevel < ApplicationRecord
     init_builder(*expand) do |json|
       json.(self, :name, :deleted, :order, :limit, :description)
       json.amount do 
-        json.value_in_cents amount || 0
+        json.amount amount || 0
         json.currency event.nonprofit.currency
       end
       json.available_to admin_only ? 'admins' : 'everyone'

--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -28,7 +28,7 @@ class TicketPurchase < ApplicationRecord
       end if original_discount
 
       json.amount do
-        json.value_in_cents amount
+        json.amount amount
         json.currency nonprofit.currency
       end
 

--- a/app/models/ticket_to_legacy_ticket.rb
+++ b/app/models/ticket_to_legacy_ticket.rb
@@ -33,7 +33,7 @@ class TicketToLegacyTicket < ApplicationRecord
       json.object "ticket"
 
       json.amount do
-        json.value_in_cents amount
+        json.amount amount
         json.currency nonprofit.currency
       end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -25,7 +25,7 @@ class Transaction < ApplicationRecord
 	def to_builder(*expand)
 		init_builder(*expand) do |json|
 			json.amount do 
-        json.value_in_cents amount || 0
+        json.amount amount || 0
         json.currency nonprofit.currency
       end
 		end

--- a/docs/event_definitions/common.ts
+++ b/docs/event_definitions/common.ts
@@ -1,4 +1,5 @@
 // License: LGPL-3.0-or-later
+import { MoneyAsJson } from "../../app/javascript/common/money";
 
 /**
  * the main identifier for HoudiniObjects which is unique between all other HoudiniObjects with the same object value.
@@ -15,7 +16,7 @@ export type HouID = string;
  * Describes a monetary value in the minimum unit for this current. Corresponds to Money class in
  * Ruby and Typescript
  */
-export type Amount = { currency: string, value_in_cents: string };
+export type Amount = MoneyAsJson;
 
 /**
  * A more flexible version of Amount. In cases where we can assume what the currency is,

--- a/spec/models/campaign_gift_option_spec.rb
+++ b/spec/models/campaign_gift_option_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'value_in_cents'=> amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'amount'=> amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -98,9 +98,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -161,7 +161,7 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'description' => description,
             'gift_option_amount' => [
               {
-                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -205,7 +205,7 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
             ],
             'id'=> kind_of(Numeric),
             'hide_contributions' => false,
@@ -252,9 +252,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => true,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -299,9 +299,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => true,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'value_in_cents' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'value_in_cents' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],

--- a/spec/models/campaign_gift_purchase_spec.rb
+++ b/spec/models/campaign_gift_purchase_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'deleted' => false,
       'gift_option_amount' => [{
         'amount' => {
-          'value_in_cents' => 400,
+          'amount' => 400,
           'currency' => 'usd'
         },
       }],
@@ -66,7 +66,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'id' => match_houid('trx'),
       'object' => 'transaction',
       'amount' => {
-        'value_in_cents' => trx.amount,
+        'amount' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => kind_of(Numeric),
@@ -81,7 +81,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'object' => 'campaign_gift_purchase',
       'campaign_gifts' => [modern_campaign_gift_builder],
       'amount' => {
-        'value_in_cents' => trx.amount,
+        'amount' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => supporter_builder_expanded,
@@ -94,7 +94,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
   let(:modern_campaign_gift_builder) {
     {
       'amount' => {
-        'value_in_cents' => 400,
+        'amount' => 400,
         'currency' => 'usd'
       },
       'campaign' => kind_of(Numeric),
@@ -125,7 +125,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
           'object' => 'campaign_gift_purchase',
           'campaign_gifts' => [modern_campaign_gift_builder],
           'amount' => {
-            'value_in_cents' => trx.amount,
+            'amount' => trx.amount,
             'currency' => 'usd'
           },
           'supporter' => supporter_builder_expanded,
@@ -152,7 +152,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
           'object' => 'campaign_gift_purchase',
           'campaign_gifts' => [modern_campaign_gift_builder],
           'amount' => {
-            'value_in_cents' => trx.amount,
+            'amount' => trx.amount,
             'currency' => 'usd'
           },
           'supporter' => supporter_builder_expanded,
@@ -179,7 +179,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
           'object' => 'campaign_gift_purchase',
           'campaign_gifts' => [modern_campaign_gift_builder],
           'amount' => {
-            'value_in_cents' => trx.amount,
+            'amount' => trx.amount,
             'currency' => 'usd'
           },
           'supporter' => supporter_builder_expanded,

--- a/spec/models/event_discount_spec.rb
+++ b/spec/models/event_discount_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe EventDiscount, type: :model do
                 'object' => 'ticket_level',
                 'description' => ticket_level.description,
                 'amount' => {
-                  'value_in_cents' => ticket_level.amount,
+                  'amount' => ticket_level.amount,
                   'currency' => 'usd'
                 },
                 'available_to' => 'everyone',
@@ -150,7 +150,7 @@ RSpec.describe EventDiscount, type: :model do
                 'object' => 'ticket_level',
                 'description' => ticket_level.description,
                 'amount' => {
-                  'value_in_cents' => ticket_level.amount,
+                  'amount' => ticket_level.amount,
                   'currency' => 'usd'
                 },
                 'available_to' => 'everyone',
@@ -213,7 +213,7 @@ RSpec.describe EventDiscount, type: :model do
                 'object' => 'ticket_level',
                 'description' => ticket_level.description,
                 'amount' => {
-                  'value_in_cents' => ticket_level.amount,
+                  'amount' => ticket_level.amount,
                   'currency' => 'usd'
                 },
                 'available_to' => 'everyone',

--- a/spec/models/modern_campaign_gift_spec.rb
+++ b/spec/models/modern_campaign_gift_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'deleted' => false,
       'gift_option_amount' => [{
         'amount' => {
-          'value_in_cents' => 400,
+          'amount' => 400,
           'currency' => 'usd'
         },
       }],
@@ -66,7 +66,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'id' => match_houid('trx'),
       'object' => 'transaction',
       'amount' => {
-        'value_in_cents' => trx.amount,
+        'amount' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => kind_of(Numeric),
@@ -81,7 +81,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'object' => 'campaign_gift_purchase',
       'campaign_gifts' => [match_houid('cgift')],
       'amount' => {
-        'value_in_cents' => trx.amount,
+        'amount' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => kind_of(Numeric),
@@ -103,7 +103,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'data' => {
         'object' => {
           'amount' => {
-            'value_in_cents' => 400,
+            'amount' => 400,
             'currency' => 'usd'
           },
           'campaign' => campaign_builder_expanded,
@@ -131,7 +131,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'data' => {
         'object' => {
           'amount' => {
-            'value_in_cents' => 400,
+            'amount' => 400,
             'currency' => 'usd'
           },
           'campaign' => campaign_builder_expanded,
@@ -159,7 +159,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'data' => {
         'object' => {
           'amount' => {
-            'value_in_cents' => 400,
+            'amount' => 400,
             'currency' => 'usd'
           },
           'campaign' => campaign_builder_expanded,

--- a/spec/models/modern_donation_spec.rb
+++ b/spec/models/modern_donation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ModernDonation, type: :model do
         'object' => 'donation',
         'nonprofit' => nonprofit.id,
         'supporter' => supporter.id,
-        'amount' => {'currency' => 'usd', 'value_in_cents' => 1200},
+        'amount' => {'currency' => 'usd', 'amount' => 1200},
         'transaction' => trx.id,
         'designation' => nil
       }

--- a/spec/models/ticket_level_spec.rb
+++ b/spec/models/ticket_level_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.created',
           'data' => {
             'object' => {
-              'amount' => {'value_in_cents' => 0, 'currency' => 'usd'},
+              'amount' => {'amount' => 0, 'currency' => 'usd'},
               'available_to' => 'admins',
               'deleted' => false,
               'description' => description,
@@ -90,7 +90,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.created',
           'data' => {
             'object' => {
-              'amount' => {'value_in_cents' => non_free_amount, 'currency' => 'usd'},
+              'amount' => {'amount' => non_free_amount, 'currency' => 'usd'},
               'available_to' => 'everyone',
               'deleted' => false,
               'description' => description,
@@ -136,7 +136,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.updated',
           'data' => {
             'object' => {
-              'amount' => {'value_in_cents' => 5000, 'currency' => 'usd'},
+              'amount' => {'amount' => 5000, 'currency' => 'usd'},
               'available_to' => 'admins',
               'deleted' => false,
               'description' => description,
@@ -182,7 +182,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.updated',
           'data' => {
             'object' => {
-              'amount' => {'value_in_cents' => 0, 'currency' => 'usd'},
+              'amount' => {'amount' => 0, 'currency' => 'usd'},
               'available_to' => 'everyone',
               'deleted' => false,
               'description' => description,
@@ -231,7 +231,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.deleted',
           'data' => {
             'object' => {
-              'amount' => {'value_in_cents' => 0, 'currency' => 'usd'},
+              'amount' => {'amount' => 0, 'currency' => 'usd'},
               'available_to' => 'admins',
               'deleted' => true,
               'description' => description,
@@ -273,7 +273,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.deleted',
           'data' => {
             'object' => {
-              'amount' => {'value_in_cents' => non_free_amount, 'currency' => 'usd'},
+              'amount' => {'amount' => non_free_amount, 'currency' => 'usd'},
               'available_to' => 'everyone',
               'deleted' => true,
               'description' => description,

--- a/spec/models/ticket_purchase_spec.rb
+++ b/spec/models/ticket_purchase_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe TicketPurchase, type: :model do
 					'event' => event.id,
 					'supporter' => supporter.id,
 					'tickets' => match_array(ticket_purchase.ticket_to_legacy_tickets.pluck(:id)),
-					'amount' => {'currency' => 'usd', 'value_in_cents' => 1200},
+					'amount' => {'currency' => 'usd', 'amount' => 1200},
 					'original_discount' => { 'percent' => 0},
 					'event_discount' => nil,
 					'transaction' => trx.id

--- a/spec/models/ticket_to_legacy_ticket_spec.rb
+++ b/spec/models/ticket_to_legacy_ticket_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe TicketToLegacyTicket, type: :model do
     let(:free_ticket_default) {
       ticket_default.merge({
         'ticket_level' => legacy_free_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'value_in_cents' => 0}
+        'amount' => {'currency' => 'usd', 'amount' => 0}
       })
     }
 
     let(:nonfree_ticket_default) {
       ticket_default.merge({
         'ticket_level' =>  legacy_nonfree_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'value_in_cents' => legacy_nonfree_tickets.ticket_level.amount}
+        'amount' => {'currency' => 'usd', 'amount' => legacy_nonfree_tickets.ticket_level.amount}
       })
     }
 
@@ -143,14 +143,14 @@ RSpec.describe TicketToLegacyTicket, type: :model do
     let(:free_ticket_default) {
       ticket_default.merge({
         'ticket_level' => legacy_free_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'value_in_cents' => 0}
+        'amount' => {'currency' => 'usd', 'amount' => 0}
       })
     }
 
     let(:nonfree_ticket_default) {
       ticket_default.merge({
         'ticket_level' =>  legacy_nonfree_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'value_in_cents' => 320 }
+        'amount' => {'currency' => 'usd', 'amount' => 320 }
       })
     }
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Transaction, type: :model do
         'supporter' => supporter.id,
         'object' => 'transaction',
         'amount' => {
-          'value_in_cents' => 1000,
+          'amount' => 1000,
           'currency' => 'usd'
         }
       })


### PR DESCRIPTION
Previously we weren't using the same fields as Money for monetary values in events. Now we do.﻿
