### PR TITLE
Reduce the number of unnecessary files that typescript is loading

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,18 @@
       "./types"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop":true
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "tmp",
+    "storage",
+    "log",
+    "coverage"
+  ],
+  "include": [
+    "./types/**/*",
+    "./docs/**/*",
+    "./app/javascript/**/*",
+    "./config/**/*"
+  ]
 }


### PR DESCRIPTION
We were accidentally having typescript load all of the files in every subfolder known to humanity. This limits the folders significantly.﻿
