### PR TITLE
Update TargetRubyVersion in rubocop to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - db/**/*
     - tmp/**/*


### PR DESCRIPTION
Rubocop TargetRubyVersion was accidentally 2.6﻿ even though we're on 2.7. This change corrects this.
