### PR TITLE
Correcting permissions on the dependent-issues workflow

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -22,22 +22,21 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-permissions:
-  actions: none
-  checks: none
-  contents: none
-  deployments: none
-  issues: write
-  discussions: none
-  packages: none
-  pull-requests: write
-  repository-projects: none
-  security-events: none
-  statuses: none
-
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: write
+      discussions: none
+      packages: none
+      pull-requests: write
+      repository-projects: none
+      security-events: none
+      statuses: write
     steps:
       - uses: z0al/dependent-issues@v1
         env:


### PR DESCRIPTION
After the [Updating workflow permissions](https://github.com/houdiniproject/houdini/pull/821) pull request merge, Eric stated a bug on dependent issues, so this is a correction made by changing statuses permission

Correct bug stated on [Permissions are too high in .github/workflows/dependent-issues.yml](https://github.com/houdiniproject/houdini/issues/718)

Closes #718