### PR TITLE
Remove heroku-deflater from production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,9 +82,13 @@ group :ci, :test do
 end
 
 group :production do
-  # Compression of assets on heroku
-  # https://github.com/romanbsd/heroku-deflater
-  gem 'heroku-deflater', '~> 0.6.3'
+  # A user calls `GET /assets/some-css.css` you want the result to be compressed.
+  # Normally, you'd use your webserver or some sort of reverse proxy to do so.
+  #
+  # If your server can't choose to directly serve gzip compressed assets at runtime
+  # like heroku, uncomment the `heroku-deflater` line.
+  #
+  # gem 'heroku-deflater', '~> 0.6.3' # https://github.com/romanbsd/heroku-deflater
   gem 'rack-timeout', '~> 0.5.1'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,8 +179,6 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (1.0.1)
-    heroku-deflater (0.6.3)
-      rack (>= 1.4.5)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -435,7 +433,6 @@ DEPENDENCIES
   font_assets (~> 0.1.14)
   good_job
   hamster (~> 3.0)
-  heroku-deflater (~> 0.6.3)
   houdini_full_contact!
   httparty (~> 0.17.0)
   i18n-js (~> 3.8)!

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -3792,33 +3792,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** heroku-deflater; version 0.6.3 -- 
-Copyright (c) 2012 Roman Shterenzon.
-
-Copyright (c) 2012 Roman Shterenzon
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-------
-
 ** table_print; version 1.5.7 -- 
 Copyright (c) 2013 Chris Doyle.
 Copyright (c) 2012-2016 Chris Doyle


### PR DESCRIPTION
heroku-deflater is only really used on servers where you have no other way to serve compressed assets, like heroku. Since that's sort of a special c﻿ase, the change commments out the heroku-deflater gem line.
