### PR TITLE
Automagically load all the context files for spec testing

### DIFF
--- a/spec/support/contexts.rb
+++ b/spec/support/contexts.rb
@@ -2,5 +2,7 @@
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/master/LICENSE
-require 'support/contexts/shared_donation_charge_context'
-require 'support/contexts/shared_rd_donation_value_context'
+
+ Dir["#{File.dirname (__FILE__)}/contexts/*"].each do |file|
+  require_relative "./contexts/#{File.basename(file, ".rb")}" 
+end


### PR DESCRIPTION
Previously we had to manually require all the files in spec/support/contexts. Now they're automagically loaded. What a world!﻿
