### PR TITLE
Remove activestorage from eslint and add missing licenses on TS type defs

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -59,7 +59,6 @@ app/javascript/legacy_react/src/lib/vjf_rules.ts
 app/javascript/packs/loading_indicator.ts
 types/dotize/index.d.ts
 types/mobx-react-form/index.d.ts
-types/rails__activestorage/index.d.ts
 types/react-aria-modal/index.d.ts
 
 # old js files

--- a/types/rails__activestorage/index.d.ts
+++ b/types/rails__activestorage/index.d.ts
@@ -1,3 +1,4 @@
+// License: MIT (the same as Activestorage itself)
 import {start, DirectUpload, DirectUploadDelegate, Blob} from 'activestorage';
 
 export {start, DirectUpload, DirectUploadDelegate, Blob};

--- a/types/storybook-addon-intl/index.d.ts
+++ b/types/storybook-addon-intl/index.d.ts
@@ -1,3 +1,4 @@
+// License: MIT (the same as storybook-addon-intl itself)
 
 export declare function setIntlConfig(...unknown);
 export declare function withIntl(...unknown);

--- a/types/storybook-addon-intl/shared.d.ts
+++ b/types/storybook-addon-intl/shared.d.ts
@@ -1,3 +1,4 @@
+// License: MIT (the same as storybook-addon-intl itself)
 declare module 'storybook-addon-intl/shared' {
   export declare const EVENT_SET_CONFIG_ID:string;
   export declare const EVENT_GET_LOCALE_ID:string;


### PR DESCRIPTION
There were some missing licenses on some TS types definitions. I've marked them as having the license of the packages they describe and I don't see how that's a problem; we could go with LGPL﻿ but that seems wrong since it seems like the types for a package should match that package.
