### PR TITLE
Allow framing of nonprofits/:id/donate and nonprofits/:id/btn

### DIFF
--- a/app/controllers/concerns/controllers/x_frame.rb
+++ b/app/controllers/concerns/controllers/x_frame.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
+module Controllers::XFrame
+	extend ActiveSupport::Concern
+
+	included do
+		private
+
+		# allows the page to be put in a frame, i.e. remove the X-Frame-Options header
+		def allow_framing
+			response.headers.delete('X-Frame-Options') if response.headers.has_key?('X-Frame-Options')
+		end
+	end
+end

--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -5,10 +5,14 @@
 class NonprofitsController < ApplicationController
   include Controllers::Nonprofit::Current
   include Controllers::Nonprofit::Authorization
+  include Controllers::XFrame
 
   helper_method :current_nonprofit_user?
   before_action :authenticate_nonprofit_user!, only: %i[dashboard dashboard_metrics dashboard_todos payment_history profile_todos recurring_donation_stats update verify_identity]
   before_action :authenticate_super_admin!, if: proc {|c| ( c.action_name == "destroy") || (c.action_name == "show" && !current_nonprofit.published) }
+
+  # we have to allow nonprofits/:id/donation and nonprofits/:id/btn to be framed
+  after_action :allow_framing, only: %i[donate btn]
 
   # get /nonprofits/:id
   # get /:state_code/:city/:name

--- a/spec/controllers/nonprofits_spec.rb
+++ b/spec/controllers/nonprofits_spec.rb
@@ -76,4 +76,21 @@ describe NonprofitsController, type: :controller do
       end
     end
   end
+
+  describe '#donate' do
+    let(:nonprofit) { force_create(:nm_justice) }
+    it 'allows being put into a frame by not setting X-Frame-Options header' do
+      get :donate, params: {id: nonprofit.id}
+      expect(response.headers).to_not include 'X-Frame-Options'
+    end
+    
+  end
+
+  describe '#btn' do
+    let(:nonprofit) { force_create(:nm_justice) }
+    it 'allows being put into a frame by not setting X-Frame-Options header' do
+      get :btn, params: {id: nonprofit.id}
+      expect(response.headers).to_not include 'X-Frame-Options'
+    end
+  end
 end


### PR DESCRIPTION
In order to embed a donate widget, the X-Frame-Options header cannot be set on /nonprofits/:id/btn or /nonprofits/:id/donate. By default, Rails sets this. This change removed the X-Frame-Options headers for these two actions.
