### PR TITLE
Alphabetize api/nonprofits/* routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,10 +15,10 @@ Rails.application.routes.draw do
   defaults format: :json do # they're APIs, you have to use JSON
     namespace :api do
       resources :nonprofits, only: [:create, :show] do
+        resources :campaigns, only: [:show]
         resources :supporters, only: [:index, :show] do 
           resources :supporter_addresses, only: [:index, :show]
         end
-        resources :campaigns, only: [:show]
       end
 
       resources :users, only: [] do


### PR DESCRIPTION
It's easier to catch changes in routes if they're alphabetized. So we're doing that!﻿
