### PR TITLE
Removed a deprecated arg for DatabaseCleaner

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,7 +106,7 @@ RSpec.configure do |config|
   config.include ActionMailerMatchers
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation, reset_ids: true)
+    DatabaseCleaner.clean_with(:truncation)
     Rails.application.load_seed
   end
 


### PR DESCRIPTION
We get a warning on the latest version of DatabaseCleaner so this addresses that﻿
