### PR TITLE
mail_view is now included in Rails so not needed in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,6 @@ end
 group :development, :ci, :test do
   gem 'byebug', '~> 11.0', '>= 11.0.1'
   gem 'dotenv-rails', '~> 2.7', '>= 2.7.5', require: 'dotenv/rails-now'
-  gem 'mail_view', '~> 2.0'
   gem 'pry', '~> 0.12.2'
   gem 'pry-byebug', '~> 3.7.0'
   gem 'rspec-rails', '~> 4.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,8 +204,6 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
-    mail_view (2.0.4)
-      tilt
     marcel (1.0.1)
     method_source (0.9.2)
     mime-types (3.3.1)
@@ -443,7 +441,6 @@ DEPENDENCIES
   jbuilder (~> 2.10)
   listen
   lograge (~> 0.11.2)
-  mail_view (~> 2.0)
   mini_racer
   money (~> 6.13)
   param_validation!


### PR DESCRIPTION
According to https://github.com/basecamp/mail_view, the mail_view﻿ gem is included in Rails starting in Rails 4.1. We remove it from being explicitly included in the Gemfile.
