### PR TITLE
Validates nonprofit's timezone

### DIFF
--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -106,6 +106,7 @@ class Nonprofit < ApplicationRecord
   validates_presence_of :user_id, on: :create, unless: -> {register_np_only}
   validate :user_is_valid, on: :create, unless: -> {register_np_only}
   validate :user_registerable_as_admin, on: :create, unless: -> {register_np_only}
+  validate :timezone_is_valid
 
   scope :vetted, -> { where(vetted: true) }
   scope :identity_verified, -> { where(verification_status: 'verified') }
@@ -305,6 +306,12 @@ private
 
   def user_is_valid
     (user && user.is_a?(User)) || errors.add(:user_id, "is not a valid user")
+  end
+
+  def timezone_is_valid
+    timezone.blank? or
+      ActiveSupport::TimeZone.all.map{ |t| t.tzinfo.name }.include?(timezone) or
+      errors.add(:timezone, 'is not a valid timezone')
   end
 end
 

--- a/spec/models/nonprofit_spec.rb
+++ b/spec/models/nonprofit_spec.rb
@@ -204,6 +204,20 @@ RSpec.describe Nonprofit, type: :model do
         nonprofit.valid?
         expect(nonprofit.errors['slug'].first).to match /.*could not be created.*/
       end
+
+      describe 'timezone validations' do
+        it 'does not fail if the timezone is nil' do
+          expect { create(:nm_justice, timezone: nil) }.not_to raise_error(ActiveRecord::RecordInvalid)
+        end
+
+        it 'does not fail if the timezone is readable by postgres' do
+          expect { create(:nm_justice, timezone: 'America/Chicago') }.not_to raise_error(ActiveRecord::RecordInvalid)
+        end
+
+        it 'raises error if the timezone is invalid' do
+          expect { create(:nm_justice, timezone: 'Central Time (US & Canada)') }.to raise_error(ActiveRecord::RecordInvalid)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Validates that the time zones used by the nonprofits are the ones that come from `ActiveSupport::TimeZone`, which are also compatible with Postgresql.