### PR TITLE
Reduce TS member ordering in eslint to warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -83,7 +83,7 @@ module.exports = {
 		"comma-dangle": "off",
 		"@typescript-eslint/comma-dangle": ["error", "always-multiline"],
 		"@typescript-eslint/no-unused-vars": ['error', { "args": "all", "argsIgnorePattern": "^_" }],
-		'@typescript-eslint/member-ordering': ['error',
+		'@typescript-eslint/member-ordering': ['warn',
 			{
 				// this is the default from @typescript-eslint itself
 				"default": {


### PR DESCRIPTION
Currently, in Houdini, we force eslint to ﻿error when Typescript members are not ordered in a particular way. Generally, I think we should follow a guideline but it's super annoying doing it this way because it's not fixable automatically
