### PR TITLE
Add a cacheable package download to big workflows

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -8,7 +8,25 @@ on:
       - "**.md"
     types: [opened, reopened, synchronize]
 jobs:
+  package-download: # this downloads and caches all of the packages. That way if a future job fails, the caching will still occur
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        node: [14.6.0]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.ruby }}
+          bundler-cache: true
   lint:
+    needs: package-download
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -35,6 +53,7 @@ jobs:
       - name: run eslint
         run: yarn eslint
   jest:
+    needs: package-download
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -61,6 +80,7 @@ jobs:
       - name: run jest
         run: yarn jest
   webpack:
+    needs: package-download
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,26 @@ on:
       - "yarn.lock"
     types: [opened, reopened, synchronize]
 jobs:
+  package-download: # this downloads and caches all of the packages. That way if a future job fails, the caching will still occur
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        node: [14.6.0]
+        ruby: [2.7.4]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
   main_build:
+    needs: package-download
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -49,6 +68,7 @@ jobs:
       - name: run spec
         run: bin/rails spec
   rubocop:
+    needs: package-download
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Previously, if a bundler or yarn cache didn't exist, each job would concurrently try to download the packages. Additionally, some of these workflows would fail so the cached packages would have be regenerated on the next build. This moves package downloading into its own job. As long as the packages download, they'll be cached. Big workflow tasks will depend on the package download job.
