### PR TITLE
Ignore semver major changes for dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"] # we don't want to have semver-major changes
 


### PR DESCRIPTION
Semver major changes are likely to cause chaos so we're ignoring them for now on bundler﻿
