### PR TITLE
Move rubocop into its own workflow 

### DIFF
--- a/.github/workflows/placeholders.yml
+++ b/.github/workflows/placeholders.yml
@@ -45,3 +45,12 @@ jobs:
         ruby: [2.7.4]
     steps:
       - run: 'echo "Placeholder for main_build"'
+  rubocop:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        node: [14.6.0]
+        ruby: [2.7.4]
+    steps:
+      - run: 'echo "Placeholder for rubocop"'

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,7 +46,42 @@ jobs:
           cd gems/bess
           bundle exec rake spec
       - run: bin/setup ci
-      - name: rubocop
-        run: bundle exec rubocop
       - name: run spec
         run: bin/rails spec
+  rubocop:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        node: [14.6.0]
+        ruby: [2.7.4]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Install Code Scanning integration
+        run: bundle add code-scanning-rubocop --skip-install
+
+      - name: Install dependencies
+        run: |
+          bundle config unset deployment # we added code-scanning-rubocop but on deployment mode, this won't work.
+          bundle config path vendor/bundle
+          bundle install --jobs 4
+      - name: Rubocop run
+        run: |
+          bash -c "
+            bundle exec rubocop --require code_scanning --format CodeScanning::SarifFormatter -o rubocop.sarif
+            [[ $? -ne 2 ]]
+          "
+      - name: Upload Sarif output
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: rubocop.sarif
+
+    


### PR DESCRIPTION
I moved rubocop out into a separate workflow job and integrated with the code scanning functionality of Github. Not sure this is the best design but I'm submitting it here for review for us to decide.

What do you think @clarissalimab ?