### PR TITLE
Add support for turbo_test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,7 +66,7 @@ jobs:
           bundle exec rake spec
       - run: bin/setup ci
       - name: run spec
-        run: bin/rails spec
+        run: bundle exec turbo_test -n 2
   rubocop:
     needs: package-download
     runs-on: ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development, :ci, :test do
   gem 'rubocop-rake', '~> 0.6.0'
   gem 'rubocop-rspec', '~> 2.6'
   gem 'shoulda-matchers', '~> 5.0.0'
+  gem 'turbo_test'
 end
 
 group :ci, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,6 +112,15 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
+    async (1.30.1)
+      console (~> 1.10)
+      nio4r (~> 2.3)
+      timers (~> 4.1)
+    async-container (0.16.12)
+      async
+      async-io
+    async-io (1.32.2)
+      async
     bcrypt (3.1.16)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
@@ -122,6 +131,8 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
+    console (1.13.1)
+      fiber-local
     countries (4.0.1)
       i18n_data (~> 0.13.0)
       sixarm_ruby_unaccent (~> 1.1)
@@ -162,6 +173,7 @@ GEM
       railties (>= 5.0.0)
     fast_blank (1.0.1)
     ffi (1.15.4)
+    fiber-local (1.0.0)
     font_assets (0.1.14)
       rack
     fugit (1.5.2)
@@ -221,6 +233,7 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
+    mapping (1.1.1)
     marcel (1.0.2)
     method_source (1.0.0)
     mime-types (3.3.1)
@@ -369,6 +382,9 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.3)
       ffi (~> 1.12)
+    samovar (2.1.4)
+      console (~> 1.0)
+      mapping (~> 1.0)
     sassc (2.4.0)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
@@ -396,8 +412,15 @@ GEM
     thor (1.1.0)
     tilt (2.0.10)
     timecop (0.9.4)
+    timers (4.3.3)
     traceroute (0.8.1)
       rails (>= 3.0.0)
+    turbo_test (0.1.2)
+      async-container
+      async-io
+      msgpack
+      rspec
+      samovar
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -488,6 +511,7 @@ DEPENDENCIES
   test-unit (~> 3.5)
   timecop (~> 0.9.4)
   traceroute (~> 0.8.0)
+  turbo_test
   validate_url
   webmock (~> 3.14)
   webpacker (~> 5.4.3)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -953,6 +953,32 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** rubocop-ast; version 1.13.0 -- 
+
+Copyright (c) 2012-20 Bozhidar Batsov
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------
+
 ** rake; version 12.3.3 -- 
 Copyright Jim Weirich.
 Copyright (c) Jim Weirich
@@ -2881,8 +2907,20 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ** activerecord; version 6.1.4.1 -- 
 copyright (c) 2007-2016 Nick Kallen, Bryan Helmkamp, Emilio Tagua, Aaron Patterson
+** async; version 1.30.1 -- 
+Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
+** async-container; version 0.16.12 -- 
+Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
+** async-io; version 1.32.2 -- 
 ** coderay; version 1.1.3 -- 
 Copyright (c) 2005-2012 Kornelius Kalnbach <murphy@rubychan.de>
+** console; version 1.13.1 -- 
+Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
 ** crack; version 0.4.5 -- 
 Copyright (c) 2004-2008 David Heinemeier Hansson
 ** css_parser; version 1.9.0 -- 
@@ -2890,6 +2928,7 @@ Copyright (c) 2007-11 Alex Dunae
 ** database_cleaner; version 1.99.0 -- 
 ** devise; version 4.8.0 -- 
 Copyright 2009-2019 Plataformatec.
