### PR TITLE
Remove tests on push

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -3,9 +3,6 @@ name: Javascript build and test
 env: 
   ruby: '2.7.4'
 on: 
-  push:
-    paths-ignore:
-      - "**.md"
   pull_request:
     paths-ignore:
       - "**.md"

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,8 +1,6 @@
 # License: LGPL-3.0-or-later
 name: Markdown lint
 on: 
-  push:
-    paths: ["**.md"]
   pull_request:
     paths: ["**.md"]
     types: [opened, reopened, synchronize]

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,15 +1,6 @@
 # License: LGPL-3.0-or-later
 name: Ruby test and build
 on: 
-  push:
-    paths-ignore:
-      - "**.[jt]sx?"
-      - "**.es6"
-      - "**.md"
-      - "NOTICE-js"
-      - "NOTICE-ruby"
-      - "package.json"
-      - "yarn.lock"
   pull_request:
     paths-ignore:
       - "**.[jt]sx?"


### PR DESCRIPTION
Currently, we run tests on pushes. Since we use PRs for any of the prod branches, this is redundant and fills up the build resources for no reasons.
