### PR TITLE
Move info about the hoster into its own module

### DIFF
--- a/app/controllers/concerns/controllers/user/authorization.rb
+++ b/app/controllers/concerns/controllers/user/authorization.rb
@@ -32,7 +32,7 @@ module Controllers::User::Authorization
 			store_location
 			if current_user
 				flash[:notice] =
-					"It looks like you're not allowed to access that page. If this seems like a mistake, please contact #{Houdini.support_email}"
+					"It looks like you're not allowed to access that page. If this seems like a mistake, please contact #{Houdini.hoster.support_email}"
 				redirect_to root_path
 			else
 				msg ||= 'We need to sign you in before you can do that.'

--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -11,6 +11,6 @@ class AdminMailer < BaseMailer
   def notify_failed_gift(donation, campaign_gift_option)
     @campaign_gift_option = campaign_gift_option
     @donation = donation
-    mail subject: "Tried to associate donation #{donation.id} with campaign gift option #{campaign_gift_option.id} which is out of stock", to: Houdini.support_email, from: Houdini.support_email
+    mail subject: "Tried to associate donation #{donation.id} with campaign gift option #{campaign_gift_option.id} which is out of stock", to: Houdini.hoster.support_email, from: Houdini.hoster.support_email
   end
 end

--- a/app/mailers/base_mailer.rb
+++ b/app/mailers/base_mailer.rb
@@ -7,6 +7,6 @@ class BaseMailer < ActionMailer::Base
   include Devise::Controllers::UrlHelpers
   include ApplicationHelper
   helper ApplicationHelper
-  default from: Houdini.support_email
+  default from: Houdini.hoster.support_email
   layout 'email'
 end

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -7,12 +7,12 @@ class GenericMailer < BaseMailer
     @from_email = from_email
     @from_name = from_name
     @message = message
-    mail(to: to_email, from: "#{from_name} <#{Houdini.support_email}>", reply_to: from_email, subject: subject.to_s)
+    mail(to: to_email, from: "#{from_name} <#{Houdini.hoster.support_email}>", reply_to: from_email, subject: subject.to_s)
   end
 
   # For sending a system notice to super admins
   def admin_notice(options)
-    @from_email = Houdini.support_email
+    @from_email = Houdini.hoster.support_email
     @from_name = 'CC Bot'
     @message = options[:body]
     emails = QueryUsers.super_admin_emails

--- a/app/models/import_request.rb
+++ b/app/models/import_request.rb
@@ -14,10 +14,10 @@ class ImportRequest < ApplicationRecord
 		rescue Exception => e
 			body = "Import failed. Error: #{e}"
 			GenericMailer.generic_mail(
-				Houdini.support_email, Houdini.support_email, # FROM
+				Houdini.hoster.support_email, Houdini.hoster.support_email, # FROM
 				body,
 				'Import error', # SUBJECT
-				Houdini.support_email, Houdini.support_email # TO
+				Houdini.hoster.support_email, Houdini.hoster.support_email # TO
 			).deliver
 		end
 	end

