### PR TITLE
Remove dependabot notifications for the test-dependabot branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,3 @@ updates:
     schedule:
       interval: "weekly"
 
-  - package-ecosystem: "bundler" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    target-branch: "test-dependabot"
-    schedule:
-      interval: "daily"


### PR DESCRIPTION
I'm doing dependabot update testing elsewhere so this isn't needed for now.﻿
