### PR TITLE
Change ubuntu-latest to specific version (ubuntu-20.04)

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
     steps:
       - uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
     steps:
       - uses: actions/checkout@v2
@@ -106,7 +106,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -7,7 +7,7 @@ on:
     paths: ["**.md"]
 jobs:
   markdownlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js environment

--- a/.github/workflows/notice_js.yml
+++ b/.github/workflows/notice_js.yml
@@ -2,7 +2,7 @@
 name: NOTICE-js verification
 env:
   node: 14.6.0
-  os: ubuntu-latest
+  os: ubuntu-20.04
 on: 
   push:
     paths:
@@ -18,7 +18,7 @@ on:
       - NOTICE-js
 jobs:
   notice_js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1.4.4

--- a/.github/workflows/notice_ruby.yml
+++ b/.github/workflows/notice_ruby.yml
@@ -12,7 +12,7 @@ on:
       - Gemfile.lock
       - NOTICE-ruby
 env:
-  os: ubuntu-latest
+  os: ubuntu-20.04
   ruby: '2.7.2'
 jobs:
   notice_ruby:

--- a/.github/workflows/placeholders.yml
+++ b/.github/workflows/placeholders.yml
@@ -5,18 +5,18 @@ name: Placeholders
 on: ['push', 'pull_request']
 jobs:
   notice_js:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: 'echo "Placeholder for notice_js"'
   notice_ruby:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - run: 'echo "Placeholder for notice_ruby"'
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
     steps:
       - run: 'echo "Placeholder for lint"'
@@ -24,7 +24,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
     steps:
       - run: 'echo "Placeholder for jest"'
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
     steps:
       - run: 'echo "Placeholder for webpack"'
@@ -40,7 +40,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
         ruby: [2.7.2]
     steps:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         node: [14.6.0]
         ruby: [2.7.2]
     steps:


### PR DESCRIPTION
When ubuntu-latest changed from 18.04 to 20.04, our caches became invalid. This will happen in two years again. We'll just be more specific and set it to 20.04 to avoid this problem in the future.﻿
