### PR TITLE
Rename the id param in APIs to transaction_id and create a `current_transaction` concern

### DIFF
--- a/app/controllers/api/transactions_controller.rb
+++ b/app/controllers/api/transactions_controller.rb
@@ -5,7 +5,7 @@
 
 # A controller for interacting with a nonprofit's supporters
 class Api::TransactionsController < Api::ApiController
-	include Controllers::Nonprofit::Current
+	include Controllers::Api::Transaction::Current
 	include Controllers::Nonprofit::Authorization
 	before_action :authenticate_nonprofit_user!
 
@@ -18,6 +18,6 @@ class Api::TransactionsController < Api::ApiController
 	# Gets the a single nonprofit supporter
 	# If not logged in, causes a 401 error
 	def show
-		@transaction = current_nonprofit.transactions.find(params[:id])
+		@transaction = current_transaction
 	end
 end

--- a/app/controllers/concerns/controllers/api/transaction/current.rb
+++ b/app/controllers/concerns/controllers/api/transaction/current.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+module Controllers::Api::Transaction::Current
+	extend ActiveSupport::Concern
+	include Controllers::Nonprofit::Current
+
+	included do
+		private
+
+		def current_transaction
+			@current_transaction ||= current_nonprofit.transactions.find(params[:transaction_id])
+		end
+	end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
           resources :supporter_notes, only: [:index, :show]
         end
         resources :tag_definitions, only: [:index, :show]
-        resources :transactions, only: [:index, :show]
+        resources :transactions, only: [:index, :show], param: :transaction_id
       end
 
       resources :users, only: [] do

--- a/spec/controllers/concerns/api/transaction/current_spec.rb
+++ b/spec/controllers/concerns/api/transaction/current_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+require 'rails_helper'
+
+describe 'Controllers::Api::Transaction::Current', type: :controller do
+	let(:transaction) { force_create(:transaction_for_donation) }
+	let(:nonprofit) { transaction.nonprofit }
+
+	controller(Api::ApiController) do
+		include Controllers::Api::Transaction::Current
+
+		def index
+			render json: {
+				transaction: current_transaction.id
+			}
+		end
+	end
+
+	it 'gets transaction if found' do
+		get :index, params: { nonprofit_id: nonprofit.id, transaction_id: transaction.id }
+		expect(JSON.parse(response.body)).to eq(
+			{
+				'transaction' => transaction.id
+			}
+		)
+	end
+
+	it 'throw RecordNotFound if not found' do
+		expect do
+			get :index, params: { nonprofit_id: nonprofit.id, transaction_id: 124_124_905 }
+		end.to raise_error(ActiveRecord::RecordNotFound)
+	end
+end


### PR DESCRIPTION
Currently, we use the id param in the API for the last item in a route. For example, if you wanted a transaction via the API, it would be `﻿/api/nonprofits/:nonprofit_id/transactions/:id`. This is normally fine but it gets awkward when you have a nested resource. Then it becomes: `/api/nonprofits/:nonprofit_id/transactions/:transaction_id/subtransactions/:id`. This makes it difficult have a single method like `current_transaction` to get the current transaction because the param being checked varies.

This PR changes changes the routes so use  `/api/nonprofits/:nonprofit/transactions/:transaction_id`. This also allows us to create a concern to get current transaction via `current_transaction`.
