### PR TITLE
Changed money to use "cents" so it's consistent with ruby-money Money object

### DIFF
--- a/app/javascript/common/money.spec.ts
+++ b/app/javascript/common/money.spec.ts
@@ -1,6 +1,6 @@
 // License: LGPL-3.0-or-later
 import BigNumber from 'bignumber.js';
-import { Money, Operand, RoundingMode } from './money';
+import { Money, MoneyAsJson, Operand, RoundingMode } from './money';
 
 describe("Money", () => {
 	describe('Money.fromCents', () => {
@@ -15,7 +15,7 @@ describe("Money", () => {
 		});
 		it('succeeds from a json', () => {
 			expect.hasAssertions();
-			const old = { amount: 333, currency: 'eur' };
+			const old:MoneyAsJson = { cents: 333, currency: 'eur' };
 
 			const result = Money.fromCents(old);
 			// eslint-disable-next-line jest/prefer-strict-equal
@@ -28,7 +28,7 @@ describe("Money", () => {
 			expect.hasAssertions();
 			const old = Money.fromCents(333, 'eur');
 
-			const result = Money.fromCents({ amount: '333', currency: 'eur' });
+			const result = Money.fromCents({ cents: '333', currency: 'eur' });
 			// eslint-disable-next-line jest/prefer-strict-equal
 			expect(result).toEqual(old);
 
@@ -39,7 +39,7 @@ describe("Money", () => {
 			expect.hasAssertions();
 			const result = Money.fromCents(333, 'eur');
 			// eslint-disable-next-line jest/prefer-strict-equal
-			expect(result).toEqual({ amount: 333, currency: 'eur' });
+			expect(result).toEqual({ cents: 333, currency: 'eur' });
 
 			expect(result).toBeInstanceOf(Money);
 		});
@@ -48,7 +48,7 @@ describe("Money", () => {
 			expect.hasAssertions();
 			const result = Money.fromCents(new BigNumber(333), 'eur');
 			// eslint-disable-next-line jest/prefer-strict-equal
-			expect(result).toEqual({ amount: 333, currency: 'eur' });
+			expect(result).toEqual({ cents: 333, currency: 'eur' });
 		});
 
 		it('rejects if string is not an integer', () => {
@@ -170,7 +170,7 @@ describe("Money", () => {
 	describe('.divide', () => {
 		it('divides 36 into 9', () => {
 			expect.assertions(1);
-			expect(Money.fromCents(36, 'usd').divide(9).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents(36, 'usd').divide(9).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 		});
 
 		it('throws if the currencies do not match', () => {
@@ -180,27 +180,27 @@ describe("Money", () => {
 
 		it('defaults to rounding to HalfUp', () => {
 			expect.assertions(3);
-			expect(Money.fromCents(40, 'usd').divide(Money.fromCents(9, 'usd')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents(40, 'usd').divide(Money.fromCents(9, 'usd')).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 
-			expect(Money.fromCents(41, 'usd').divide(Money.fromCents(9, 'usd')).toJSON()).toStrictEqual({amount: 5, currency: 'usd'});
+			expect(Money.fromCents(41, 'usd').divide(Money.fromCents(9, 'usd')).toJSON()).toStrictEqual({cents: 5, currency: 'usd'});
 
-			expect(Money.fromCents(7, 'usd').divide(Money.fromCents(2, 'usd')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents(7, 'usd').divide(Money.fromCents(2, 'usd')).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 		});
 		it('rounds to floor if requested', () => {
 			expect.assertions(1);
-			expect(Money.fromCents(41, 'usd').divide(Money.fromCents(9, 'usd'), RoundingMode.Floor).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents(41, 'usd').divide(Money.fromCents(9, 'usd'), RoundingMode.Floor).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 		});
 
 		it('rounds to ceil if requested', () => {
 			expect.assertions(1);
-			expect(Money.fromCents(40, 'usd').divide(Money.fromCents(9, 'usd'), RoundingMode.Ceil).toJSON()).toStrictEqual({amount: 5, currency: 'usd'});
+			expect(Money.fromCents(40, 'usd').divide(Money.fromCents(9, 'usd'), RoundingMode.Ceil).toJSON()).toStrictEqual({cents: 5, currency: 'usd'});
 		});
 	});
 
 	describe('.multiply', () => {
 		it('multiply 9 x 4', () => {
 			expect.assertions(1);
-			expect(Money.fromCents(9, 'usd').multiply(4).toJSON()).toStrictEqual({amount: 36, currency: 'usd'});
+			expect(Money.fromCents(9, 'usd').multiply(4).toJSON()).toStrictEqual({cents: 36, currency: 'usd'});
 		});
 
 		it('throws if the currencies do not match', () => {
@@ -210,22 +210,22 @@ describe("Money", () => {
 
 		it('handles multiplying by a decimal properly', () => {
 			expect.assertions(1);
-			expect(Money.fromCents('3', 'usd').multiply(new BigNumber('1.263')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents('3', 'usd').multiply(new BigNumber('1.263')).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 		});
 
 		it('defaults to rounding to HalfUp', () => {
 			expect.assertions(1);
-			expect(Money.fromCents(7, 'usd').multiply(new BigNumber('.5')).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents(7, 'usd').multiply(new BigNumber('.5')).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 		});
 
 		it('rounds to floor if requested', () => {
 			expect.assertions(1);
-			expect(Money.fromCents('3', 'usd').multiply('1.263', RoundingMode.Floor).toJSON()).toStrictEqual({amount: 3, currency: 'usd'});
+			expect(Money.fromCents('3', 'usd').multiply('1.263', RoundingMode.Floor).toJSON()).toStrictEqual({cents: 3, currency: 'usd'});
 		});
 
 		it('rounds to ceil if requested', () => {
 			expect.assertions(1);
-			expect(Money.fromCents('3', 'usd').multiply('1.263', RoundingMode.Ceil).toJSON()).toStrictEqual({amount: 4, currency: 'usd'});
+			expect(Money.fromCents('3', 'usd').multiply('1.263', RoundingMode.Ceil).toJSON()).toStrictEqual({cents: 4, currency: 'usd'});
 		});
 	});
 

--- a/app/javascript/common/money.ts
+++ b/app/javascript/common/money.ts
@@ -31,7 +31,7 @@ function coerceToBigNumber(operand:unknown, mustBeInteger=false): BigNumber {
 	}
 	else if (typeof operand === 'object') {
 		//it's MoneyAsJson
-		bigNumber = new BigNumber((operand as MoneyAsJson).amount);
+		bigNumber = new BigNumber((operand as MoneyAsJson).cents);
 	}
 	else if(typeof operand === 'string') {
 		bigNumberDebug(() => {
@@ -54,8 +54,8 @@ function coerceToBigNumber(operand:unknown, mustBeInteger=false): BigNumber {
 	return bigNumber;
 }
 
-export type MoneyAsJson = { amount: number, currency: string };
-type StringyMoneyAsJson = {amount:string, currency: string};
+export type MoneyAsJson = { cents: number, currency: string };
+type StringyMoneyAsJson = { cents:string, currency: string };
 
 export type Operand = number | Money | BigNumber | string;
 
@@ -115,7 +115,7 @@ export class Money {
 	 */
 	readonly currency: string;
 
-	protected constructor(readonly amount: number, currency: string) {
+	protected constructor(readonly cents: number, currency: string) {
 		this.currency = currency.toLowerCase();
 		const methodsToBind = [this.equals, this.add, this.subtract, this.multiply, this.divide,
 			this.compare, this.greaterThan, this.greaterThanOrEqual, this.lessThan,
@@ -326,7 +326,7 @@ export class Money {
 	 * Get the amount of the Money instance as a `BigNumber`.
 	 */
 	toBigNumber() : BigNumber {
-		return new BigNumber(this.amount);
+		return new BigNumber(this.cents);
 	}
 
 	/**
@@ -336,7 +336,7 @@ export class Money {
 	*/
 	toJSON(): MoneyAsJson {
 		return {
-			amount: this.amount,
+			cents: this.cents,
 			currency: this.currency,
 		};
 	}

--- a/app/javascript/components/formik/MoneyTextField.spec.tsx
+++ b/app/javascript/components/formik/MoneyTextField.spec.tsx
@@ -20,7 +20,7 @@ function FormikInner(props: { onChange:(args:{value:Money})=> void}) {
 		onChange({value});
 	}, [value, onChange]);
 
-	return <><div><span aria-label="amount">{value.amount}</span><span aria-label="currency">{value.currency}</span></div>
+	return <><div><span aria-label="amount">{value.cents}</span><span aria-label="currency">{value.currency}</span></div>
 		<Field component={MoneyTextField} name="value" aria-label="field"/></>;
 }
 
@@ -42,7 +42,7 @@ FormikHandler.defaultProps = {
 describe('MoneyTextField', () => {
 	it('displays the $8.00 when Money of {800, usd} is passed in', async () => {
 		expect.hasAssertions();
-		const result = render(<FormikHandler value={Money.fromCents({ amount: 800, currency: 'usd' })}  />);
+		const result = render(<FormikHandler value={Money.fromCents({ cents: 800, currency: 'usd' })}  />);
 		const field = result.container.querySelector("input[name=value]");
 		expect(field).toHaveValue("$8.00");
 		const amount = await result.findByLabelText('amount');
@@ -54,7 +54,7 @@ describe('MoneyTextField', () => {
 
 	it('displays the 8.00 € when Money of {800, eur} is passed in', async () => {
 		expect.hasAssertions();
-		const result = render(<FormikHandler value={Money.fromCents({ amount: 800, currency: 'eur' })} />);
+		const result = render(<FormikHandler value={Money.fromCents({ cents: 800, currency: 'eur' })} />);
 		const field = result.container.querySelector("input[name=value]");
 		expect(field).toHaveValue("€8.00");
 		const amount = await result.findByLabelText('amount');
@@ -66,7 +66,7 @@ describe('MoneyTextField', () => {
 
 	it('displays the ¥800 when Money of {800, jpy} is passed in', async () => {
 		expect.hasAssertions();
-		const result = render(<FormikHandler value={Money.fromCents({ amount: 800, currency: 'jpy' })} />);
+		const result = render(<FormikHandler value={Money.fromCents({ cents: 800, currency: 'jpy' })} />);
 		const field = result.container.querySelector("input[name=value]");
 		expect(field).toHaveValue("¥800");
 		const amount = await result.findByLabelText('amount');
@@ -79,7 +79,7 @@ describe('MoneyTextField', () => {
 
 	it('displays the $8.00 when Money of {100, usd} is passed in and then the amount changes to 8.00', async () => {
 		expect.hasAssertions();
-		const result = render(<FormikHandler value={Money.fromCents({ amount: 100, currency: 'usd' })} />);
+		const result = render(<FormikHandler value={Money.fromCents({ cents: 100, currency: 'usd' })} />);
 		const field = result.container.querySelector("input[name=value]");
 		expect(field).toHaveValue("$1.00");
 
@@ -100,7 +100,7 @@ describe('MoneyTextField', () => {
 
 	it('displays the $80.00 when Money of {800, usd} is passed in and then the amount changes to 8.000', async () => {
 		expect.hasAssertions();
-		const result = render(<FormikHandler value={Money.fromCents({ amount: 800, currency: 'usd' })} />);
+		const result = render(<FormikHandler value={Money.fromCents({ cents: 800, currency: 'usd' })} />);
 		const field = result.container.querySelector("input[name=value]");
 		expect(field).toHaveValue("$8.00");
 
@@ -121,7 +121,7 @@ describe('MoneyTextField', () => {
 
 	it('displays the $80.00 when Money of {800, usd} is passed in and then {8000, usd} is passed in', async () => {
 		expect.hasAssertions();
-		const {container, findByLabelText, rerender}  = render(<FormikHandler value={Money.fromCents({ amount:800, currency: 'usd' })} />, );
+		const {container, findByLabelText, rerender}  = render(<FormikHandler value={Money.fromCents({ cents:800, currency: 'usd' })} />, );
 		const field = container.querySelector("input[name=value]");
 		expect(field).toHaveValue("$8.00");
 
@@ -132,7 +132,7 @@ describe('MoneyTextField', () => {
 		expect(currency).toHaveTextContent("usd");
 
 
-		rerender(<FormikHandler value={Money.fromCents({ amount:8000, currency: 'usd' })} />);
+		rerender(<FormikHandler value={Money.fromCents({ cents:8000, currency: 'usd' })} />);
 		expect(amount).toHaveTextContent("8000");
 		expect(currency).toHaveTextContent("usd");
 

--- a/app/javascript/components/formik/MoneyTextField.stories.tsx
+++ b/app/javascript/components/formik/MoneyTextField.stories.tsx
@@ -15,7 +15,7 @@ function FormikInner(props: { onChange:(args:{value:Money})=> void}) {
 		onChange({value});
 	}, [value, onChange]);
 
-	return <><div><span aria-label="amount">{value.amount}</span><span aria-label="currency">{value.currency}</span></div>
+	return <><div><span aria-label="cents">{value.cents}</span><span aria-label="currency">{value.currency}</span></div>
 		<Field component={MoneyTextField} name="value" aria-label="field" /></>;
 }
 

--- a/app/javascript/components/formik/MoneyTextField.tsx
+++ b/app/javascript/components/formik/MoneyTextField.tsx
@@ -31,11 +31,11 @@ export function useSerializeMoney(props:UseSerializeMoneyProps) : ReturnType<typ
 	const intl = useIntl();
 	const {locale} = intl;
 	const {value, ...other} = props;
-	const {amount, currency} = value;
+	const {cents, currency} = value;
 
 	const i18n = useI18nCurrencyInput({...other, locale,
 		currency,
-		value:amount,
+		value:cents,
 	});
 
 

--- a/app/models/campaign_gift_option.rb
+++ b/app/models/campaign_gift_option.rb
@@ -51,7 +51,7 @@ class CampaignGiftOption < ApplicationRecord
     if amount_one_time
       gift_option_amount.push({
         amount:{
-          amount: amount_one_time, 
+          cents: amount_one_time, 
           currency: campaign.nonprofit.currency
         }
       })
@@ -60,7 +60,7 @@ class CampaignGiftOption < ApplicationRecord
     if amount_recurring
       gift_option_amount.push({
         amount:{
-          amount: amount_recurring, 
+          cents: amount_recurring, 
           currency: campaign.nonprofit.currency
         },
         recurrence: {
@@ -83,7 +83,7 @@ class CampaignGiftOption < ApplicationRecord
       json.gift_option_amount gift_option_amount do |desc|
         json.amount do 
           json.currency desc[:amount][:currency]
-          json.amount desc[:amount][:amount]
+          json.cents desc[:amount][:cents]
         end
         json.recurrence do 
           json.interval desc[:recurrence][:interval]

--- a/app/models/campaign_gift_purchase.rb
+++ b/app/models/campaign_gift_purchase.rb
@@ -33,7 +33,7 @@ class CampaignGiftPurchase < ApplicationRecord
       json.(self, :deleted)
       
       json.amount do
-        json.amount amount
+        json.cents amount
         json.currency nonprofit.currency
       end
 

--- a/app/models/modern_campaign_gift.rb
+++ b/app/models/modern_campaign_gift.rb
@@ -43,7 +43,7 @@ class ModernCampaignGift < ApplicationRecord
 			json.(self, :deleted)
 			json.object 'campaign_gift'
 			json.amount do
-        json.amount amount
+        json.cents amount
         json.currency nonprofit.currency
       end
 		end

--- a/app/models/modern_donation.rb
+++ b/app/models/modern_donation.rb
@@ -29,7 +29,7 @@ class ModernDonation < ApplicationRecord
 			# TODO the line above is a hacky solution
 
       json.amount do
-        json.amount amount
+        json.cents amount
         json.currency nonprofit.currency
       end
     end

--- a/app/models/ticket_level.rb
+++ b/app/models/ticket_level.rb
@@ -62,7 +62,7 @@ class TicketLevel < ApplicationRecord
     init_builder(*expand) do |json|
       json.(self, :name, :deleted, :order, :limit, :description)
       json.amount do 
-        json.amount amount || 0
+        json.cents amount || 0
         json.currency event.nonprofit.currency
       end
       json.available_to admin_only ? 'admins' : 'everyone'

--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -28,7 +28,7 @@ class TicketPurchase < ApplicationRecord
       end if original_discount
 
       json.amount do
-        json.amount amount
+        json.cents amount
         json.currency nonprofit.currency
       end
 

--- a/app/models/ticket_to_legacy_ticket.rb
+++ b/app/models/ticket_to_legacy_ticket.rb
@@ -33,7 +33,7 @@ class TicketToLegacyTicket < ApplicationRecord
       json.object "ticket"
 
       json.amount do
-        json.amount amount
+        json.cents amount
         json.currency nonprofit.currency
       end
 

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -25,7 +25,7 @@ class Transaction < ApplicationRecord
 	def to_builder(*expand)
 		init_builder(*expand) do |json|
 			json.amount do 
-        json.amount amount || 0
+        json.cents amount || 0
         json.currency nonprofit.currency
       end
 		end

--- a/docs/event_definitions/common.ts
+++ b/docs/event_definitions/common.ts
@@ -1,5 +1,4 @@
 // License: LGPL-3.0-or-later
-import { MoneyAsJson } from "../../app/javascript/common/money";
 
 /**
  * the main identifier for HoudiniObjects which is unique between all other HoudiniObjects with the same object value.
@@ -16,7 +15,7 @@ export type HouID = string;
  * Describes a monetary value in the minimum unit for this current. Corresponds to Money class in
  * Ruby and Typescript
  */
-export type Amount = MoneyAsJson;
+export type Amount = { cents: string, currency: string };
 
 /**
  * A more flexible version of Amount. In cases where we can assume what the currency is,

--- a/spec/models/campaign_gift_option_spec.rb
+++ b/spec/models/campaign_gift_option_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'amount'=> amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'cents'=> amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'cents' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -98,9 +98,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'cents' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'cents' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -161,7 +161,7 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'description' => description,
             'gift_option_amount' => [
               {
-                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'cents' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -205,7 +205,7 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => false,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'cents' => amount_one_time, 'currency' => nonprofit.currency}},
             ],
             'id'=> kind_of(Numeric),
             'hide_contributions' => false,
@@ -252,9 +252,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => true,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'cents' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'cents' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],
@@ -299,9 +299,9 @@ RSpec.describe CampaignGiftOption, 'type' => :model do
             'deleted' => true,
             'description' => description,
             'gift_option_amount' => [
-              {'amount' => {'amount' => amount_one_time, 'currency' => nonprofit.currency}},
+              {'amount' => {'cents' => amount_one_time, 'currency' => nonprofit.currency}},
               {
-                'amount' => {'amount' => amount_recurring, 'currency' => nonprofit.currency},
+                'amount' => {'cents' => amount_recurring, 'currency' => nonprofit.currency},
                 'recurrence' => { 'interval' => 1, 'type' => 'monthly'}
               }
             ],

--- a/spec/models/campaign_gift_purchase_spec.rb
+++ b/spec/models/campaign_gift_purchase_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'deleted' => false,
       'gift_option_amount' => [{
         'amount' => {
-          'amount' => 400,
+          'cents' => 400,
           'currency' => 'usd'
         },
       }],
@@ -66,7 +66,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'id' => match_houid('trx'),
       'object' => 'transaction',
       'amount' => {
-        'amount' => trx.amount,
+        'cents' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => kind_of(Numeric),
@@ -81,7 +81,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'object' => 'campaign_gift_purchase',
       'campaign_gifts' => [modern_campaign_gift_builder],
       'amount' => {
-        'amount' => trx.amount,
+        'cents' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => supporter_builder_expanded,
@@ -94,7 +94,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
   let(:modern_campaign_gift_builder) {
     {
       'amount' => {
-        'amount' => 400,
+        'cents' => 400,
         'currency' => 'usd'
       },
       'campaign' => kind_of(Numeric),
@@ -125,7 +125,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
           'object' => 'campaign_gift_purchase',
           'campaign_gifts' => [modern_campaign_gift_builder],
           'amount' => {
-            'amount' => trx.amount,
+            'cents' => trx.amount,
             'currency' => 'usd'
           },
           'supporter' => supporter_builder_expanded,
@@ -152,7 +152,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
           'object' => 'campaign_gift_purchase',
           'campaign_gifts' => [modern_campaign_gift_builder],
           'amount' => {
-            'amount' => trx.amount,
+            'cents' => trx.amount,
             'currency' => 'usd'
           },
           'supporter' => supporter_builder_expanded,
@@ -179,7 +179,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
           'object' => 'campaign_gift_purchase',
           'campaign_gifts' => [modern_campaign_gift_builder],
           'amount' => {
-            'amount' => trx.amount,
+            'cents' => trx.amount,
             'currency' => 'usd'
           },
           'supporter' => supporter_builder_expanded,

--- a/spec/models/event_discount_spec.rb
+++ b/spec/models/event_discount_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe EventDiscount, type: :model do
                 'object' => 'ticket_level',
                 'description' => ticket_level.description,
                 'amount' => {
-                  'amount' => ticket_level.amount,
+                  'cents' => ticket_level.amount,
                   'currency' => 'usd'
                 },
                 'available_to' => 'everyone',
@@ -150,7 +150,7 @@ RSpec.describe EventDiscount, type: :model do
                 'object' => 'ticket_level',
                 'description' => ticket_level.description,
                 'amount' => {
-                  'amount' => ticket_level.amount,
+                  'cents' => ticket_level.amount,
                   'currency' => 'usd'
                 },
                 'available_to' => 'everyone',
@@ -213,7 +213,7 @@ RSpec.describe EventDiscount, type: :model do
                 'object' => 'ticket_level',
                 'description' => ticket_level.description,
                 'amount' => {
-                  'amount' => ticket_level.amount,
+                  'cents' => ticket_level.amount,
                   'currency' => 'usd'
                 },
                 'available_to' => 'everyone',

--- a/spec/models/modern_campaign_gift_spec.rb
+++ b/spec/models/modern_campaign_gift_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'deleted' => false,
       'gift_option_amount' => [{
         'amount' => {
-          'amount' => 400,
+          'cents' => 400,
           'currency' => 'usd'
         },
       }],
@@ -66,7 +66,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'id' => match_houid('trx'),
       'object' => 'transaction',
       'amount' => {
-        'amount' => trx.amount,
+        'cents' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => kind_of(Numeric),
@@ -81,7 +81,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'object' => 'campaign_gift_purchase',
       'campaign_gifts' => [match_houid('cgift')],
       'amount' => {
-        'amount' => trx.amount,
+        'cents' => trx.amount,
         'currency' => 'usd'
       },
       'supporter' => kind_of(Numeric),
@@ -103,7 +103,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'data' => {
         'object' => {
           'amount' => {
-            'amount' => 400,
+            'cents' => 400,
             'currency' => 'usd'
           },
           'campaign' => campaign_builder_expanded,
@@ -131,7 +131,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'data' => {
         'object' => {
           'amount' => {
-            'amount' => 400,
+            'cents' => 400,
             'currency' => 'usd'
           },
           'campaign' => campaign_builder_expanded,
@@ -159,7 +159,7 @@ RSpec.describe ModernCampaignGift, type: :model do
       'data' => {
         'object' => {
           'amount' => {
-            'amount' => 400,
+            'cents' => 400,
             'currency' => 'usd'
           },
           'campaign' => campaign_builder_expanded,

--- a/spec/models/modern_donation_spec.rb
+++ b/spec/models/modern_donation_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ModernDonation, type: :model do
         'object' => 'donation',
         'nonprofit' => nonprofit.id,
         'supporter' => supporter.id,
-        'amount' => {'currency' => 'usd', 'amount' => 1200},
+        'amount' => {'currency' => 'usd', 'cents' => 1200},
         'transaction' => trx.id,
         'designation' => nil
       }

--- a/spec/models/ticket_level_spec.rb
+++ b/spec/models/ticket_level_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.created',
           'data' => {
             'object' => {
-              'amount' => {'amount' => 0, 'currency' => 'usd'},
+              'amount' => {'cents' => 0, 'currency' => 'usd'},
               'available_to' => 'admins',
               'deleted' => false,
               'description' => description,
@@ -90,7 +90,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.created',
           'data' => {
             'object' => {
-              'amount' => {'amount' => non_free_amount, 'currency' => 'usd'},
+              'amount' => {'cents' => non_free_amount, 'currency' => 'usd'},
               'available_to' => 'everyone',
               'deleted' => false,
               'description' => description,
@@ -136,7 +136,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.updated',
           'data' => {
             'object' => {
-              'amount' => {'amount' => 5000, 'currency' => 'usd'},
+              'amount' => {'cents' => 5000, 'currency' => 'usd'},
               'available_to' => 'admins',
               'deleted' => false,
               'description' => description,
@@ -182,7 +182,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.updated',
           'data' => {
             'object' => {
-              'amount' => {'amount' => 0, 'currency' => 'usd'},
+              'amount' => {'cents' => 0, 'currency' => 'usd'},
               'available_to' => 'everyone',
               'deleted' => false,
               'description' => description,
@@ -231,7 +231,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.deleted',
           'data' => {
             'object' => {
-              'amount' => {'amount' => 0, 'currency' => 'usd'},
+              'amount' => {'cents' => 0, 'currency' => 'usd'},
               'available_to' => 'admins',
               'deleted' => true,
               'description' => description,
@@ -273,7 +273,7 @@ RSpec.describe TicketLevel, type: :model do
           'type' => 'ticket_level.deleted',
           'data' => {
             'object' => {
-              'amount' => {'amount' => non_free_amount, 'currency' => 'usd'},
+              'amount' => {'cents' => non_free_amount, 'currency' => 'usd'},
               'available_to' => 'everyone',
               'deleted' => true,
               'description' => description,

--- a/spec/models/ticket_purchase_spec.rb
+++ b/spec/models/ticket_purchase_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe TicketPurchase, type: :model do
 					'event' => event.id,
 					'supporter' => supporter.id,
 					'tickets' => match_array(ticket_purchase.ticket_to_legacy_tickets.pluck(:id)),
-					'amount' => {'currency' => 'usd', 'amount' => 1200},
+					'amount' => {'currency' => 'usd', 'cents' => 1200},
 					'original_discount' => { 'percent' => 0},
 					'event_discount' => nil,
 					'transaction' => trx.id

--- a/spec/models/ticket_to_legacy_ticket_spec.rb
+++ b/spec/models/ticket_to_legacy_ticket_spec.rb
@@ -58,14 +58,14 @@ RSpec.describe TicketToLegacyTicket, type: :model do
     let(:free_ticket_default) {
       ticket_default.merge({
         'ticket_level' => legacy_free_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'amount' => 0}
+        'amount' => {'currency' => 'usd', 'cents' => 0}
       })
     }
 
     let(:nonfree_ticket_default) {
       ticket_default.merge({
         'ticket_level' =>  legacy_nonfree_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'amount' => legacy_nonfree_tickets.ticket_level.amount}
+        'amount' => {'currency' => 'usd', 'cents' => legacy_nonfree_tickets.ticket_level.amount}
       })
     }
 
@@ -143,14 +143,14 @@ RSpec.describe TicketToLegacyTicket, type: :model do
     let(:free_ticket_default) {
       ticket_default.merge({
         'ticket_level' => legacy_free_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'amount' => 0}
+        'amount' => {'currency' => 'usd', 'cents' => 0}
       })
     }
 
     let(:nonfree_ticket_default) {
       ticket_default.merge({
         'ticket_level' =>  legacy_nonfree_tickets.ticket_level.id,
-        'amount' => {'currency' => 'usd', 'amount' => 320 }
+        'amount' => {'currency' => 'usd', 'cents' => 320 }
       })
     }
 

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Transaction, type: :model do
         'supporter' => supporter.id,
         'object' => 'transaction',
         'amount' => {
-          'amount' => 1000,
+          'cents' => 1000,
           'currency' => 'usd'
         }
       })


### PR DESCRIPTION
We're going to use [Money](https://github.com/RubyMoney/money) internal to Ruby going forward.﻿ Since that's the case, our external Javascript Money class should also use the same field names. This fix does that.
