### PR TITLE
Only use eslint-jest/style and ./recommended rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,12 +11,15 @@ const tsSpecBase = {
 	extends: [
 		'eslint:recommended',
 		'plugin:@typescript-eslint/recommended',
-		'plugin:jest/all',
+		'plugin:jest/recommended',
+		'plugin:jest/style',
 		'plugin:react-hooks/recommended',
 	],
 	rules: {
 		"jest/lowercase-name": ["error", { "ignore": ["describe"] }],
 		"react-hooks/exhaustive-deps": 'error',
+		"jest/no-duplicate-hooks": 'error',
+		"jest/prefer-hooks-on-top": 'warning',
 	},
 };
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ const tsSpecBase = {
 		"jest/lowercase-name": ["error", { "ignore": ["describe"] }],
 		"react-hooks/exhaustive-deps": 'error',
 		"jest/no-duplicate-hooks": 'error',
-		"jest/prefer-hooks-on-top": 'warning',
+		"jest/prefer-hooks-on-top": 'warn',
 	},
 };
 


### PR DESCRIPTION
Currently, we're use all eslint-plugin-jest rules and some of them aren't that useful. I tried to move the few that are useful into the config.
