### PR TITLE
Reduce number of pull_request events where the build runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+# License: LGPL-3.0-or-later
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,3 +1,4 @@
+# License: LGPL-3.0-or-later
 name: Dependent Issues
 
 on:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,3 +1,4 @@
+# License: LGPL-3.0-or-later
 name: Greetings
 
 on: [pull_request, issues]

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
+    types: [opened, reopened, synchronize]
 jobs:
   lint:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -5,6 +5,7 @@ on:
     paths: ["**.md"]
   pull_request:
     paths: ["**.md"]
+    types: [opened, reopened, synchronize]
 jobs:
   markdownlint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/notice_js.yml
+++ b/.github/workflows/notice_js.yml
@@ -16,6 +16,7 @@ on:
       - package.json
       - included.json
       - NOTICE-js
+    types: [opened, reopened, synchronize]
 jobs:
   notice_js:
     runs-on: ubuntu-20.04

--- a/.github/workflows/notice_ruby.yml
+++ b/.github/workflows/notice_ruby.yml
@@ -11,6 +11,7 @@ on:
       - Gemfile
       - Gemfile.lock
       - NOTICE-ruby
+    types: [opened, reopened, synchronize]
 env:
   os: ubuntu-20.04
   ruby: '2.7.4'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,6 +20,7 @@ on:
       - "NOTICE-ruby"
       - "package.json"
       - "yarn.lock"
+    types: [opened, reopened, synchronize]
 jobs:
   main_build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
We currently run builds when anything happens to a pull request, including when they're closed. It's a waste of limited build resources. 

With this change, builds only run when a pull request is opened, reopened, or updated (synchronized).

Also, I've added some forgotten license headers on the YML files in the .github directory