+** fiber-local; version 1.0.0 -- 
 ** http-accept; version 1.7.0 -- 
 Copyright (c) 2016, Matthew Kerwin <matthew@kerwin.net.au>
 Copyright, 2016, by Matthew Kerwin (http://kerwin.net.au).
@@ -2934,6 +2973,14 @@ Copyright Kickstarter, PBC.
 Copyright (c) 2013-2015 Kasper Timm Hansen
 ** rails-html-sanitizer; version 1.4.2 -- 
 Copyright (c) 2013-2015 Rafael Mendonca Franca, Kasper Timm Hansen
+** rubocop-rspec; version 2.6.0 -- 
+** samovar; version 2.1.4 -- 
+Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
+Copyright, 2016, by Samuel G. D. Williams (http://www.codeotaku.com/samuel-williams).
+** timers; version 4.3.3 -- 
+Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
+** turbo_test; version 0.1.2 -- 
 ** unicode-display_width; version 2.1.0 -- 
 ** wisper; version 2.0.1 -- 
 Copyright (c) 2013 Kris Leech
@@ -4749,3 +4796,73 @@ See the file docs/artistic.txt in the main distribution.
 
 === GNU GPL version 2
 See the file docs/COPYING.txt in the main distribution.
+
+
+------
+
+** test-unit; version 3.5.1 -- 
+
+test-unit is copyrighted free software by Kouhei Sutou
+<kou@cozmixng.org>, Ryan Davis <ryand-ruby@zenspider.com>
+and Nathaniel Talbott <nathaniel@talbott.ws>.
+
+You can redistribute it and/or modify it under either the terms of the
+2-clause BSDL (see the file BSDL), or the conditions below:
+
+1. You may make and give away verbatim copies of the source form of the
+   software without restriction, provided that you duplicate all of the
+   original copyright notices and associated disclaimers.
+
+2. You may modify your copy of the software in any way, provided that
+   you do at least ONE of the following:
+
+   a. place your modifications in the Public Domain or otherwise
+      make them Freely Available, such as by posting said
+      modifications to Usenet or an equivalent medium, or by allowing
+      the author to include your modifications in the software.
+
+   b. use the modified software only within your corporation or
+      organization.
+
+   c. give non-standard binaries non-standard names, with
+      instructions on where to get the original software distribution.
+
+   d. make other distribution arrangements with the author.
+
+3. You may distribute the software in object code or binary form,
+   provided that you do at least ONE of the following:
+
+   a. distribute the binaries and library files of the software,
+      together with instructions (in the manual page or equivalent)
+      on where to get the original distribution.
+
+   b. accompany the distribution with the machine-readable source of
+      the software.
+
+   c. give non-standard binaries non-standard names, with
+      instructions on where to get the original software distribution.
+
+   d. make other distribution arrangements with the author.
+
+4. You may modify and include the part of the software into any other
+   software (possibly commercial).  But some files in the distribution
+   are not written by the author, so that they are not under these terms.
+
+   For the list of those files and their copying conditions, see the
+   file LEGAL.
+
+5. The scripts and library files supplied as input to or produced as
+   output from the software do not automatically fall under the
+   copyright of the software, but belong to whomever generated them,
+   and may be sold commercially, and may be aggregated with this
+   software.
+
+6. THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+   PURPOSE.
+
+Exceptions
+----------
+
+  * lib/test/unit/diff.rb: This license and PSF license

--- a/spec/lib/format/name_spec.rb
+++ b/spec/lib/format/name_spec.rb
@@ -7,12 +7,9 @@ require 'format/name'
 
 describe Format::Name do
   describe '.email_from_np' do
-    before(:each) do
-      Houdini.hoster.support_email = 'support@email.com'
-    end
     it 'gives the name, minus commas, with our email in brackets' do
       result = Format::Name.email_from_np('Test, X, Y')
-      expect(result).to eq('"Test X Y" <support@email.com>')
+      expect(result).to eq("\"Test X Y\" <#{Houdini.hoster.support_email}>")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -106,7 +106,7 @@ RSpec.configure do |config|
   config.include ActionMailerMatchers
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with(:truncation, except: %w(ar_internal_metadata))
     Rails.application.load_seed
   end
 

--- a/turbo_test.rb
+++ b/turbo_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+# based on code at: https://github.com/ioquatix/turbo_test/issues/6
+ENV['RAILS_ENV'] = 'test'
+
+worker do |index|
+	index += 1
+	ENV['TEST_ENV_NUMBER'] = index == 1 ? '' : index.to_s
+	ENV['RAILS_ENV'] = 'test'
+	system('bin/rails', 'db:environment:set', 'RAILS_ENV=test')
+	system('bin/rails', 'db:drop', 'db:create', 'db:schema:load')
+end


### PR DESCRIPTION
[turbo_test](https://github.com/ioquatix/turbo_test) is a parallelized spec runner. It shrinks build time from 8-10 minutes to 3 on my computer.

This is a draft PR to look at how well this actually works in practice.

Follow-up: after testing, we found it works well on my computer but doesn't help on the build. Therefore, we don't use it on the build but make it available to developers on their own machines.