--- a/app/views/billing_subscription_mailer/failed_notice.html.erb
+++ b/app/views/billing_subscription_mailer/failed_notice.html.erb
@@ -16,7 +16,7 @@ Unfortunately, the credit card we currently have on file (<%= @card.name %>, exp
 <br>
 
 <p>
-If you have any questions or concerns, please feel free to call us (888) 204-8792 or to email <%= Houdini.support_email %> and we'll respond promptly to help.
+If you have any questions or concerns, please feel free to call us (888) 204-8792 or to email <%= Houdini.hoster.support_email %> and we'll respond promptly to help.
 </p>
 <br>
 <br>

--- a/app/views/billing_subscriptions/cancellation.html.erb
+++ b/app/views/billing_subscriptions/cancellation.html.erb
@@ -9,7 +9,7 @@
 
   <p> By cancelling your subscription, we will move you onto the <strong>2.0% tier</strong> and your card will no longer get charged. </p>
 
-  <p> Contact <%= Houdini.support_email %> if you need any help with exports or migrations. </p>
+  <p> Contact <%= Houdini.hoster.support_email %> if you need any help with exports or migrations. </p>
 
   <p>
   <form action="/nonprofits/<%=@nonprofit.id%>/billing_subscription/cancel" method="post">

--- a/app/views/campaign_mailer/federated_creation_followup.html.erb
+++ b/app/views/campaign_mailer/federated_creation_followup.html.erb
@@ -48,7 +48,7 @@ link_to_campaign: content_tag(:strong,
 
 <p><%= t('campaign_mailer.if_you_need_help_email_support', 
         email_support: content_tag(:strong,
-          Houdini.support_email)
+          Houdini.hoster.support_email)
 )%></p>
 
 <%= render 'emails/sig' %>

--- a/app/views/components/_footer_sub.html.erb
+++ b/app/views/components/_footer_sub.html.erb
@@ -13,9 +13,9 @@
 
 					<span class='globalFooter-sub-item'>
 						<% if current_user %>
-							<% if Houdini.terms_and_privacy&.help_url %><span><%= link_to("Help", Houdini.terms_and_privacy.help_url) %></span><% end %>
+							<% if Houdini.hoster.terms_and_privacy&.help_url %><span><%= link_to("Help", Houdini.terms_and_privacy.help_url) %></span><% end %>
 						<% else %>
-							<% if Houdini.terms_and_privacy&.about_url %><span><%= link_to("About", Houdini.terms_and_privacy.about_url) %></span><% end %>
+							<% if Houdini.hoster.terms_and_privacy&.about_url %><span><%= link_to("About", Houdini.terms_and_privacy.about_url) %></span><% end %>
 						<% end %>
 					</span>
 					<span class='globalFooter-sub-item'>

--- a/app/views/emails/_sig.html.erb
+++ b/app/views/emails/_sig.html.erb
@@ -5,5 +5,5 @@
 <p>All the best,</p>
 <p>
 The CommitChange Team<br>
-<a href="<%= Houdini.support_email %>"><%= Houdini.support_email %></a>
+<a href="<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a>
 </p>

--- a/app/views/event_mailer/creation_followup.html.erb
+++ b/app/views/event_mailer/creation_followup.html.erb
@@ -18,6 +18,6 @@
 <p><strong>Note:</strong> You can still share an unpublished event, but it will not show up on your nonprofit profile page or on your event listing page.</p>
 <br>
 
-<p>If you need some help getting your event up and running, don't hesitate to contact <strong><%= Houdini.support_email %></strong>.</p>
+<p>If you need some help getting your event up and running, don't hesitate to contact <strong><%= Houdini.hoster.support_email %></strong>.</p>
 
 <%= render 'emails/sig' %>

--- a/app/views/export_mailer/export_payments_completed_notification.html.erb
+++ b/app/views/export_mailer/export_payments_completed_notification.html.erb
@@ -6,6 +6,6 @@
 
 <p>Note: your generated CSV file will be automatically deleted from our servers after seven days. Don't worry; you can always visit your payments panel and export a new CSV file.</p>
 
-<p>If you have any questions about this export, please contact <a href="mailto:<%= Houdini.support_email %>"><%= Houdini.support_email %></a>.</p>
+<p>If you have any questions about this export, please contact <a href="mailto:<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a>.</p>
 
 <%= render 'emails/sig' %>

--- a/app/views/export_mailer/export_payments_failed_notification.html.erb
+++ b/app/views/export_mailer/export_payments_failed_notification.html.erb
@@ -2,7 +2,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE -%>
 <p>Your export from <%= Format::Date.simple @export.created_at %> did not succeed due to a technical error.</p>
 <p>While CommitChange engineers have been notified, don't hesitate to contact
-  <a href="mailto:<%= Houdini.support_email %>"><%= Houdini.support_email %></a> with the following information:</p>
+  <a href="mailto:<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a> with the following information:</p>
 
 <ul>
   <li>Export ID: <%= @export.id %></li>

--- a/app/views/export_mailer/export_recurring_donations_completed_notification.html.erb
+++ b/app/views/export_mailer/export_recurring_donations_completed_notification.html.erb
@@ -6,6 +6,6 @@
 
 <p>Note: your generated CSV file will be automatically deleted from our servers after seven days. Don't worry; you can always visit your recurring donations panel and export a new CSV file.</p>
 
-<p>If you have any questions about this export, please contact <a href="mailto:<%= Houdini.support_email %>"><%= Houdini.support_email %></a>.</p>
+<p>If you have any questions about this export, please contact <a href="mailto:<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a>.</p>
 
 <%= render 'emails/sig' %>

--- a/app/views/export_mailer/export_recurring_donations_failed_notification.html.erb
+++ b/app/views/export_mailer/export_recurring_donations_failed_notification.html.erb
@@ -2,7 +2,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE -%>
 <p>Your export from <%= Format::Date.simple @export.created_at %> did not succeed due to a technical error.</p>
 <p>While CommitChange engineers have been notified, don't hesitate to contact
-  <a href="mailto:<%= Houdini.support_email %>"><%= Houdini.support_email %></a> with the following information:</p>
+  <a href="mailto:<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a> with the following information:</p>
 
 <ul>
   <li>Export ID: <%= @export.id %></li>

--- a/app/views/export_mailer/export_supporter_notes_completed_notification.html.erb
+++ b/app/views/export_mailer/export_supporter_notes_completed_notification.html.erb
@@ -4,6 +4,6 @@
 
 <p>Note: your generated CSV file will be automatically deleted from our servers after seven days. Don't worry; you can always visit your recurring donations panel and export a new CSV file.</p>
 
-<p>If you have any questions about this export, please contact <a href="mailto:<%= Houdini.support_email %>"><%= Houdini.support_email %></a>.</p>
+<p>If you have any questions about this export, please contact <a href="mailto:<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a>.</p>
 
 <%= render 'emails/sig' %>

--- a/app/views/export_mailer/export_supporter_notes_failed_notification.html.erb
+++ b/app/views/export_mailer/export_supporter_notes_failed_notification.html.erb
@@ -1,6 +1,6 @@
 <p>Your export from <%= Format::Date.simple @export.created_at %> did not succeed due to a technical error.</p>
 <p>While CommitChange engineers have been notified, don't hesitate to contact
-  <a href="mailto:<%= Houdini.support_email %>"><%= Houdini.support_email %></a> with the following information:</p>
+  <a href="mailto:<%= Houdini.hoster.support_email %>"><%= Houdini.hoster.support_email %></a> with the following information:</p>
 
 <ul>
   <li>Export ID: <%= @export.id %></li>

--- a/app/views/import_mailer/import_completed_notification.html.erb
+++ b/app/views/import_mailer/import_completed_notification.html.erb
@@ -6,7 +6,7 @@
 
 <p>To view your new payments data, visit: <a href='<%= root_url %>nonprofits/<%= @nonprofit.id %>/payments'>payment history.</a></p>
 
-<p>If you have any questions about this import, please contact <%= Houdini.support_email %>.</p>
+<p>If you have any questions about this import, please contact <%= Houdini.hoster.support_email %>.</p>
 
 
 <%= render 'emails/sig' %>

--- a/app/views/layouts/_apified_footer.html.erb
+++ b/app/views/layouts/_apified_footer.html.erb
@@ -4,8 +4,8 @@
 <% if @theme == 'minimal' %>
   <div class="minimalFooter">
     <div class="container">
-      <span>&copy; <%= Time.current.year %> <%= Houdini.general.name %></span>
-      <% if Houdini.terms_and_privacy&.about_url %><span><%= link_to("About", Houdini.terms_and_privacy.about_url) %></span><% end %>
+      <span>&copy; <%= Time.current.year %> <%= Houdini.hoster.legal_name %></span>
+      <% if Houdini.hoster.terms_and_privacy&.about_url %><span><%= link_to("About", Houdini.terms_and_privacy.about_url) %></span><% end %>
       <span><%= link_to( t("footer.terms_and_privacy"), :static_terms_and_privacy) %></span>
     </div>
 

--- a/app/views/layouts/_side_nav.html.erb
+++ b/app/views/layouts/_side_nav.html.erb
@@ -26,7 +26,7 @@
 
 	<% unless current_role?([:nonprofit_admin,:nonprofit_associate]) %>
 		<section class='sideNav-section'>
-      <% if Houdini.terms_and_privacy&.help_url %>
+      <% if Houdini.hoster.terms_and_privacy&.help_url %>
         <a class='sideNav-link' href="<%=Houdini.terms_and_privacy.help_url %>">
           <i class='sideNav-icon icon-bubble-ask-2'></i>
           <span class='sideNav-text'>Help</span>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -20,7 +20,7 @@
 		</a>
 		<% if current_role?([:nonprofit_admin,:nonprofit_associate]) %>
 
-      <% if Houdini.terms_and_privacy&.help_url %>
+      <% if Houdini.hoster.terms_and_privacy&.help_url %>
         <a class='sideNav-link' href='<%=Houdini.terms_and_privacy.help_url %>'>
           <i class='sideNav-icon icon-question-mark'></i>
           <span class='sideNav-text'>Help</span>

--- a/app/views/nonprofit_admin_mailer/supporter_fundraiser.html.erb
+++ b/app/views/nonprofit_admin_mailer/supporter_fundraiser.html.erb
@@ -8,6 +8,6 @@
 
 <p>If you would like to get in touch with your supporter, you can email them at <a href="mailto:<%= @profile.user.email %>"><%= @profile.user.email %></a>.</p><br>
 
-<p>If you need help or have any questions, don't hesitate to contact us at <strong><%= Houdini.support_email %></strong>.</p>
+<p>If you need help or have any questions, don't hesitate to contact us at <strong><%= Houdini.hoster.support_email %></strong>.</p>
 
 <%= render 'emails/sig' %>

--- a/app/views/nonprofit_mailer/failed_verification_notice.html.erb
+++ b/app/views/nonprofit_mailer/failed_verification_notice.html.erb
@@ -11,7 +11,7 @@
 
 <p><strong><a href='<%= root_url + "/nonprofits/#{@nonprofit.id}/payouts" %>'>Visit your payouts page to get everything sorted out.</a></strong></p>
 
-<p>As always, if you have any questions, please send us a note at <%= Houdini.support_email %></p>
+<p>As always, if you have any questions, please send us a note at <%= Houdini.hoster.support_email %></p>
 
 <%= render 'emails/sig' %>
 

--- a/app/views/nonprofit_mailer/invoice_payment_notification.html.erb
+++ b/app/views/nonprofit_mailer/invoice_payment_notification.html.erb
@@ -39,7 +39,7 @@ Your invoice for the month of <%= @month_name %> has been paid and the receipt i
       CommitChange Inc. 
       <br>Oakland, CA
       <br>EIN 46-3123854
-      <br><%= Houdini.support_email %>
+      <br><%= Houdini.hoster.support_email %>
     </td>
   </tr>
 

--- a/app/views/nonprofit_mailer/new_bank_account_notification.html.erb
+++ b/app/views/nonprofit_mailer/new_bank_account_notification.html.erb
@@ -12,6 +12,6 @@
 
 <p><a href='<%= confirmation_nonprofits_bank_account_url(@nonprofit, :t => @bank_account.confirmation_token) %>' class='button'>Confirm Change</a></p>
 
-<p>If you think something is wrong with this change, please contact <a href='mailto:<%= Houdini.support_email %>'><%= Houdini.support_email %></a>.</p>
+<p>If you think something is wrong with this change, please contact <a href='mailto:<%= Houdini.hoster.support_email %>'><%= Houdini.hoster.support_email %></a>.</p>
 
 <%= render 'emails/sig' %>

--- a/app/views/nonprofit_mailer/pending_payout_notification.html.erb
+++ b/app/views/nonprofit_mailer/pending_payout_notification.html.erb
@@ -8,7 +8,7 @@
 
 <p>If the above looks correct, we don't need any futher actions. The transfer will complete within 1-3 business days.</p><br>
 
-<p><strong>If anything looks incorrect</strong>, please contact <a href='mailto:<%= Houdini.support_email %>'><%= Houdini.support_email %></a>.</p>
+<p><strong>If anything looks incorrect</strong>, please contact <a href='mailto:<%= Houdini.hoster.support_email %>'><%= Houdini.hoster.support_email %></a>.</p>
 
 <%= render 'emails/sig' %>
 

--- a/app/views/nonprofit_mailer/successful_payout_notification.html.erb
+++ b/app/views/nonprofit_mailer/successful_payout_notification.html.erb
@@ -4,11 +4,11 @@
 
 <%= render 'payout_table', payout: @payout %>
 
-<p>Look for the deposit with in the above net amount with <strong><%= Houdini.support_email %></strong> in the statement.</p>
+<p>Look for the deposit with in the above net amount with <strong><%= Houdini.hoster.support_email %></strong> in the statement.</p>
 
 <p><%= link_to 'Visit this link', nonprofits_payouts_url(@nonprofit) %> to view your detailed payout history.</p><br>
 
-<p><strong>If anything looks incorrect</strong>, please contact <a href='mailto:<%= Houdini.support_email %>'><%= Houdini.support_email %></a>.</p>
+<p><strong>If anything looks incorrect</strong>, please contact <a href='mailto:<%= Houdini.hoster.support_email %>'><%= Houdini.hoster.support_email %></a>.</p>
 
 <%= render 'emails/sig' %>
 

--- a/app/views/nonprofit_mailer/welcome.html.erb
+++ b/app/views/nonprofit_mailer/welcome.html.erb
@@ -32,7 +32,7 @@ Here are a few things you can do right away to get up and running:
 </ul>
 
 <p>
-If you need help or have any questions, our support team is just a phone call or email away. You can contact us directly at <%= Houdini.support_email %> or 888-204-8792.
+If you need help or have any questions, our support team is just a phone call or email away. You can contact us directly at <%= Houdini.hoster.support_email %> or 888-204-8792.
 </p>
 
 <%= render 'emails/sig' %>

--- a/app/views/nonprofits/bank_accounts/cancellation.html.erb
+++ b/app/views/nonprofits/bank_accounts/cancellation.html.erb
@@ -18,5 +18,5 @@
 		<p>The bank account for this nonprofit was never initially confirmed.</p>
 	<% end %>
 
-	<p>If you think this was in error, please contact <%= mail_to '<%= Houdini.support_email %>' %>
+	<p>If you think this was in error, please contact <%= mail_to '<%= Houdini.hoster.support_email %>' %>
 </div>

--- a/app/views/nonprofits/dashboard/_todo_messages.html.erb
+++ b/app/views/nonprofits/dashboard/_todo_messages.html.erb
@@ -10,6 +10,6 @@
 		 Once you've started completing these tasks, you'll see your dashboard come to life with helpful data and reminders.
 	</span>
 
-    <% if Houdini.terms_and_privacy&.help_url %> If you need help with any these tasks, visit our <%= link_to("Help Center", Houdini.terms_and_privacy.help_url) %>.<% end %>
+    <% if Houdini.hoster.terms_and_privacy&.help_url %> If you need help with any these tasks, visit our <%= link_to("Help Center", Houdini.terms_and_privacy.help_url) %>.<% end %>
 	</p>
 </div>

--- a/app/views/nonprofits/payments/_details_table.html.erb
+++ b/app/views/nonprofits/payments/_details_table.html.erb
@@ -15,7 +15,7 @@
 
 <p class='notification'>
   <!--= show_if payment_details.data.dispute -->
-  One of your supporters has disputed a charge (ie. made a charge-back), meaning they have called their bank and claimed that the charge was unauthorized. You need to collect evidence, via email, that the supporter intended to make the charge. Please contact <%= Houdini.support_email %> so we can help resolve this for you.
+  One of your supporters has disputed a charge (ie. made a charge-back), meaning they have called their bank and claimed that the charge was unauthorized. You need to collect evidence, via email, that the supporter intended to make the charge. Please contact <%= Houdini.hoster.support_email %> so we can help resolve this for you.
 </p>
 
 <table class='table--small'>

--- a/app/views/nonprofits/payouts/_todos.html.erb
+++ b/app/views/nonprofits/payouts/_todos.html.erb
@@ -67,6 +67,6 @@
 	<div class='modal-body'>
 		<p>Success! The confirmation email to activate your bank account has been successfully re-sent. Expect it to arrive in your inbox within a few minutes. If you can't find it, be sure to check your spam folder.</p>
 		<p><blockquote>Why do we require this confirmation? It proves that you have access to both your <%= Houdini.general.name %> account and your email account, preventing anybody from changing your organization's bank account if you leave your CommitChange account signed in on a shared computer.</blockquote></p>
-		<p>If you still have trouble finding the confirmation email, please contact <a href='mailto:<%= Houdini.support_email %>'><%= Houdini.support_email %></a>.</p>
+		<p>If you still have trouble finding the confirmation email, please contact <a href='mailto:<%= Houdini.hoster.support_email %>'><%= Houdini.hoster.support_email %></a>.</p>
 	</div>
 </div>

--- a/app/views/settings/_pricing.html.erb
+++ b/app/views/settings/_pricing.html.erb
@@ -37,7 +37,7 @@
 		</p>
 	<% end %>
 
-	<p class='note u-marginTop--10'>If you have any questions about your current plan, please contact <a href='mailto:<%= Houdini.support_email %>'><%= Houdini.support_email %></a></p>
+	<p class='note u-marginTop--10'>If you have any questions about your current plan, please contact <a href='mailto:<%= Houdini.hoster.support_email %>'><%= Houdini.hoster.support_email %></a></p>
 </div>
 
 

--- a/app/views/static/terms_and_privacy.html.erb
+++ b/app/views/static/terms_and_privacy.html.erb
@@ -3,11 +3,11 @@
 <% content_for :title, "Terms and Privacy" %>
 <div class="container"><h1>Terms and Privacy</h1>
 
-<% if Houdini.terms_and_privacy&.terms_url %>
+<% if Houdini.hoster.terms_and_privacy&.terms_url %>
   <h2><a href="<%= Houdini.terms_and_privacy.terms_url  %>">Terms of Use</a></h2>
 <% end %>
 
-<% if Houdini.terms_and_privacy&.privacy_url %>
+<% if Houdini.hoster.terms_and_privacy&.privacy_url %>
   <h2><a href="<%= Houdini.terms_and_privacy.privacy_url  %>">Privacy Policy</a></h2>
 <% end %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ require "rails/test_unit/railtie"
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-# require File.expand_path('lib/htp') # Hamster Table Print
+
 module Commitchange
   class Application < Rails::Application
     config.load_defaults '5.0'
@@ -110,3 +110,6 @@ module Commitchange
     end
   end
 end
+
+# we want to add the houdini configuration
+require_relative './houdini_config'

--- a/config/houdini_config.rb
+++ b/config/houdini_config.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+
+# customize Houdini configuration here.
+Rails.application.configure do
+	config.houdini.hoster.legal_name = 'SET config.houdini.hoster.legal_name IN app/config/houdini_config.rb'
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,7 +8,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = Houdini.support_email
+  config.mailer_sender = Houdini.hoster.support_email
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -6,4 +6,4 @@ require 'stripe'
 
 #Stripe.api_key = Houdini.payment_providers.stripe.stripe.private_key
 
-Rails.application.config.houdini.support_email = "support@email.com"
+#Rails.application.config.Houdini.hoster.support_email = "support@email.com"

--- a/docs/event_definitions/Hoster.ts
+++ b/docs/event_definitions/Hoster.ts
@@ -1,0 +1,16 @@
+// License: LGPL-3.0-or-later
+
+/**
+ * Describes the hoster of this instance of Houdini
+ */
+export interface Hoster {
+	casual_name: string;
+	legal_name: string;
+	main_admin_email: string;
+	support_email: string;
+	terms_and_privacy:{
+		about_url?: string;
+		help_url?: string;
+		privacy_url?: string;
+	};
+}

--- a/gems/bess/lib/houdini.rb
+++ b/gems/bess/lib/houdini.rb
@@ -2,7 +2,6 @@
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
-require "houdini/engine"
 
 module Houdini
   extend ActiveSupport::Autoload
@@ -14,6 +13,8 @@ module Houdini
   autoload :EventPublisher
   autoload :WebhookAdapter
   autoload :NonprofitCreation
+  autoload :Hoster
+  autoload :EngineInitializers
 
   mattr_accessor :intl, :maintenance, :ccs
 
@@ -32,12 +33,15 @@ module Houdini
   mattr_accessor :show_state_field, default: true
 
   mattr_accessor :nonprofits_must_be_vetted, default: false
-  mattr_accessor :terms_and_privacy, default: {}
   mattr_accessor :button_host
 
-  mattr_accessor :support_email
+  mattr_accessor :hoster, default: Houdini::Hoster
 
   mattr_accessor :core_classes, default: {supporter: 'Supporter', nonprofit: 'Nonprofit'}
 
   mattr_accessor :event_publisher, default: Houdini::EventPublisher.new
+
 end
+
+# need to have Houdini loaded first before we can add engine
+require "houdini/engine"

--- a/gems/bess/lib/houdini/engine_initializers.rb
+++ b/gems/bess/lib/houdini/engine_initializers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+
+# loads all of the engine initializer modules for Houdini
+module Houdini::EngineInitializers
+	extend ActiveSupport::Concern
+	extend ActiveSupport::Autoload
+	initializer_path = File.expand_path(File.join(File.dirname(__FILE__), 'engine_initializers'))
+	initializers = Dir.glob("#{initializer_path}/*").to_a
+	initializers.each do |file|
+		autoload File.basename(file, '.rb').camelize.to_sym
+		include "Houdini::EngineInitializers::#{File.basename(file, '.rb').camelize}".constantize
+	end
+end

--- a/gems/bess/lib/houdini/engine_initializers/hoster.rb
+++ b/gems/bess/lib/houdini/engine_initializers/hoster.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+module Houdini::EngineInitializers
+	# an engine initializer for information about the hoster
+	module Hoster
+		extend ActiveSupport::Concern
+		included do
+			initializer 'houdini.hoster.set_configs',
+															before: 'houdini.finish_configs' do |app|
+				app.config.to_prepare do
+					options = app.config.houdini.hoster
+
+					options.support_email ||= ActionMailer::Base.default[:from]
+					options.main_admin_email ||= ActionMailer::Base.default[:from]
+
+					options.each { |k, v| Houdini::Hoster.send("#{k}=", v) }
+				end
+			end
+
+			config.houdini.hoster = ActiveSupport::OrderedOptions.new
+			config.houdini.hoster.terms_and_privacy = ActiveSupport::OrderedOptions.new
+		end
+	end
+end

--- a/gems/bess/lib/houdini/engine_initializers/intl.rb
+++ b/gems/bess/lib/houdini/engine_initializers/intl.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+module Houdini::EngineInitializers
+	# engine initializer for everything international
+	module Intl
+		extend ActiveSupport::Concern
+		included do
+			initializer 'houdini.intl.set_configs',
+															before: 'houdini.finish_configs' do |app|
+				app.config.to_prepare do
+					Houdini.intl = Houdini::Intl.new(app.config.houdini.intl.to_h)
+					Houdini.intl.all_countries ||=  ISO3166::Country.all.map(&:alpha2)
+					Houdini.intl.all_currencies ||= Money::Currency.table
+					if Houdini.intl.available_locales.map(&:to_s)
+															.none? { |l| l == Houdini.intl.language.to_s }
+						raise("The language #{Houdini.intl.language} is not listed \
+		in the provided locales: #{Houdini.intl.available_locales.join(', ')}")
+					end
+				end
+			end
+
+			config.houdini.intl = ActiveSupport::OrderedOptions.new
+			config.houdini.intl.language = :en
+			config.houdini.intl.available_locales = %i[en de es fr it nl pl ro]
+			config.houdini.intl.all_countries = nil
+			config.houdini.intl.currencies = ['usd']
+			config.houdini.intl.all_currencies = nil
+		end
+	end
+end

--- a/gems/bess/lib/houdini/hoster.rb
+++ b/gems/bess/lib/houdini/hoster.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+module Houdini::Hoster
+	#  (required) - the legal name of the hoster
+	mattr_accessor :legal_name
+
+	# (optional but STRONGLY RECOMMENDED) - the email used for receiving emails
+	# and notifications which deal with contacting the admin
+	mattr_accessor :main_admin_email
+
+	mattr_writer :casual_name
+
+	## (optional, defaults to legal_name) - a more casual name of the website As an example
+	## if your hoster was HoudiniCo LLC, you might use HoudiniCo or
+	## CustomHoudiniInstance here. We use this for possessive nouns and similar.
+	def self.casual_name
+		@@casual_name || Houdini::Hoster.legal_name
+	end
+
+	# has casual_name been set?
+	def self.casual_name?
+		@@casual_name.present?
+	end
+
+	# (optional) - the email address for contacting support
+	mattr_accessor :support_email
+
+	# terms_and_privacy
+	mattr_accessor :terms_and_privacy
+end

--- a/lib/fetch/fetch_nonprofit_email.rb
+++ b/lib/fetch/fetch_nonprofit_email.rb
@@ -5,11 +5,11 @@
 module FetchNonprofitEmail
   def self.with_charge(charge)
     nonprofit = charge.nonprofit
-    nonprofit.email.blank? ? Houdini.support_email : nonprofit.email
+    nonprofit.email.blank? ? Houdini.hoster.support_email : nonprofit.email
   end
 
   def self.with_donation(donation)
     nonprofit = donation.nonprofit
-    nonprofit.email.blank? ? Houdini.support_email : nonprofit.email
+    nonprofit.email.blank? ? Houdini.hoster.support_email : nonprofit.email
   end
 end

--- a/lib/format/format/name.rb
+++ b/lib/format/format/name.rb
@@ -14,7 +14,7 @@ module Format
 
     # Format a nonprofit name into an email <from> header
     def self.email_from_np(np_name)
-      "\"#{np_name.delete(',').delete('"')}\" <#{Houdini.support_email}>"
+      "\"#{np_name.delete(',').delete('"')}\" <#{Houdini.hoster.support_email}>"
     end
   end
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -19,8 +19,9 @@ task :heroku_scheduled_job, [:name] => :environment do |_t, args|
   rescue Exception => e
     results += "Failure: #{e}\n"
   end
+
   GenericMailer.admin_notice(
-    subject: "Scheduled job results on CommitChange for '#{job_name}'",
+    subject: "Scheduled job results on #{Houdini.hoster.casual_name} for '#{job_name}'",
     body: results.empty? ? 'No jobs to run today.' : results
   ).deliver_later
 end

--- a/spec/lib/fetch/fetch_nonprofit_email_spec.rb
+++ b/spec/lib/fetch/fetch_nonprofit_email_spec.rb
@@ -15,12 +15,12 @@ describe FetchNonprofitEmail, pending: true do
 
     it 'returns support@commitchange.com if Nonprofit email is blank' do
       charge.nonprofit.email = ''
-      expect(FetchNonprofitEmail.with_charge(charge)).to eq(Houdini.support_email)
+      expect(FetchNonprofitEmail.with_charge(charge)).to eq(Houdini.hoster.support_email)
     end
 
     it 'returns support@commitchange.com if Nonprofit email is nil' do
       charge.nonprofit.email = nil
-      expect(FetchNonprofitEmail.with_charge(charge)).to eq(Houdini.support_email)
+      expect(FetchNonprofitEmail.with_charge(charge)).to eq(Houdini.hoster.support_email)
     end
   end
 end

--- a/spec/lib/format/name_spec.rb
+++ b/spec/lib/format/name_spec.rb
@@ -8,7 +8,7 @@ require 'format/name'
 describe Format::Name do
   describe '.email_from_np' do
     before(:each) do
-      Houdini.support_email = 'support@email.com'
+      Houdini.hoster.support_email = 'support@email.com'
     end
     it 'gives the name, minus commas, with our email in brackets' do
       result = Format::Name.email_from_np('Test, X, Y')

--- a/spec/mailers/admin_spec.rb
+++ b/spec/mailers/admin_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it 'renders the headers for mail without desc' do
       expect(mail.subject).to eq("Tried to associate donation #{donation.id} with campaign gift option #{campaign_gift_option.id} which is out of stock")
-      expect(mail.to).to eq([Houdini.support_email])
-      expect(mail.from).to eq([Houdini.support_email])
+      expect(mail.to).to eq([Houdini.hoster.support_email])
+      expect(mail.from).to eq([Houdini.hoster.support_email])
     end
 
     it 'renders the body without desc' do
@@ -29,8 +29,8 @@ RSpec.describe AdminMailer, type: :mailer do
 
     it 'renders the headers on mail with desc' do
       expect(mail_with_desc.subject).to eq("Tried to associate donation #{donation.id} with campaign gift option #{campaign_gift_option_with_desc.id} which is out of stock")
-      expect(mail_with_desc.to).to eq([Houdini.support_email])
-      expect(mail_with_desc.from).to eq([Houdini.support_email])
+      expect(mail_with_desc.to).to eq([Houdini.hoster.support_email])
+      expect(mail_with_desc.from).to eq([Houdini.hoster.support_email])
     end
 
     it 'renders the body with desc' do


### PR DESCRIPTION
This makes it possible to get information about the hoster of an Houdini instance. This is accessed via Houdini.hoster.