### PR TITLE
Update parser so it stops warning when using Ruby 2.7.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,7 +229,7 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
-    parser (3.0.0.0)
+    parser (3.0.1.1)
       ast (~> 2.4.1)
     pg (1.2.3)
     power_assert (1.2.0)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -3548,7 +3548,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** parser; version 3.0.0.0 -- 
+** parser; version 3.0.1.1 -- 
 Copyright (c) 2013-2016
 Copyright (c) Ryan Davis, seattle.rb
 


### PR DESCRIPTION
We updated to Ruby 2.7.3 but parser wasn't updated to support it yet. This change corrects that.﻿
