### PR TITLE
Update node dependencies with security vulnerabilities

### DIFF
--- a/NOTICE-js
+++ b/NOTICE-js
@@ -339,178 +339,6 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ------
 
-** @houdiniproject/react-i18n-currency-input; version 2.0.0 -- 
-
-                   GNU LESSER GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-
-  This version of the GNU Lesser General Public License incorporates
-the terms and conditions of version 3 of the GNU General Public
-License, supplemented by the additional permissions listed below.
-
-  0. Additional Definitions.
-
-  As used herein, "this License" refers to version 3 of the GNU Lesser
-General Public License, and the "GNU GPL" refers to version 3 of the GNU
-General Public License.
-
-  "The Library" refers to a covered work governed by this License,
-other than an Application or a Combined Work as defined below.
-
-  An "Application" is any work that makes use of an interface provided
-by the Library, but which is not otherwise based on the Library.
-Defining a subclass of a class defined by the Library is deemed a mode
-of using an interface provided by the Library.
-
-  A "Combined Work" is a work produced by combining or linking an
-Application with the Library.  The particular version of the Library
-with which the Combined Work was made is also called the "Linked
-Version".
-
-  The "Minimal Corresponding Source" for a Combined Work means the
-Corresponding Source for the Combined Work, excluding any source code
-for portions of the Combined Work that, considered in isolation, are
-based on the Application, and not on the Linked Version.
-
-  The "Corresponding Application Code" for a Combined Work means the
-object code and/or source code for the Application, including any data
-and utility programs needed for reproducing the Combined Work from the
-Application, but excluding the System Libraries of the Combined Work.
-
-  1. Exception to Section 3 of the GNU GPL.
-
-  You may convey a covered work under sections 3 and 4 of this License
-without being bound by section 3 of the GNU GPL.
-
-  2. Conveying Modified Versions.
-
-  If you modify a copy of the Library, and, in your modifications, a
-facility refers to a function or data to be supplied by an Application
-that uses the facility (other than as an argument passed when the
-facility is invoked), then you may convey a copy of the modified
-version:
-
-   a) under this License, provided that you make a good faith effort to
-   ensure that, in the event an Application does not supply the
-   function or data, the facility still operates, and performs
-   whatever part of its purpose remains meaningful, or
-
-   b) under the GNU GPL, with none of the additional permissions of
-   this License applicable to that copy.
-
-  3. Object Code Incorporating Material from Library Header Files.
-
-  The object code form of an Application may incorporate material from
-a header file that is part of the Library.  You may convey such object
-code under terms of your choice, provided that, if the incorporated
-material is not limited to numerical parameters, data structure
-layouts and accessors, or small macros, inline functions and templates
-(ten or fewer lines in length), you do both of the following:
-
-   a) Give prominent notice with each copy of the object code that the
-   Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the object code with a copy of the GNU GPL and this license
-   document.
-
-  4. Combined Works.
-
-  You may convey a Combined Work under terms of your choice that,
-taken together, effectively do not restrict modification of the
-portions of the Library contained in the Combined Work and reverse
-engineering for debugging such modifications, if you also do each of
-the following:
-
-   a) Give prominent notice with each copy of the Combined Work that
-   the Library is used in it and that the Library and its use are
-   covered by this License.
-
-   b) Accompany the Combined Work with a copy of the GNU GPL and this license
-   document.
-
-   c) For a Combined Work that displays copyright notices during
-   execution, include the copyright notice for the Library among
-   these notices, as well as a reference directing the user to the
-   copies of the GNU GPL and this license document.
-
-   d) Do one of the following:
-
-       0) Convey the Minimal Corresponding Source under the terms of this
-       License, and the Corresponding Application Code in a form
-       suitable for, and under terms that permit, the user to
-       recombine or relink the Application with a modified version of
-       the Linked Version to produce a modified Combined Work, in the
-       manner specified by section 6 of the GNU GPL for conveying
-       Corresponding Source.
-
-       1) Use a suitable shared library mechanism for linking with the
-       Library.  A suitable mechanism is one that (a) uses at run time
-       a copy of the Library already present on the user's computer
-       system, and (b) will operate properly with a modified version
-       of the Library that is interface-compatible with the Linked
-       Version.
-
-   e) Provide Installation Information, but only if you would otherwise
-   be required to provide such information under section 6 of the
-   GNU GPL, and only to the extent that such information is
-   necessary to install and execute a modified version of the
-   Combined Work produced by recombining or relinking the
-   Application with a modified version of the Linked Version. (If
-   you use option 4d0, the Installation Information must accompany
-   the Minimal Corresponding Source and Corresponding Application
-   Code. If you use option 4d1, you must provide the Installation
-   Information in the manner specified by section 6 of the GNU GPL
-   for conveying Corresponding Source.)
-
-  5. Combined Libraries.
-
-  You may place library facilities that are a work based on the
-Library side by side in a single library together with other library
-facilities that are not Applications and are not covered by this
-License, and convey such a combined library under terms of your
-choice, if you do both of the following:
-
-   a) Accompany the combined library with a copy of the same work based
-   on the Library, uncombined with any other library facilities,
-   conveyed under the terms of this License.
-
-   b) Give prominent notice with the combined library that part of it
-   is a work based on the Library, and explaining where to find the
-   accompanying uncombined form of the same work.
-
-  6. Revised Versions of the GNU Lesser General Public License.
-
-  The Free Software Foundation may publish revised and/or new versions
-of the GNU Lesser General Public License from time to time. Such new
-versions will be similar in spirit to the present version, but may
-differ in detail to address new problems or concerns.
-
-  Each version is given a distinguishing version number. If the
-Library as you received it specifies that a certain numbered version
-of the GNU Lesser General Public License "or any later version"
-applies to it, you have the option of following the terms and
-conditions either of that published version or of any later version
-published by the Free Software Foundation. If the Library as you
-received it does not specify a version number of the GNU Lesser
-General Public License, you may choose any version of the GNU Lesser
-General Public License ever published by the Free Software Foundation.
-
-  If the Library as you received it specifies that a proxy can decide
-whether future versions of the GNU Lesser General Public License shall
-apply, that proxy's public statement of acceptance of any version is
-permanent authorization for you to choose that version for the
-Library.
-
-
-
-------
-
 ** @npmcli/move-file; version 1.0.1 -- https://github.com/npm/move-file#readme
 Copyright (c) npm, Inc.
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
@@ -1511,6 +1339,1722 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+------
+
+** @houdiniproject/react-i18n-currency-input; version 2.0.0 -- 
+(c) 2017
+(c) by W3C
+(c) Object C
+(c) Zeno Rocha
+Copyright 2014
+(c) Luke Childs
+(c) John Otander
+(c) Titus Wormer
+(c) Sindre Sorhus
+(c) Bogdan Chadkin
+Copyright (c) 2014
+Copyright (c) 2015
+Copyright (c) 2016
+Copyright (c) 2017
+Copyright Grant. I
+Copyright Isaac Z.
+Copyright npm, Inc
+(c) Eugene Sharygin
+(c) (c) (r) (R) (tm)
+(c) 2011 Gary Court.
+(c) Dustin Diaz 2015
+Copyright (c) Google
+Copyright 2015 Airbnb
+Copyright 2017 Smooth
+Copyright Google Inc.
+Copyright (c) 2016 Baz
+Copyright (c) Rod Vagg
+Copyright Joyent, Inc.
+(c) 2006 VeriSign, Inc.
+Copyright (c) 2011-2017
+Copyright (c) 2011-2018
+Copyright (c) 2016 W.Y.
+Copyright (c) 2016-2018
+Copyright (c) npm, Inc.
+Copyright 2015 AJ ONeal
+Jordan Harband (c) 2013
+(c) 2013 Mikola Lysenko.
+(c) 2018 Denis Pushkarev
+(c) 2019 Denis Pushkarev
+Copyright (c) 2017 Anton
+Copyright (c) Felix Bohm
+Copyright (c) Meryn Stol
+Copyright (c) Zeno Rocha
+Copyright Caolan McMahon
+copyright Tobias Koppers
+copyright copysource cor
+(c) 2011, Charlie Robbins
+(c) 2011-2015 John Hewson
+(c) 2014 J. C. Phillipps.
+(c) Compositor and Vercel
+Copyright (c) 2005 Tom Wu
+Copyright (c) 2013 - 2014
+Copyright (c) 2015 - 2016
+Copyright (c) 2016 Airbnb
+Copyright (c) 2018 WHATWG
+Copyright (c) Chad Walker
+Copyright 2016 Trent Mick
+(c) Microsoft Corporation.
+Copyright (c) 2012 Raynos.
+Copyright (c) 2013 Raynos.
+Copyright (c) 2014 LevelUP
+Copyright (c) 2014 PostCSS
+Copyright 2011 Gary Court.
+Copyright 2013 Google Inc.
+Copyright 2013 Naitik Shah
+Copyright 2014 Google Inc.
+Copyright 2014 Yahoo! Inc.
+Copyright 2015 Yahoo! Inc.
+Copyright 2015, Yahoo Inc.
+Copyright 2016, Joyent Inc
+Copyright 2017 Kat Marchan
+(c) Korporatsiia Maikrosoft
+Copyright (c) 2012 Colingo.
+Copyright (c) 2013 Colingo.
+Copyright (c) 2013 Ryan Day
+Copyright (c) 2014 Rod Vagg
+Copyright (c) 2015 AJ ONeal
+Copyright (c) 2015 Rod Vagg
+Copyright (c) 2017 SysGears
+Copyright (c) 2018 LitoMore
+Copyright (c) Marak Squires
+Copyright 2012 Joyent, Inc.
+Copyright 2013 Mathias Buus
+Copyright 2015 Glen Maddern
+Copyright 2015 Joyent, Inc.
+Copyright 2015, Dustin Diaz
+Copyright 2015, Yahoo! Inc.
+Copyright 2016 Joyent, Inc.
+Copyright 2017 Joyent, Inc.
+Copyright 2018 Glen Maddern
+Copyright 2018 Joyent, Inc.
+copyright 2016 Titus Wormer
+Copyright (c) 2012 Lea Verou
+Copyright (c) 2012 Rob Burns
+Copyright (c) 2013 Braveg1rl
+Copyright (c) 2013 Max Ogden
+Copyright (c) 2013 Tim Perry
+Copyright (c) 2014 Component
+Copyright (c) 2015 Sam Mikes
+Copyright (c) 2015, Wes Todd
+Copyright (c) 2015, npm, Inc
+Copyright (c) 2016 Denis Rul
+Copyright (c) 2017 Braveg1rl
+Copyright (c) James Halliday
+Copyright (c) Tobias Koppers
+Copyright 2017 JS Foundation
+Copyright 2017 Kirollos Risk
+Copyright 2018 Stefan Penner
+Copyright Isaac Z. Schlueter
+copyright 2012-2018 AJ ONeal
+(c) 2013-2015, Facebook, Inc.
+Copyright (c) 2010 Kris Kowal
+Copyright (c) 2011 LearnBoost
+Copyright (c) 2012 Artur Adib
+Copyright (c) 2013 Meryn Stol
+Copyright (c) 2014 Nadav Ivgi
+Copyright (c) 2015 JD Ballard
+Copyright (c) 2015 Jed Watson
+Copyright (c) 2015 Kiko Beats
+Copyright (c) 2015 TypeStrong
+Copyright (c) 2016 Mael Nison
+Copyright (c) 2016 Zeit, Inc.
+Copyright (c) 2017 CoderPuppy
+Copyright (c) 2019 Inspect JS
+Copyright (c) 2019 Tan Li Hau
+Copyright (c) 2019 TypeStrong
+Copyright (c) Federico Zivolo
+Copyright (c) George Zahariev
+Copyright (c) Nikita Vasilyev
+Copyright 2015 Calvin Metcalf
+Copyright 2018 Kilian Valkhof
+Copyright (c) 2003-2005 Tom Wu
+Copyright (c) 2005-2009 Tom Wu
+Copyright (c) 2009 Google Inc.
+Copyright (c) 2010 Sencha Inc.
+Copyright (c) 2011 Google Inc.
+Copyright (c) 2011 Mark Cavage
+Copyright (c) 2011 Sencha Inc.
+Copyright (c) 2012 Google Inc.
+Copyright (c) 2012 Mark Cavage
+Copyright (c) 2012 Tim Caswell
+Copyright (c) 2013 Andrey Popp
+Copyright (c) 2013 Aria Minaei
+Copyright (c) 2013 Dulin Marat
+Copyright (c) 2013 Google Inc.
+Copyright (c) 2013 Joyent Inc.
+Copyright (c) 2013 Trent Mick.
+Copyright (c) 2014 Aria Minaei
+Copyright (c) 2014 Google Inc.
+Copyright (c) 2015 Aria Minaei
+Copyright (c) 2015 Bryan Braun
+Copyright (c) 2015 Dan Abramov
+Copyright (c) 2015 David Clark
+Copyright (c) 2015 John Hiesey
+Copyright (c) 2015 Joyent Inc.
+Copyright (c) 2015 Rich Harris
+Copyright (c) 2015 Steven Chim
+Copyright (c) 2016 Alex Indigo
+Copyright (c) 2016 David Frank
+Copyright (c) 2016 John Hiesey
+Copyright (c) 2017 Ilya Kantor
+Copyright (c) 2017 Jed Watson.
+Copyright (c) 2017 Kat Marchan
+Copyright (c) 2017 Luke Childs
+Copyright (c) 2017 Xiaoyi Chen
+Copyright (c) 2018 Matt Steele
+Copyright (c) 2019 Ian Schmitz
+Copyright 2009-2017 Kris Kowal
+Copyright 2014 Julien Fontanet
+Copyright 2014 Marten de Vries
+Copyright 2017 Cameron Lakenen
+Copyright Fedor Indutny, 2014.
+Copyright Fedor Indutny, 2015.
+copyright 2016 Federico Zivolo
+Copyright (c) 2009 Gerard Paapu
+Copyright (c) 2010 Elijah Insua
+Copyright (c) 2010 Ryan McGrath
+Copyright (c) 2011 Dominic Tarr
+Copyright (c) 2011 Rick Waldron
+Copyright (c) 2011 Sami Samhuri
+Copyright (c) 2011 Tom Robinson
+Copyright (c) 2011 VMware, Inc.
+Copyright (c) 2012, Joshua Bell
+Copyright (c) 2012-2014 Raynos.
+Copyright (c) 2013 Dominic Tarr
+Copyright (c) 2013 Jonathan Ong
+Copyright (c) 2013 Simon Lydell
+Copyright (c) 2014 Elan Shanker
+Copyright (c) 2014 Evan Wallace
+Copyright (c) 2014 Hugh Kennedy
+Copyright (c) 2014 IndigoUnited
+Copyright (c) 2014 Jonathan Ong
+Copyright (c) 2014 Mathias Buus
+Copyright (c) 2014 Simon Lydell
+Copyright (c) 2014, Yahoo! Inc.
+Copyright (c) 2015 Cedric Dugas
+Copyright (c) 2015 Elan Shanker
+Copyright (c) 2015 Kiran Abburi
+Copyright (c) 2015 Lucas Wiener
+Copyright (c) 2015 Mathias Buus
+Copyright (c) 2015 Titus Wormer
+Copyright (c) 2015 Tyler Kellen
+Copyright (c) 2015, Scott Motte
+Copyright (c) 2015, Yahoo! Inc.
+Copyright (c) 2016 Lucas Wiener
+Copyright (c) 2016 Mathias Buus
+Copyright (c) 2016, Scott Motte
+Copyright (c) 2017 Jason Miller
+Copyright (c) 2017 Scott Corgan
+Copyright (c) 2017 SysGears INC
+Copyright (c) 2018 Huafu Gandon
+Copyright (c) 2018 Mathias Buus
+Copyright (c) 2018 Nik Coughlin
+Copyright (c) 2018 React Popper
+Copyright (c) 2018 Scott Taylor
+Copyright (c) 2018 Tobias Reich
+Copyright (c) 2019 John Otander
+Copyright (c) Denis Malinochkin
+Copyright 2007-2009 Tyler Close
+Copyright 2012-2015 Yahoo! Inc.
+Copyright 2012-2015, Yahoo Inc.
+Copyright 2013 Thorsten Lorenz.
+Copyright 2014 Simon Lydell X11
+Copyright 2015 (c) Visoft, Inc.
+copyright (c) 2012 Kir Belevich
+copyright (c) 2013 Dave Porter.
+(c) Mike Bostock <mike@ocks.org>
+Copyright (c) 2008 Ariel Flesler
+Copyright (c) 2010 Kit Cambridge
+Copyright (c) 2012, Joyent, Inc.
+Copyright (c) 2013 ESHA Research
+Copyright (c) 2013, Dominic Tarr
+Copyright (c) 2014 Stefan Thomas
+Copyright (c) 2014, Naitik Shah.
+Copyright (c) 2015 Andreas Lubbe
+Copyright (c) 2015 Brian Donovan
+Copyright (c) 2015 Dmitry Ivanov
+Copyright (c) 2015 ESHA Research
+Copyright (c) 2015 Eric McCarthy
+Copyright (c) 2015 Javier Blanco
+Copyright (c) 2015, Glen Maddern
+Copyright (c) 2016 Kevin Gravier
+Copyright (c) 2016 Michael Pratt
+Copyright (c) 2016 Sean Matheson
+Copyright (c) 2016 Sultan Tarimo
+Copyright (c) 2016, Joyent, Inc.
+Copyright (c) 2017 ESHA Research
+Copyright (c) 2017 JS Foundation
+Copyright (c) 2017 Kent C. Dodds
+Copyright (c) 2017 Mikael Brevik
+Copyright (c) 2017 Simen Bekkhus
+Copyright (c) 2018 Michael Pratt
+Copyright (c) 2019 Andres Suarez
+Copyright (c) 2019 ESHA Research
+Copyright (c) 2019 ZHAO Jinxiang
+Copyright (c) EventSource GitHub
+Copyright (c) Isaac Z. Schlueter
+copyright Louis-Dominique Dubeau
+(c) John Smith <email@domain.com>
+(c) extraPathPercentEncodeSet.has
+Copyright (c) 2006, Ivan Sagalaev
+Copyright (c) 2011 Daniel Friesen
+Copyright (c) 2011 TJ Holowaychuk
+Copyright (c) 2012 James Halliday
+Copyright (c) 2012 Kenji Urushima
+Copyright (c) 2012 Robert Kieffer
+Copyright (c) 2012 Simon Boudrias
+Copyright (c) 2012 TJ Holowaychuk
+Copyright (c) 2012 Tobias Koppers
+Copyright (c) 2013 James Halliday
+Copyright (c) 2013 Jordan Harband
+Copyright (c) 2013 Mikola Lysenko
+Copyright (c) 2013 Roman Shtylman
+Copyright (c) 2013 Stephen Sugden
+Copyright (c) 2014 Daniel Cousens
+Copyright (c) 2014 Jameson Little
+Copyright (c) 2014 Jeremie Miller
+Copyright (c) 2014 Jordan Harband
+Copyright (c) 2014 KARASZI Istvan
+Copyright (c) 2014 Robert Kieffer
+Copyright (c) 2014 Simon Boudrias
+Copyright (c) 2015 Calvin Metcalf
+Copyright (c) 2015 Daniel Cousens
+Copyright (c) 2015 Jonathan Nicol
+Copyright (c) 2015 Jordan Harband
+Copyright (c) 2015 Matteo Collina
+Copyright (c) 2016 Brian Woodward
+Copyright (c) 2016 Jordan Harband
+Copyright (c) 2016 Misha Moroshko
+Copyright (c) 2016 Sebastian Mayr
+Copyright (c) 2016-2018 Ari Porad
+Copyright (c) 2017 Artur Kenzhaev
+Copyright (c) 2017 Calvin Metcalf
+Copyright (c) 2017 Jordan Harband
+Copyright (c) 2017 Mauro Bringolf
+Copyright (c) 2018 Jason Mulligan
+Copyright (c) 2018 Jordan Harband
+Copyright (c) 2018 Szymon Marczak
+Copyright (c) 2018 Trevor Brindle
+Copyright (c) 2018, ESHA Research
+Copyright (c) 2019 Anton Zinovyev
+Copyright (c) 2019 Conor Hastings
+Copyright (c) 2019 Jordan Harband
+Copyright (c) 2019 Michael Peyper
+Copyright (c) Feross Aboukhadijeh
+Copyright 2017 - Refael Ackermann
+(c) 2016 Copyright (c) 2005 Tom Wu
+(c) Zaripov Yura <yur4ik7@ukr.net>
+Copyright (c) 2011 Florian Schafer
+Copyright (c) 2011 Quildreen Motta
+Copyright (c) 2011 Steven Levithan
+Copyright (c) 2011 by Jimmy Cuadra
+Copyright (c) 2012 Charlie Robbins
+Copyright (c) 2012 Federico Romero
+Copyright (c) 2013 Forbes Lindesay
+Copyright (c) 2013 Josh Glazebrook
+Copyright (c) 2014 Arnout Kazemier
+Copyright (c) 2014 Federico Romero
+Copyright (c) 2014 Forbes Lindesay
+Copyright (c) 2015 Eugene Sharygin
+Copyright (c) 2015 Jon Schlinkert.
+Copyright (c) 2015, Facebook, Inc.
+Copyright (c) 2015, Rebecca Turner
+Copyright (c) 2016 Eugene Sharygin
+Copyright (c) 2016 James Messinger
+Copyright (c) 2016 Kirill Fomichev
+Copyright (c) 2017 Cameron Lakenen
+Copyright (c) 2017, Jon Schlinkert
+Copyright (c) 2018 Dmitry Shirokov
+Copyright (c) 2018 Formidable Labs
+Copyright (c) 2018, Aleck Greenham
+Copyright (c) 2018, Jason Mulligan
+copyright (c) 2019 Denis Pushkarev
+Copyright (c) 2010 Cowboy Ben Alman
+Copyright (c) 2011 by Roly Fentanes
+Copyright (c) 2011-2012 Tim Caswell
+Copyright (c) 2011-2015 John Hewson
+Copyright (c) 2012 Montillet Xavier
+Copyright (c) 2012 by Vitaly Puzrin
+Copyright (c) 2013 Cowboy Ben Alman
+Copyright (c) 2013 Thiago de Arruda
+Copyright (c) 2015 EcmaScript Shims
+Copyright (c) 2015 Kyle E. Mitchell
+Copyright (c) 2015 Robin Frischmann
+Copyright (c) 2015, Jon Schlinkert.
+Copyright (c) 2015-2018 Steven Chim
+Copyright (c) 2016, Jon Schlinkert.
+Copyright (c) 2017 Domenic Denicola
+Copyright (c) 2017 ECMAScript Shims
+Copyright (c) 2017 Khaled Al-Ansari
+Copyright (c) 2017 Robin Frischmann
+Copyright (c) 2018 Tamino Martinius
+Copyright 2008 Fair Oaks Labs, Inc.
+Copyright 2011 The Closure Compiler
+Copyright 2012 Irakli Gozalishvili.
+Copyright (c) 2007-2017 Diego Perini
+Copyright (c) 2007-2019 Diego Perini
+Copyright (c) 2008-2011 Pivotal Labs
+Copyright (c) 2008-2016 Pivotal Labs
+Copyright (c) 2012-2016 Kir Belevich
+Copyright (c) 2013-2014 Jonathan Ong
+Copyright (c) 2013-2017 Jared Hanson
+Copyright (c) 2014 Jeremiah Senkpiel
+Copyright (c) 2014, Domenic Denicola
+Copyright (c) 2015 Joris van der Wel
+Copyright (c) 2016 Espen Hovlandsdal
+Copyright (c) 2016 Evgeny Poberezkin
+Copyright (c) 2017 Evgeny Poberezkin
+Copyright (c) 2017 Michel Weststrate
+Copyright (c) Microsoft Corporation.
+Copyright 2013 The Chromium Authors.
+copyright (c) 2013-2014 Dave Porter.
+(c) Jeremy Hull <sourdrums@gmail.com>
+(c) Luke Edwards (https://lukeed.com)
+(c) Sindre Sorhus Copyright 2009-2015
+(c) Titus Wormer (https://wooorm.com)
+Copyright (c) 1991-2017 Unicode, Inc.
+Copyright (c) 2009 Raymond Hettinger.
+Copyright (c) 2010-2012 Mikeal Rogers
+Copyright (c) 2011-2017 JP Richardson
+Copyright (c) 2012 Isaac Z. Schlueter
+Copyright (c) 2013 Jose F. Romaniello
+Copyright (c) 2013-2018 Petka Antonov
+Copyright (c) 2013-2019 Petka Antonov
+Copyright (c) 2014 Phillip Gates-Idem
+Copyright (c) 2014-2018 Suguru Motegi
+Copyright (c) 2015, Espen Hovlandsdal
+Copyright (c) 2015, Forrest L Norvell
+Copyright (c) 2015-2016 JP Richardson
+Copyright (c) 2015-present Evan Scott
+Copyright (c) 2016-2018 Kevin Gravier
+Copyright (c) 2017 JakubPawlowicz.com
+Copyright (c) 2017-2018 Fredrik Nicol
+Copyright (c) 2018 Made With MOXY Lda
+Copyright (c) 2018 Michael Mclaughlin
+(c) 2018 Angry Bytes and contributors.
+(c) Ben Drucker (http://bendrucker.me)
+(c) Microsoft Corporation. Alle Rechte
+(c) Microsoft Corporation. Bao Liu Suo
+Copyright ( (c ) )? (year)s Google Inc
+Copyright (c) 2009-2013 TJ Holowaychuk
+Copyright (c) 2010-2018 Caolan McMahon
+Copyright (c) 2011 Alexander Shtuchkin
+Copyright (c) 2012-2013 TJ Holowaychuk
+Copyright (c) 2012-2014 Andris Reinman
+Copyright (c) 2012-2014 Roman Shtylman
+Copyright (c) 2012-2014 TJ Holowaychuk
+Copyright (c) 2012-2016 Tobias Koppers
+Copyright (c) 2013, Deoxxa Development
+Copyright (c) 2013-2014 TJ Holowaychuk
+Copyright (c) 2015 Thomas Watson Steen
+Copyright (c) 2015-2016 Sebastian Mayr
+Copyright (c) 2016 Thomas Watson Steen
+(c) Aahan Krish <geekpanth3r@gmail.com>
+(c) Dmitriy Tarasov <dimatar@gmail.com>
+(c) Terkel Gjervig (https://terkel.com)
+Copyright (c) 1992-2004 by P.J. Plauger
+Copyright (c) 2009-2011 Michael Ficarra
+Copyright (c) 2010-2014 Bruce Williams.
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2015 Thorsten Lorenz
+Copyright (c) 2013 Digital Bazaar, Inc.
+Copyright (c) 2013-2017 Josh Glazebrook
+Copyright (c) 2014 Digital Bazaar, Inc.
+Copyright (c) 2014-2016 Matt Zabriskie.
+Copyright (c) 2014-2016 Zoltan Frombach
+Copyright (c) 2015 Tiancheng Timothy Gu
+Copyright (c) 2015-2017 Jon Schlinkert.
+Copyright (c) 2016, 2018 Linus Unneback
+Copyright (c) 2019 Digital Bazaar, Inc.
+Copyright 2012 The Obvious Corporation.
+(c) Gustavo Costa <gusbemacbe@gmail.com>
+Copyright (c) 2008, Fair Oaks Labs, Inc.
+Copyright (c) 2010, Digital Bazaar, Inc.
+Copyright (c) 2011-2015 by Vitaly Puzrin
+Copyright (c) 2012 The Chromium Authors.
+Copyright (c) 2014-2015, Jon Schlinkert.
+Copyright (c) 2014-2016, Jon Schlinkert.
+Copyright (c) 2014-2017, Jon Schlinkert.
+Copyright (c) 2014-2018, Jon Schlinkert.
+Copyright (c) 2015 Alexandre Kirszenberg
+Copyright (c) 2015, Salesforce.com, Inc.
+Copyright (c) 2015-2016, Jon Schlinkert.
+Copyright (c) 2015-2017, Jon Schlinkert.
+Copyright (c) 2015-2018, Jon Schlinkert.
+Copyright (c) 2015-2019 by Roman Dvornov
+Copyright (c) 2016-2017, Brian Woodward.
+Copyright (c) 2016-2017, Jon Schlinkert.
+Copyright (c) 2016-2018, Jon Schlinkert.
+Copyright (c) 2016-2019 by Roman Dvornov
+Copyright (c) 2016-present Matt Phillips
+Copyright (c) 2018, Salesforce.com, Inc.
+Copyright (c) npm, Inc. and Contributors
+Copyright 2008-2013 Digital Bazaar, Inc.
+Copyright 2011-2016 Digital Bazaar, Inc.
+Copyright 2011-2017 Digital Bazaar, Inc.
+(c) Ivan Nikolic (http://ivannikolic.com)
+(c) James Kyle (https://thejameskyle.com)
+(c) Kiko Beats (http://www.kikobeats.com)
+(c) Vasily Polovnyov <vast@whiteants.net>
+Copyright (c) 2010, Linden Research, Inc.
+Copyright (c) 2015, 2017, Jon Schlinkert.
+Copyright (c) 2015-2017 Evgeny Poberezkin
+Copyright (c) 2016, 2018, Jon Schlinkert.
+Copyright (c) 2018 Terkel Gjervig Nielsen
+Copyright (c) 2018 The Khronos Group Inc.
+Copyright (c) 2018-present, Ryan Florence
+Copyright (c) James Long and contributors
+Copyright 2018 The New York Times Company
+(c) 2011 Creative Commons Zero Google Inc.
+(c) Vladimir Epifanov <voldmar@voldmar.ru>
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2013-present, Facebook, Inc.
+Copyright (c) 2014-present, Facebook, Inc.
+Copyright (c) 2015-present Jon Schlinkert.
+Copyright (c) 2015-present, Facebook, Inc.
+Copyright (c) 2016, Istanbul Code Coverage
+Copyright (c) 2016-present, Facebook, Inc.
+(c) Jason Miller (https://jasonformat.com/)
+(c) Javier Blanco (http://jbgutierrez.info)
+(c) Microsoft Corporation. Zhu Zuo Quan Suo
+(c) Sindre Sorhus (http://sindresorhus.com)
+Copyright (c) 2013-2018 sha.js contributors
+Copyright (c) 2014-present, Jon Schlinkert.
+Copyright (c) 2015-2016 Thomas Watson Steen
+Copyright (c) 2015-present, Brian Woodward.
+Copyright (c) 2015-present, Jon Schlinkert.
+Copyright (c) 2016-2018 Thomas Watson Steen
+Copyright (c) 2017-present, Jon Schlinkert.
+Copyright 2016-2017 Sebastian Software GmbH
+copyrighted by the Free Software Foundation
+(c) Sindre Sorhus (https://sindresorhus.com)
+Copyright (c) 2008-2013 Digital Bazaar, Inc.
+Copyright (c) 2009-2010 Raynos Jake Verbaten
+Copyright (c) 2009-2012 Digital Bazaar, Inc.
+Copyright (c) 2009-2013 Digital Bazaar, Inc.
+Copyright (c) 2009-2014 Digital Bazaar, Inc.
+Copyright (c) 2009-2015 Digital Bazaar, Inc.
+Copyright (c) 2010-2012 Digital Bazaar, Inc.
+Copyright (c) 2010-2013 Digital Bazaar, Inc.
+Copyright (c) 2010-2014 Digital Bazaar, Inc.
+Copyright (c) 2010-2015 Digital Bazaar, Inc.
+Copyright (c) 2010-2018 Digital Bazaar, Inc.
+Copyright (c) 2010-2019 Juriy kangax Zaytsev
+Copyright (c) 2011-2014 Digital Bazaar, Inc.
+Copyright (c) 2012-2014 Digital Bazaar, Inc.
+Copyright (c) 2012-2015 Digital Bazaar, Inc.
+Copyright (c) 2013-2014 Digital Bazaar, Inc.
+Copyright (c) 2013-2018 Viacheslav Lotsmanov
+Copyright (c) 2014-2015 Digital Bazaar, Inc.
+Copyright (c) 2017-2019 Digital Bazaar, Inc.
+Copyright 2018 Eemeli Aro <eemeli@gmail.com>
+(c) 1995-2013 Jean-loup Gailly and Mark Adler
+(c) Angel Garcia <angelgarcia.mail@gmail.com>
+Copyright (c) 2000 Lars Knoll (knoll@kde.org)
+Copyright (c) 2000-2006, The Perl Foundation.
+Copyright (c) 2007-2014, Alexandru Marasteanu
+Copyright (c) 2009 John Resig, Jorn Zaefferer
+Copyright (c) 2013-2018, Viacheslav Lotsmanov
+Copyright (c) 2014 Douglas Christopher Wilson
+Copyright (c) 2015 Douglas Christopher Wilson
+Copyright (c) 2016 Douglas Christopher Wilson
+Copyright (c) Julian Viereck and Contributors
+Copyright 2009-2017 Kristopher Michael Kowal.
+Copyright Isaac Z. Schlueter and Contributors
+(c) Ivan Sagalaev <Maniac@SoftwareManiacs.Org>
+(c) Ivan Sagalaev <maniac@softwaremaniacs.org>
+(c) Julien Fontanet (http://julien.isonoe.net)
+(c) Kevin Martensson (http://github.com/kevva)
+(c) silverwind (https://github.com/silverwind)
+Copyright (c) 2011-2015 by Sergey Kryzhanovsky
+Copyright (c) 2014-2015, 2017, Jon Schlinkert.
+Copyright (c) 2015 Unshift.io, Arnout Kazemier
+Copyright (c) 2015, 2017-2018, Jon Schlinkert.
+Copyright (c) James Talmage <james@talmage.io>
+Copyright 2010 LearnBoost <dev@learnboost.com>
+Copyright 2011 Mark Cavage <mcavage@gmail.com>
+Copyright 2015 Luis Rudge <luis@luisrudge.net>
+Copyright 2018 Copyright 2014 Simon Lydell X11
+Copyright JS Foundation and other contributors
+(c) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
+(c) Kevin Martensson (https://github.com/kevva)
+(c) Vsevolod Strukchinsky (floatdrop@gmail.com)
+Copyright (c) 2012-2014 by various contributors
+Copyright (c) 2012-2018 by various contributors
+Copyright (c) 2014-2017 createECDH contributors
+Copyright (c) 2017-present by Andrea Giammarchi
+Copyright (c) Ben Drucker <bvdrucker@gmail.com>
+Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+Copyright 2013 Andrey Sitnik <andrey@sitnik.ru>
+Copyright 2017 Andrey Sitnik <andrey@sitnik.ru>
+(c) Tristian Kelly <tristian.kelly560@gmail.com>
+Copyright (c) 2004 Sam Hocevar <sam@hocevar.net>
+Copyright (c) 2013 Pieroxy <pieroxy@pieroxy.net>
+Copyright (c) 2015 Vitaly Puzrin, Alex Kocharin.
+Copyright (c) 2016 Kadira Inc. <hello@kadira.io>
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io>
+Copyright (c) Facebook, Inc. and its affiliates.
+(c) Vasily Mikhailitchenko <vaskas@programica.ru>
+Copyright (c) 2009 Thomas Robinson <280north.com>
+Copyright (c) 2012 Ben Ripkens http://bripkens.de
+Copyright (c) 2012 LearnBoost <tj@learnboost.com>
+Copyright (c) 2012-2018 Aseem Kishore, and others
+Copyright (c) 2013 Ted Unangst <tedu@openbsd.org>
+Copyright (c) 2015 Jed Watson <jed.watson@me.com>
+Copyright (c) 2017 crypto-browserify contributors
+Copyright (c) Bogdan Chadkin <trysound@yandex.ru>
+Copyright (c) Emotion team and other contributors
+Copyright (c) Isaac Z. Schlueter and Contributors
+Copyright (c) John Hiesey and other contributors.
+Copyright 2010 James Halliday (mail@substack.net)
+Copyright 2014, 2015, 2016, 2017 Simon Lydell X11
+Copyright Louis-Dominique Dubeau and contributors
+(c) James Talmage (http://github.com/jamestalmage)
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
+Copyright (c) 2010 LearnBoost <dev@learnboost.com>
+Copyright (c) 2012 Ben Newman <bn@cs.stanford.edu>
+Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
+Copyright (c) 2014 Ben Newman <bn@cs.stanford.edu>
+Copyright (c) 2014 Ivan Nikulin <ifaaan@gmail.com>
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+Copyright (c) 2015-2016 Douglas Christopher Wilson
+Copyright (c) 2016 Domenic Denicola <d@domenic.me>
+Copyright (c) 2016-2017 Douglas Christopher Wilson
+Copyright (c) 2017, crypto-browserify contributors
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com>
+Copyright (c) Mathias Pettersson and Brian Hammond
+Copyright 2011 Mozilla Foundation and contributors
+Copyright 2012 Stefan Siegl <stesie@brokenpipe.de>
+Copyright 2014 Copyright (c) 2011 Andrei Mackenzie
+Copyright 2014 Mozilla Foundation and contributors
+Copyright 2018 Logan Smyth <loganfsmyth@gmail.com>
+(c) Petka Antonov, John-David Dalton, Sindre Sorhus
+Copyright (c) 2011 Troy Goode <troygoode@gmail.com>
+Copyright (c) 2014 Azer Koculu <azer@roadbeats.com>
+Copyright (c) 2014 Petka Antonov 2015 Sindre Sorhus
+Copyright (c) 2014-2017 browserify-aes contributors
+Copyright (c) 2016 Federico Zivolo and contributors
+Copyright (c) Ivan Nikolic <http://ivannikolic.com>
+Copyright 2010 - 2014 Sami Samhuri sami@samhuri.net
+Copyright 2014, 2015, 2016, 2017, 2018 Simon Lydell
+Copyright Joyent, Inc. and other Node contributors.
+(c) 2015 Ari Porad (@ariporad) <http://ariporad.com>
+Copyright (c) 2012 Kris Kowal <kris.kowal@cixar.com>
+Copyright (c) 2012, Artur Adib <arturadib@gmail.com>
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014, Rebecca Turner <me@re-becca.org>
+Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>
+Copyright (c) 2015 Hannah von Reth <vonreth@kde.org>
+Copyright (c) 2015, Rebecca Turner <me@re-becca.org>
+Copyright (c) 2017, Rebecca Turner <me@re-becca.org>
+Copyright (c) Elan Shanker and Node.js contributors.
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com>
+Copyright 2006, Kevin Krammer <kevin.krammer@gmx.at>
+Copyright 2011, Sebastian Tschan https://blueimp.net
+Copyright Mathias Bynens <https://mathiasbynens.be/>
+Copyright (c) 2007 Kris Zyp SitePen (www.sitepen.com)
+Copyright (c) 2012 James Halliday <mail@substack.net>
+Copyright (c) 2012-2016 Eloy Duran, Julien Blanchard.
+Copyright (c) 2013 James Halliday (mail@substack.net)
+Copyright (c) 2014-2015 Calvin Metcalf & contributors
+Copyright (c) 2014-2015 Jon Schlinkert, contributors.
+Copyright (c) 2014-2017 Calvin Metcalf & contributors
+Copyright (c) 2016 Ben Noordhuis <info@bnoordhuis.nl>
+Copyright (c) 2017 Lupo Montero lupomontero@gmail.com
+Copyright (c) 2017, Nicolai Kamenzky and contributors
+Copyright (c) 2018-2019 Titus Wormer and John Otander
+Copyright (c) 2019, Nicolai Kamenzky and contributors
+Copyright (c) Feross Aboukhadijeh (http://feross.org)
+Copyright 2006, Jeremy White <jwhite@codeweavers.com>
+Copyright (c) 2010 XXX TODO Gozala Irakli Gozalishvili
+Copyright (c) 2011 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2012 J. Ryan Stinnett <jryans@gmail.com>
+Copyright (c) 2012 John Freeman <jfreeman08@gmail.com>
+Copyright (c) 2012 Stefan Siegl <stesie@brokenpipe.de>
+Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2012-2017 Kirollos Risk (http://kiro.me)
+Copyright (c) 2013 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2013 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015 Ingvar Stepanyan <me@rreverser.com>
+Copyright (c) 2015 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) Jorge Bucaran <https://jorgebucaran.com>
+Copyright (c) Kat Marchan, npm, Inc., and Contributors
+Copyright 2012 (c) Mihai Bazon <mihai.bazon@gmail.com>
+(c) Sam Verschueren (https://github.com/SamVerschueren)
+(c) Vsevolod Strukchinsky (http://github.com/floatdrop)
+Copyright (c) 1989, 1991 Free Software Foundation, Inc.
+Copyright (c) 1995-2003 by Internet Software Consortium
+Copyright (c) 1995-2013 Jean-loup Gailly and Mark Adler
+Copyright (c) 1998 - 2009, Paul Johnston & Contributors
+Copyright (c) 2011-2016, Heather Arthur and Josh Junon.
+Copyright (c) 2012 Nathan Cartwright <fshost@yahoo.com>
+Copyright (c) 2013-2014 Scott Sauyet and Michael Hurley
+Copyright (c) 2013-2016 Domenic Denicola <d@domenic.me>
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
+Copyright (c) 2014-2019 Luis Couto <hello@luiscouto.pt>
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2016-2018 Domenic Denicola <d@domenic.me>
+Copyright (c) 2017 Eric Wendelin and other contributors
+Copyright (c) 2017 JS Foundation and other contributors
+Copyright (c) 2017 Lupo Montero <lupomontero@gmail.com>
+Copyright (c) 2017 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2017-2018 Domenic Denicola <d@domenic.me>
+Copyright (c) 2018 Ahmad Nassri <ahmad@ahmadnassri.com>
+Copyright (c) Ellis Pritchard, Guardian Unlimited 2003.
+Copyright 2009-2011 Mozilla Foundation and contributors
+Copyright 2013 Michael Hart (michael.hart.au@gmail.com)
+copyright Ben Newman <https://github.com/benjamn/reify>
+Copyright (c) 2012 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2012-2013 Mathias Bynens <mathias@qiwi.be>
+Copyright (c) 2013 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2014 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2015 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2015, Ahmad Nassri <ahmad@ahmadnassri.com>
+Copyright (c) 2017, Ryan Zimmerman <opensrc@ryanzim.com>
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+Copyright 2009-2010, Fathi Boudra <fabo@freedesktop.org>
+copyright ahmadnassri.com (https://www.ahmadnassri.com/)
+Copyright (c) 2010 CLA - DomenicDenicola Domenic Denicola
+Copyright (c) 2013 Alex Seville <hi@alexanderseville.com>
+Copyright (c) 2013 Irakli Gozalishvili <rfobic@gmail.com>
+Copyright (c) 2013-2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015-present Sergey Berezhnoy <veged@ya.ru>
+Copyright (c) 2017-2019 Compositor, Inc. and Vercel, Inc.
+Copyright (c) Sam Verschueren <sam.verschueren@gmail.com>
+Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com>
+Copyright 2010, 2011, Chris Winberry <chris@winberry.net>
+Copyright 2013-2016 by Paul Miller (http://paulmillr.com)
+Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
+Copyright (c) 2012 Ariya Hidayat <ariya.hidayat@gmail.com>
+Copyright (c) 2012 Nathan Rajlich <nathan@tootallnate.net>
+Copyright (c) 2012, 2013 Thorsten Lorenz <thlorenz@gmx.de>
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com>
+Copyright (c) 2013 Ramesh Nair (http://www.hiddentao.com/)
+Copyright (c) 2014 Aleksandr Tsertkov <tsertkov@gmail.com>
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+Copyright (c) 2014 Thiago de Arruda <tpadilha84@gmail.com>
+Copyright (c) 2015 Julian Gruber <julian@juliangruber.com>
+Copyright (c) 2017 Alberto Leal <mailforalberto@gmail.com>
+Copyright (c) Feross Aboukhadijeh, and other contributors.
+Copyright (c) Kevin Martensson <kevinmartensson@gmail.com>
+Copyright 2012 The Obvious Corporation. http://obvious.com
+Copyright (c) 2007-2019 Diego Perini (http://www.iport.it/)
+Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2012-2014 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2013-2015 Benjamin Tan. https://d10.github.io
+Copyright (c) 2013-2015 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2014-2016 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com>
+Copyright (c) 2017-present James Kyle <me@thejameskyle.com>
+Copyright 1997 Niels Provos <provos@physnet.uni-hamburg.de>
+Copyright 2009-2010, Rex Dieter <rdieter@fedoraproject.org>
+Copyright 2012-2016, JP Richardson <jprichardson@gmail.com>
+Copyright 2012-2018 (c) Mihai Bazon <mihai.bazon@gmail.com>
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc.
+Copyright (c) 2009-2011, Mozilla Foundation and contributors
+Copyright (c) 2011 Debuggable Limited <felix@debuggable.com>
+Copyright (c) 2014-2015 Devon Govett <devongovett@gmail.com>
+Copyright (c) 2014-2017 by Vitaly Puzrin and Andrei Tuputcyn
+Copyright (c) 2015, Ilya Radchenko <ilya@burstcreations.com>
+Copyright (c) 2015-2016 Titus Wormer <tituswormer@gmail.com>
+Copyright (c) 2016 - 2020 Brian Hough and Maximilian Stoiber
+Copyright (c) 2017 Menglin Mark Xu <mark@remarkablemark.org>
+Copyright (c) 2017 Samuel Reed <samuel.trace.reed@gmail.com>
+copyright 2018 Jason Mulligan <jason.mulligan@avoidwork.com>
+(c) 2013 Rod Vagg <rod@vagg.org> https://github.com/rvagg/prr
+Copyright (c) 2010-2016 Robert Kieffer and other contributors
+Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
+Copyright (c) 2011-2017 KARASZI Istvan <github@spam.raszi.hu>
+Copyright (c) 2012 Arpad Borsos <arpad.borsos@googlemail.com>
+Copyright (c) 2012 Vitaly Puzrin (https://github.com/puzrin).
+Copyright (c) 2012-2013 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2012-2014 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2012-2015 Kit Cambridge. http://kitcambridge.be
+Copyright (c) 2013 Rod Vagg rvagg (https://twitter.com/rvagg)
+Copyright (c) 2013-2014 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (c) 2014 Rod Vagg rvagg (https://twitter.com/rvagg)
+Copyright (c) 2014, 2015, 2016, 2017, 2018, 2019 Simon Lydell
+Copyright (c) 2015 Rod Vagg rvagg (https://twitter.com/rvagg)
+Copyright (c) Michael Ciniawsky <michael.ciniawsky@gmail.com>
+Copyright (c) Tjarda Koster, https://jelloween.deviantart.com
+Copyright 2009-2017 Kristopher Michael Kowal and contributors
+Copyright 2012-2014, Kit Cambridge http://kit.mit-license.org
+Copyright 2015 Mark Dalgleish <mark.john.dalgleish@gmail.com>
+Copyright (c) 2010-2015 Linux Foundation and its Contributors.
+Copyright (c) 2014 Lautaro Cozzani <lautaro.cozzani@scytl.com>
+Copyright (c) 2016, Brian Woodward (https://github.com/doowb).
+Copyright (c) 2017 Tiancheng Timothy Gu and other contributors
+Copyright (c) 2017, Brian Woodward (https://github.com/doowb).
+Copyright (c) 2017-present Sven Greb <development@svengreb.de>
+Copyright (c) 2019, Brian Woodward (https://github.com/doowb).
+Copyright (c) 2011-2012 Ariya Hidayat <ariya.hidayat@gmail.com>
+Copyright (c) 2012 Artur Adib http://github.com/shelljs/shelljs
+Copyright (c) 2012-2015, JP Richardson <jprichardson@gmail.com>
+Copyright (c) 2016 Christian Speckner <cnspeckn@googlemail.com>
+Copyright (c) 2019 Angelos Pikoulas <agelos.pikoulas@gmail.com>
+Copyright (c) 2019 W3C and Jeff Carpenter jeffcarp@chromium.org
+Copyright (c) Steven Vachon <contact@svachon.com> (svachon.com)
+Copyright (c) 2014 James Talmage <james.talmage@jrtechnical.com>
+Copyright (c) 2002-2008 Kris Kowal <http://cixar.com/~kris.kowal>
+Copyright (c) 2009-2016 Kristopher Michael Kowal and contributors
+Copyright (c) 2014 Jeremiah Senkpiel <fishrock123@rocketmail.com>
+Copyright (c) 2017 Sergey Rubanov (https://github.com/chicoxyzzy)
+Copyright (c) Isaac Z. Schlueter, Ben Noordhuis, and Contributors
+Copyright (c) 2012 Yusuke Suzuki (http://github.com/Constellation)
+Copyright (c) 2013 Yusuke Suzuki (http://github.com/Constellation)
+Copyright (c) 2015 JP Richardson (https://github.com/jprichardson)
+Copyright (c) 2018-present Mohsin Ul Haq <mohsinulhaq01@gmail.com>
+Copyright (c) Luke Edwards <luke.edwards05@gmail.com> (lukeed.com)
+Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+Copyright (c) 2012 Joost-Wim Boekesteijn <joost-wim@boekesteijn.nl>
+Copyright (c) 2015 y18n version 4.0.0 https://github.com/yargs/y18n
+Copyright (c) Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
+(c) 2013-2016 Scott Sauyet, Michael Hurley, and David Chambers Ramda
+(c) Ahmad Awais <https://twitter.com/mrahmadawais/> link GitHub Repo
+Copyright (c) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+Copyright (c) 2014-2017 Calvin Metcalf, Fedor Indutny & contributors
+Copyright (c) 2014-2019 Angelos Pikoulas (agelos.pikoulas@gmail.com)
+Copyright (c) 2014-present Sebastian McKenzie and other contributors
+Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com
+(c) Zeno Rocha des.js version 1.0.1 https://github.com/indutny/des.js
+Copyright (c) 2012 Robert Gust-Bardon <donate@robert.gust-bardon.org>
+Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
+Copyright (c) 2016 test-exclude version 5.2.3 https://istanbul.js.org
+Copyright (c) 2016, Jon Schlinkert (http://github.com/jonschlinkert).
+Copyright JS Foundation and other contributors, https://js.foundation
+Copyright (c) 2014 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright 2014 Andrey Sitnik <andrey@sitnik.ru> and other contributors
+Copyright (c) 2011-2017 JP Richardson (https://github.com/jprichardson)
+Copyright (c) 2014-2015 Calvin Metcalf and browserify-sign contributors
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+Copyright (c) Stephen Sugden <me@stephensugden.com> (stephensugden.com)
+Copyright (c) npm, Inc. ssri version 6.0.1 https://github.com/zkat/ssri
+Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/)
+(c) Pavel Pertsev (original style at https://github.com/morhetz/gruvbox)
+(c) Zeno Rocha growly version 1.3.0 https://github.com/theabraham/growly
+Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors
+Copyright (c) 2014-2016 Jonathan Ong me@jongleberry.com and Contributors
+Copyright (c) 2016 Yehuda Katz, Tom Dale, Stefan Penner and contributors
+Copyright jQuery Foundation and other contributors <https://jquery.org/>
+HCopyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/)
+JCopyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/)
+NCopyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/)
+copyright year 69cbf7a (https://github.com/PrismJS/prism/commit/69cbf7a)
+iCopyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/)
+oCopyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/)
+Copyright (c) 2013 Richardson & Sons, LLC (http://richardsonandsons.com/)
+Copyright (c) 2014-2015 Jon Schlinkert (https://github.com/jonschlinkert)
+Copyright (c) 2015-2016 Douglas Christopher Wilson doug@somethingdoug.com
+Copyright 2018 Sebastian Software GmbH (http://www.sebastian-software.de)
+Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
+Copyright (c) npm, Inc. libnpm version 2.0.1 https://github.com/npm/libnpm
+Copyright (c) 2010-2016 Charlie Robbins, Jarrett Cruger & the Contributors.
+Copyright (c) 2013-2016 Paul Miller (http://paulmillr.com) and contributors
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) 2016-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+Copyright (c) George Zahariev prelude-ls version 1.1.2 http://preludels.com
+Copyright 2012-2015, Kit Cambridge, Benjamin Tan http://kit.mit-license.org
+Copyright (c) 2012 - 2015 Copyright (c) node-modules and other contributors.
+Copyright (c) 2016 Mael Nison popper.js version 1.16.1 https://popper.js.org
+Copyright (c) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc.
+Copyright (c) 2010 - 2016 Charlie Robbins, Jarrett Cruger & the Contributors.
+Copyright (c) 2012 Felix Geisendorfer (felix@debuggable.com) and contributors
+Copyright (c) 2012 Barnesandnoble.com, llc, Donavon West, and Domenic Denicola
+Copyright (c) 2016 Lucas Wiener https://github.com/wnr/element-resize-detector
+Copyright (c) 2017-present Arctic Ice Studio <development@arcticicestudio.com>
+Copyright (c) 2017-present, Jon Schlinkert (https://github.com/jonschlinkert).
+Copyright (c) Feross Aboukhadijeh (http://feross.org), and other contributors.
+Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
+Copyright npm, Inc libnpmorg version 1.0.1 https://npmjs.com/package/libnpmorg
+(c) Zeno Rocha select-hose version 2.0.0 https://github.com/indutny/select-hose
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
+Copyright (c) 2012 Yusuke Suzuki (twitter Constellation) and other contributors.
+Copyright (c) 2012-2013 Michael Ficarra <escodegen.copyright@michael.ficarra.me>
+Copyright (c) 2018 Copyright 2018 Klaus Hartl, Fagner Brack, GitHub Contributors
+Copyright (c) Felix Bohm css-what version 3.3.0 https://github.com/fb55/css-what
+Copyright (c) Felix Bohm domutils version 1.7.0 https://github.com/FB55/domutils
+Copyright (c) Felix Bohm entities version 1.1.2 https://github.com/fb55/entities
+Copyright npm, Inc libnpmteam version 1.0.2 https://npmjs.com/package/libnpmteam
+Copyright 2014 Simon Lydell X11 urix version 0.1.0 https://github.com/lydell/urix
+Copyright npm, Inc unique-slug version 2.0.2 https://github.com/iarna/unique-slug
+Copyright (c) npm, Inc. libnpmhook version 5.0.3 https://github.com/npm/libnpmhook
+Copyright 2015-present Facebook, Inc. ejs version 2.7.4 https://github.com/mde/ejs
+Copyright (c) 2016 set-blocking version 2.0.0 https://github.com/yargs/set-blocking
+Copyright (c) 2011 Copyright (c) 2009-2016 Kristopher Michael Kowal and contributors
+Copyright (c) 2012 Raynos. dom-walk version 0.1.2 https://github.com/Raynos/dom-walk
+Copyright (c) 2012 Raynos. duplexer version 0.1.1 https://github.com/Raynos/duplexer
+Copyright (c) 2013-2016 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
+Copyright (c) 2014 Mathias Buus pump version 3.0.0 https://github.com/mafintosh/pump
+Copyright (c) 2016 yargs-parser version 10.1.0 https://github.com/yargs/yargs-parser
+Copyright (c) 2017 Luke Childs keyv version 3.1.0 https://github.com/lukechilds/keyv
+Copyright (c) Felix Bohm domhandler version 2.4.2 https://github.com/fb55/DomHandler
+Copyright (c) Rod Vagg rvagg (https://twitter.com/rvagg) and additional contributors
+Copyright npm, Inc libnpmconfig version 1.2.1 https://npmjs.com/package/libnpmconfig
+Copyright npm, Inc libnpmsearch version 2.0.2 https://npmjs.com/package/libnpmsearch
+Copyright (c) 2011-2018 Copyright 2012-2014, Kit Cambridge http://kit.mit-license.org
+Copyright (c) 2012-2013 Yusuke Suzuki (twitter Constellation) and other contributors.
+Copyright (c) 2015-2018 Google, Inc., Netflix, Inc., Microsoft Corp. and contributors
+Copyright (c) 2016 which-module version 2.0.0 https://github.com/nexdrew/which-module
+Copyright (c) Tobias Koppers tapable version 1.1.3 https://github.com/webpack/tapable
+Copyright (c) 2015 Tim Caswell (https://github.com/creationix) and other contributors.
+Copyright 2012-2015, Yahoo Inc. istanbul-reports version 2.2.7 https://istanbul.js.org
+Copyright npm, Inc libnpmpublish version 1.1.3 https://npmjs.com/package/libnpmpublish
+Copyright (c) 2019 Inspect JS is-set version 2.0.1 https://github.com/inspect-js/is-set
+Copyright Fedor Indutny, 2015. brorand version 1.1.0 https://github.com/indutny/brorand
+Copyright Fedor Indutny, 2015. hash.js version 1.1.7 https://github.com/indutny/hash.js
+(c) 2012-2015 http://kitcambridge.be/ Kit Cambridge, https://d10.github.io/ Benjamin Tan
+Copyright (c) 2014, Naitik Shah. tmpl version 1.0.4 https://github.com/nshah/nodejs-tmpl
+Copyright (c) 2017 Kat Marchan protoduck version 5.0.1 https://github.com/zkat/protoduck
+Copyright (c) George Zahariev optionator version 0.8.3 https://github.com/gkz/optionator
+Copyright (c) George Zahariev type-check version 0.3.2 https://github.com/gkz/type-check
+Copyright (c) npm, Inc. figgy-pudding version 3.5.2 https://github.com/npm/figgy-pudding
+Copyright Fedor Indutny, 2015. stable version 0.1.8 https://github.com/Two-Screen/stable
+Copyright Mathias Bynens <https://mathiasbynens.be/> he version 1.2.0 https://mths.be/he
+Copyright (c) 2013-2017 Jared Hanson < http://jaredhanson.net/ (http://jaredhanson.net/)>
+Copyright (c) 2015 Phil Cockfield <phil@cockfield.net> (https://github.com/philcockfield)
+Copyright 2012-2015, Yahoo Inc. istanbul-lib-report version 2.0.8 https://istanbul.js.org
+Copyright Fedor Indutny, 2017. hpack.js version 2.1.6 https://github.com/indutny/hpack.js
+Copyright npm, Inc unique-filename version 1.1.1 https://github.com/iarna/unique-filename
+Copyright (c) 2014 Mathias Buus pumpify version 1.5.1 https://github.com/mafintosh/pumpify
+Copyright (c) Facebook, Inc. and its affiliates. jest-cli version 24.9.0 https://jestjs.io
+Copyright (c) Facebook, Inc. and its affiliates. react version 16.13.1 https://reactjs.org
+Copyright (c) Isaac Z. Schlueter inherits version 2.0.4 https://github.com/isaacs/inherits
+Copyright (c) npm, Inc. npm-logical-tree version 1.2.1 https://github.com/npm/logical-tree
+Copyright 2013 Andrey Sitnik <andrey@sitnik.ru> postcss version 7.0.32 https://postcss.org
+Copyright (c) 2012, Joyent, Inc. jsprim version 1.4.1 https://github.com/joyent/node-jsprim
+Copyright (c) 2014 Jordan Harband is-regex version 1.1.0 https://github.com/ljharb/is-regex
+Copyright (c) 2017 randomfill version 1.0.4 https://github.com/crypto-browserify/randomfill
+Copyright (c) Denis Malinochkin fast-glob version 2.2.7 https://github.com/mrmlnc/fast-glob
+Copyright (c) YEAR W3C(r) (MIT, ERCIM, Keio, Beihang). Disclaimers THIS WORK IS PROVIDED AS
+Copyright Fedor Indutny, 2014. chokidar version 2.1.8 https://github.com/paulmillr/chokidar
+Copyright Fedor Indutny, 2014. hmac-drbg version 1.0.1 https://github.com/indutny/hmac-drbg
+Copyright npm, Inc stringify-package version 1.0.1 https://github.com/npm/stringify-package
+Copyright (c) 2011 Joyent, Inc. sshpk version 1.16.1 https://github.com/arekinath/node-sshpk
+Copyright (c) 2016 Baz memoizerific version 1.11.3 https://github.com/thinkloop/memoizerific
+Copyright (c) Felix Bohm domelementtype version 1.3.1 https://github.com/fb55/domelementtype
+Copyright 2010-2011 Mikeal Rogers aws-sign2 version 0.7.0 https://github.com/mikeal/aws-sign
+Copyright Fedor Indutny, 2012. isarray version 1.0.0 https://github.com/juliangruber/isarray
+Copyright (c) 2015 Jordan Harband is-string version 1.0.5 https://github.com/ljharb/is-string
+Copyright (c) 2015 Titus Wormer trim-lines version 1.1.3 https://github.com/wooorm/trim-lines
+Copyright (c) Facebook, Inc. and its affiliates. react-is version 16.13.1 https://reactjs.org
+Copyright (c) Facebook, Inc. and its affiliates. scheduler version 0.19.1 https://reactjs.org
+Copyright 2012-2015, Yahoo Inc. istanbul-lib-instrument version 3.3.0 https://istanbul.js.org
+Copyright (c) 2013 Colingo. min-document version 2.19.0 https://github.com/Raynos/min-document
+Copyright (c) Facebook, Inc. and its affiliates. jest-watcher version 24.9.0 https://jestjs.io
+Copyright (c) Facebook, Inc. and its affiliates. react-dom version 16.13.1 https://reactjs.org
+Copyright (c) Isaac Z. Schlueter uid-number version 0.0.6 https://github.com/isaacs/uid-number
+Copyright (c) npm, Inc. npm-registry-fetch version 4.0.5 https://github.com/npm/registry-fetch
+Copyright Mathias Bynens <https://mathiasbynens.be/> jsesc version 2.5.2 https://mths.be/jsesc
+(c) Sindre Sorhus (http://sindresorhus.com) ip version 1.1.5 https://github.com/indutny/node-ip
+Copyright (c) 2014 Jordan Harband object-is version 1.1.2 https://github.com/es-shims/object-is
+Copyright (c) 2016-2018 Thomas Watson Steen is-ci version 2.0.0 https://github.com/watson/is-ci
+Copyright npm, Inc npm-profile version 4.0.4 https://github.com/npm/npm-profile/tree/latest/lib
+Copyright (c) 2011 Tim Koschutzki (tim@debuggable.com) Felix Geisendorfer (felix@debuggable.com)
+Copyright (c) 2012-2016 Eloy Duran eloy.de.enige@gmail.com, Julien Blanchard julien@sideburns.eu
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com> jest version 24.9.0 https://jestjs.io
+Copyright (c) 2015 JD Ballard is-arrayish version 0.2.1 https://github.com/qix-/node-is-arrayish
+Copyright (c) Facebook, Inc. and its affiliates. jest/reporters version 24.9.0 https://jestjs.io
+Copyright (c) Isaac Z. Schlueter and Contributors nopt version 3.0.6 https://github.com/npm/nopt
+Copyright (c) npm, Inc. npm-pick-manifest version 3.0.2 https://github.com/npm/npm-pick-manifest
+Copyright Mathias Bynens <https://mathiasbynens.be/> cssesc version 3.0.0 https://mths.be/cssesc
+(c) Isaac Z. Schlueter (http://github.com/isaacs), James Talmage (http://github.com/jamestalmage)
+Copyright (c) 2012, Mark Cavage. async-each version 1.0.3 https://github.com/paulmillr/async-each
+Copyright (c) 2015 Jordan Harband is-callable version 1.2.0 https://github.com/ljharb/is-callable
+Copyright (c) 2015 Jordan Harband is-symbol version 1.0.3 https://github.com/inspect-js/is-symbol
+Copyright (c) 2016 David Frank node-fetch-npm version 2.0.4 https://github.com/npm/node-fetch-npm
+Copyright (c) Isaac Z. Schlueter and Contributors ini version 1.3.5 https://github.com/isaacs/ini
+Copyright (c) Isaac Z. Schlueter slide version 1.1.6 https://github.com/isaacs/slide-flow-control
+Copyright (c) npm, Inc. make-fetch-happen version 5.0.2 https://github.com/zkat/make-fetch-happen
+Copyright Fedor Indutny, 2014. err-code version 1.1.2 https://github.com/IndigoUnited/js-err-code
+Copyright Paul Johnston 2000 - 2002. Other contributors Greg Holt, Andrew Kepert, Ydnar, Lostinet
+Copyright (c) 2015 Jordan Harband es-abstract version 1.17.6 https://github.com/ljharb/es-abstract
+Copyright (c) 2015 Mathias Buus stream-each version 1.2.3 https://github.com/mafintosh/stream-each
+Copyright (c) 2016 Jordan Harband globalthis version 1.0.1 https://github.com/ljharb/System.global
+Copyright (c) Isaac Z. Schlueter and Contributors osenv version 0.1.5 https://github.com/npm/osenv
+Copyright (c) npm, Inc. and Contributors minipass version 3.1.3 https://github.com/isaacs/minipass
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> unified version 9.0.0 https://unifiedjs.com
+Copyright (c) 2016 Kirill Fomichev md5.js version 1.3.5 https://github.com/crypto-browserify/md5.js
+Copyright (c) 2017 Kent C. Dodds rtl-css-js version 1.14.0 https://github.com/kentcdodds/rtl-css-js
+Copyright (c) 2018 Michael Mclaughlin <M8ch88l@gmail.com> https://github.com/MikeMcl/big.js/LICENCE
+Copyright (c) 2019 Jordan Harband side-channel version 1.0.2 https://github.com/ljharb/side-channel
+Copyright (c) Isaac Z. Schlueter and Contributors once version 1.4.0 https://github.com/isaacs/once
+Copyright 2010-2012 Mikeal Rogers tunnel-agent version 0.6.0 https://github.com/mikeal/tunnel-agent
+Copyright Fedor Indutny, 2015. http-deceiver version 1.2.7 https://github.com/indutny/http-deceiver
+Copyright (c) 2013 Aria Minaei pretty-error version 2.1.1 https://github.com/AriaMinaei/pretty-error
+Copyright (c) 2013 Dominic Tarr json-buffer version 3.0.0 https://github.com/dominictarr/json-buffer
+Copyright (c) 2014-2017 Douglas Christopher Wilson vary version 1.1.2 https://github.com/jshttp/vary
+Copyright (c) 2016 Federico Zivolo and contributors remark-parse version 8.0.3 https://remark.js.org
+Copyright (c) 2016 Mathias Buus stream-shift version 1.0.1 https://github.com/mafintosh/stream-shift
+Copyright (c) Emotion team and other contributors emotion-theming version 10.0.27 https://emotion.sh
+Copyright (c) Isaac Z. Schlueter and Contributors npmlog version 4.1.2 https://github.com/npm/npmlog
+Copyright (c) Isaac Z. Schlueter and Contributors tar version 4.4.13 https://github.com/npm/node-tar
+Copyright (c) Isaac Z. Schlueter and Contributors wrappy version 1.0.2 https://github.com/npm/wrappy
+Copyright (c) Paul Johnston 1999 - 2009 Other contributors Greg Holt, Andrew Kepert, Ydnar, Lostinet
+Copyright Fedor Indutny, 2013. assert-plus version 1.0.0 https://github.com/mcavage/node-assert-plus
+Copyright Mathias Bynens <https://mathiasbynens.be/> punycode version 2.1.1 https://mths.be/punycode
+Copyright (c) 2013-present, Facebook, Inc. prop-types version 15.7.2 https://facebook.github.io/react
+Copyright (c) 2014 Jordan Harband object.assign version 4.1.0 https://github.com/ljharb/object.assign
+Copyright (c) 2016 require-main-filename version 2.0.0 https://github.com/yargs/require-main-filename
+Copyright (c) 2017 Anton react-focus-lock version 2.4.1 https://github.com/theKashey/react-focus-lock
+Copyright (c) 2019 Jordan Harband internal-slot version 1.0.2 https://github.com/ljharb/internal-slot
+Copyright (c) 2019 Jordan Harband iterate-value version 1.0.2 https://github.com/ljharb/iterate-value
+Copyright (c) Isaac Z. Schlueter and Contributors isexe version 2.0.0 https://github.com/isaacs/isexe
+Copyright (c) Isaac Z. Schlueter npm-package-arg version 6.1.1 https://github.com/npm/npm-package-arg
+Copyright (c) npm, Inc. and Contributors infer-owner version 1.0.4 https://github.com/npm/infer-owner
+Copyright (c) npm, Inc. and Contributors npm-bundled version 1.1.1 https://github.com/npm/npm-bundled
+Copyright (c) 2014 Mathias Buus end-of-stream version 1.4.4 https://github.com/mafintosh/end-of-stream
+Copyright (c) 2015 Mathias Buus multicast-dns version 6.2.3 https://github.com/mafintosh/multicast-dns
+Copyright (c) 2015, Jon Schlinkert. glob-base version 0.3.0 https://github.com/jonschlinkert/glob-base
+Copyright (c) 2012, 2013, 2014 James Halliday <mail@substack.net> , 2009 Thomas Robinson <280north.com>
+Copyright (c) 2013-present, Facebook, Inc. invariant version 2.2.4 https://github.com/zertosh/invariant
+Copyright (c) 2014, Rebecca Turner <me@re-becca.org> gauge version 2.7.4 https://github.com/iarna/gauge
+Copyright (c) 2015 Jordan Harband is-date-object version 1.0.2 https://github.com/ljharb/is-date-object
+Copyright (c) 2015 Jordan Harband object.values version 1.1.1 https://github.com/es-shims/Object.values
+Copyright (c) 2015, Rebecca Turner hosted-git-info version 2.8.8 https://github.com/npm/hosted-git-info
+Copyright (c) 2017 Jordan Harband util.promisify version 1.0.1 https://github.com/ljharb/util.promisify
+Copyright (c) Facebook, Inc. and its affiliates. expect version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Isaac Z. Schlueter and Contributors rimraf version 2.7.1 https://github.com/isaacs/rimraf
+Copyright 2016, Joyent, Inc. http-signature version 1.2.0 https://github.com/joyent/node-http-signature
+Copyright Mathias Bynens <https://mathiasbynens.be/> regexpu-core version 4.7.0 https://mths.be/regexpu
+Copyright (c) 2013-present, Facebook, Inc. warning version 4.0.3 https://github.com/BerkeleyTrue/warning
+Copyright (c) 2015, Jon Schlinkert. pascalcase version 0.1.1 https://github.com/jonschlinkert/pascalcase
+Copyright (c) 2017 Luke Childs clone-response version 1.0.2 https://github.com/lukechilds/clone-response
+Copyright (c) 2018 Terkel Gjervig Nielsen sisteransi version 1.0.5 https://github.com/terkelg/sisteransi
+Copyright Fedor Indutny, 2015. spdy-transport version 3.0.0 https://github.com/spdy-http2/spdy-transport
+Copyright JS Foundation and other contributors webpack version 4.43.0 https://github.com/webpack/webpack
+Copyright Mathias Bynens <https://mathiasbynens.be/> regenerate version 1.4.1 https://mths.be/regenerate
+Copyright (c) 2012-2014 Tobias Koppers miller-rabin version 4.0.1 https://github.com/indutny/miller-rabin
+Copyright (c) 2012-2018 by various contributors acorn-walk version 6.2.0 https://github.com/acornjs/acorn
+Copyright (c) 2015 Jordan Harband es-to-primitive version 1.2.1 https://github.com/ljharb/es-to-primitive
+Copyright (c) 2015 Jordan Harband object.entries version 1.1.2 https://github.com/es-shims/Object.entries
+Copyright (c) 2015, Rebecca Turner <me@re-becca.org> aproba version 2.0.0 https://github.com/iarna/aproba
+Copyright (c) 2019 Jordan Harband es-get-iterator version 1.1.0 https://github.com/ljharb/es-get-iterator
+Copyright (c) Emotion team and other contributors babel-plugin-emotion version 10.0.33 https://emotion.sh
+Copyright (c) Isaac Z. Schlueter and Contributors semver version 5.7.1 https://github.com/npm/node-semver
+Copyright (c) Isaac Z. Schlueter and Contributors yallist version 4.0.0 https://github.com/isaacs/yallist
+Copyright (c) Isaac Z. Schlueter read-package-json version 2.1.1 https://github.com/npm/read-package-json
+copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> vfile version 4.1.1 https://github.com/vfile/vfile
+Copyright (c) 2016 Mael Nison use-callback-ref version 1.2.4 https://github.com/theKashey/use-callback-ref
+Copyright (c) Facebook, Inc. and its affiliates. jest-diff version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-each version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-mock version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-util version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Isaac Z. Schlueter and Contributors which version 1.3.1 https://github.com/isaacs/node-which
+Copyright Mathias Bynens <https://mathiasbynens.be/> emoji-regex version 7.0.3 https://mths.be/emoji-regex
+Copyright (c) 2014 Douglas Christopher Wilson on-headers version 1.0.2 https://github.com/jshttp/on-headers
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com mime-db version 1.44.0 https://github.com/jshttp/mime-db
+Copyright (c) 2015 Eugene Sharygin unist-builder version 2.0.3 https://github.com/syntax-tree/unist-builder
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> detab version 2.0.3 https://github.com/wooorm/detab
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> fault version 1.0.4 https://github.com/wooorm/fault
+Copyright (c) Facebook, Inc. and its affiliates. jest/types version 24.9.0 https://github.com/facebook/jest
+Copyright Fedor Indutny, 2017. natural-compare version 1.4.0 https://github.com/litejs/natural-compare-lite
+Copyright JS Foundation and other contributors watchpack version 1.7.2 https://github.com/webpack/watchpack
+Copyright (c) Facebook, Inc. and its affiliates. jest-worker version 24.9.0 https://github.com/facebook/jest
+Copyright (c) James Halliday stream-browserify version 2.0.2 https://github.com/browserify/stream-browserify
+Copyright (c) Microsoft Corporation. agent-base version 4.3.0 https://github.com/TooTallNate/node-agent-base
+Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca> ts-pnp version 1.2.0 https://github.com/arcanis/ts-pnp
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> ccount version 1.0.5 https://github.com/wooorm/ccount
+Copyright (c) 2015 Unshift.io, Arnout Kazemier url-parse version 1.4.7 https://github.com/unshiftio/url-parse
+Copyright (c) 2015, Rebecca Turner write-file-atomic version 2.4.3 https://github.com/iarna/write-file-atomic
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> trough version 1.0.5 https://github.com/wooorm/trough
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> zwitch version 1.0.5 https://github.com/wooorm/zwitch
+Copyright (c) 2017 Eric Wendelin and other contributors stackframe version 1.2.0 https://www.stacktracejs.com
+Copyright (c) Facebook, Inc. and its affiliates. jest-resolve version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. memory-fs version 0.4.1 https://github.com/webpack/memory-fs
+Copyright (c) Isaac Z. Schlueter and Contributors minimatch version 3.0.4 https://github.com/isaacs/minimatch
+Copyright (c) Isaac Z. Schlueter and Contributors pseudomap version 1.0.2 https://github.com/isaacs/pseudomap
+Copyright 2014-present Facebook, Inc. spdx-correct version 3.1.1 https://github.com/jslicense/spdx-correct.js
+Copyright Joyent, Inc. and other Node contributors. asn1.js version 4.10.1 https://github.com/indutny/asn1.js
+Copyright (c) 2014-2017 Douglas Christopher Wilson forwarded version 0.1.2 https://github.com/jshttp/forwarded
+Copyright (c) 2015, Jon Schlinkert. is-extendable version 0.1.1 https://github.com/jonschlinkert/is-extendable
+Copyright (c) 2015, Jon Schlinkert. shallow-clone version 0.1.2 https://github.com/jonschlinkert/shallow-clone
+Copyright (c) 2016, Jon Schlinkert. static-extend version 0.1.2 https://github.com/jonschlinkert/static-extend
+Copyright (c) 2018 Szymon Marczak defer-to-connect version 1.1.3 https://github.com/szmarczak/defer-to-connect
+Copyright (c) Facebook, Inc. and its affiliates. jest-get-type version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-snapshot version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-validate version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. pretty-format version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Isaac Z. Schlueter and Contributors fs-minipass version 2.1.0 https://github.com/npm/fs-minipass
+Copyright Angel Marin, Paul Johnston 2000 - 2009. Other contributors Greg Holt, Andrew Kepert, Ydnar, Lostinet
+Copyright (c) 2014, Nathan LaFreniere and other contributors (https://github.com/ljharb/qs/graphs/contributors)
+Copyright (c) 2014-2017 Douglas Christopher Wilson depd version 1.1.2 https://github.com/dougwilson/nodejs-depd
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> unherit version 1.1.3 https://github.com/wooorm/unherit
+Copyright (c) 2015 Titus Wormer trim-trailing-lines version 1.1.3 https://github.com/wooorm/trim-trailing-lines
+Copyright (c) Facebook, Inc. and its affiliates. diff-sequences version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-haste-map version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. storybook/csf version 0.0.1 https://github.com/storybookjs/csf
+Copyright 2014-present Olivier Lalonde <olalonde@gmail.com> , James Talmage <james@talmage.io> , Ruben Verborgh
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com destroy version 1.0.4 https://github.com/stream-utils/destroy
+Copyright (c) 2014-2016 Douglas Christopher Wilson proxy-addr version 2.0.6 https://github.com/jshttp/proxy-addr
+Copyright (c) 2015 Mathias Buus flush-write-stream version 1.1.1 https://github.com/mafintosh/flush-write-stream
+Copyright (c) 2017 Eric Wendelin and other contributors stacktrace-js version 2.0.2 https://www.stacktracejs.com
+Copyright (c) Facebook, Inc. and its affiliates. jest-regex-util version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-serializer version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest/source-map version 24.9.0 https://github.com/facebook/jest
+Copyright JS Foundation and other contributors webpack-cli version 3.3.12 https://github.com/webpack/webpack-cli
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com ee-first version 1.1.1 https://github.com/jonathanong/ee-first
+Copyright (c) 2014-2015, Jon Schlinkert. mixin-object version 2.0.1 https://github.com/jonschlinkert/mixin-object
+Copyright (c) 2014-2016, Jon Schlinkert. is-directory version 0.3.1 https://github.com/jonschlinkert/is-directory
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/core version 7.10.5 https://babeljs.io
+Copyright (c) 2015 Titus Wormer property-information version 5.5.0 https://github.com/wooorm/property-information
+Copyright (c) 2015, Rebecca Turner <me@re-becca.org> wide-align version 1.1.3 https://github.com/iarna/wide-align
+Copyright (c) 2017 Calvin Metcalf public-encrypt version 4.0.3 https://github.com/crypto-browserify/publicEncrypt
+Copyright (c) 2017 Eric Wendelin and other contributors stacktrace-gps version 3.0.4 https://www.stacktracejs.com
+Copyright (c) 2017 Evgeny Poberezkin fast-deep-equal version 2.0.1 https://github.com/epoberezkin/fast-deep-equal
+Copyright (c) 2019 Jordan Harband promise.allsettled version 1.0.2 https://github.com/es-shims/promise.allsettled
+Copyright (c) Facebook, Inc. and its affiliates. jest/fake-timers version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest/test-result version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Isaac Z. Schlueter and Contributors ignore-walk version 3.0.3 https://github.com/isaacs/ignore-walk
+Copyright (c) Isaac Z. Schlueter and Contributors mute-stream version 0.0.8 https://github.com/isaacs/mute-stream
+Copyright JS Foundation and other contributors loader-utils version 1.4.0 https://github.com/webpack/loader-utils
+Copyright JS Foundation and other contributors schema-utils version 2.7.0 https://github.com/webpack/schema-utils
+Copyright Joyent, Inc. and other Node contributors. fb-watchman version 2.0.1 https://facebook.github.io/watchman
+(c) // http://mathiasbynens.be/notes/javascript-encoding nth-check version 1.0.2 https://github.com/fb55/nth-check
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net> spdy version 4.0.2 https://github.com/indutny/node-spdy
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/types version 7.10.5 https://babeljs.io
+Copyright (c) 2015, Jon Schlinkert. define-property version 0.2.5 https://github.com/jonschlinkert/define-property
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> lowlight version 1.11.0 https://github.com/wooorm/lowlight
+Copyright (c) 2017 Eric Wendelin and other contributors stack-generator version 2.0.5 https://www.stacktracejs.com
+Copyright (c) Facebook, Inc. and its affiliates. babel-preset-jest version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-message-util version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Isaac Z. Schlueter and Contributors lru-cache version 5.1.1 https://github.com/isaacs/node-lru-cache
+Copyright Fedor Indutny, 2015. http-proxy-agent version 2.1.0 https://github.com/TooTallNate/node-http-proxy-agent
+Copyright (c) 2014, Rebecca Turner <me@re-becca.org> has-unicode version 2.0.1 https://github.com/iarna/has-unicode
+Copyright (c) 2017, Rebecca Turner <me@re-becca.org> lock-verify version 2.2.1 https://github.com/iarna/lock-verify
+Copyright (c) 2018 Angry Bytes and contributors. svg-parser version 2.0.4 https://github.com/Rich-Harris/svg-parser
+Copyright (c) 2019 Jordan Harband functions-have-names version 1.2.1 https://github.com/ljharb/functions-have-names
+Copyright (c) Facebook, Inc. and its affiliates. jest-leak-detector version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. jest-matcher-utils version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Facebook, Inc. and its affiliates. react-docgen version 5.3.0 https://github.com/reactjs/react-docgen
+Copyright (c) Kevin Martensson <kevinmartensson@gmail.com> dir-glob version 2.0.0 https://github.com/kevva/dir-glob
+Copyright Fedor Indutny, 2015. dom-accessibility-api version 0.4.6 https://github.com/eps1lon/dom-accessibility-api
+version 1.0.3 https://github.com/crypto-browserify/EVP_BytesToKey Copyright (c) 2017 crypto-browserify contributors
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helpers version 7.10.4 https://babeljs.io
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/runtime version 7.10.5 https://babeljs.io
+Copyright Fedor Indutny, 2015. socks-proxy-agent version 4.0.2 https://github.com/TooTallNate/node-socks-proxy-agent
+Copyright (c) 2013, Nick Fitzgerald http-cache-semantics version 3.8.1 https://github.com/pornel/http-cache-semantics
+Copyright (c) 2014 Blaine Bublitz <blaine.bublitz@gmail.com> , Eric Schoffstall <yo@contra.io> and other contributors
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/template version 7.10.4 https://babeljs.io
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/traverse version 7.10.5 https://babeljs.io
+Copyright (c) 2015 Unshift.io, Arnout Kazemier requires-port version 1.0.0 https://github.com/unshiftio/requires-port
+Copyright (c) 2015, Rebecca Turner <me@re-becca.org> read-cmd-shim version 1.0.5 https://github.com/npm/read-cmd-shim
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> is-decimal version 1.0.4 https://github.com/wooorm/is-decimal
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/generator version 7.10.5 https://babeljs.io
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/highlight version 7.10.4 https://babeljs.io
+Copyright (c) 2015-2016, Jon Schlinkert expand-brackets version 2.1.4 https://github.com/jonschlinkert/expand-brackets
+Copyright (c) Feross Aboukhadijeh (http://feross.org). safe-buffer version 5.2.1 https://github.com/feross/safe-buffer
+Copyright (c) Tjarda Koster, https://jelloween.deviantart.com gentle-fs version 2.3.1 https://github.com/npm/gentle-fs
+Copyright (c) 2014-2018 C. Scott Ananian pnp-webpack-plugin version 1.5.0 https://github.com/arcanis/pnp-webpack-plugin
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/preset-env version 7.10.4 https://babeljs.io
+Copyright (c) 2015 Unshift.io, Arnout Kazemier querystringify version 2.1.1 https://github.com/unshiftio/querystringify
+Copyright (c) Isaac Z. Schlueter and Contributors minipass-flush version 1.0.5 https://github.com/isaacs/minipass-flush
+Copyright (c) Isaac Z. Schlueter and Contributors npm-packlist version 1.4.8 https://www.npmjs.com/package/npm-packlist
+Copyright (c) 2012-2015 Lauri Rooden <lauri@rooden.ee> pkg-add-deps version 0.1.0 https://github.com/ratson/pkg-add-deps
+Copyright (c) 2016 Paul Miller (paulmillr.com) (http://paulmillr.com) babel-code-frame version 6.26.0 https://babeljs.io
+Copyright (c) Facebook, Inc. and its affiliates. babel-plugin-jest-hoist version 24.9.0 https://github.com/facebook/jest
+Copyright (c) Feross Aboukhadijeh (http://feross.org). run-parallel version 1.1.9 https://github.com/feross/run-parallel
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net> ignore version 3.3.10 https://github.com/kaelzhang/node-ignore
+Copyright (c) 2014 Jordan Harband regexp.prototype.flags version 1.3.0 https://github.com/es-shims/RegExp.prototype.flags
+Copyright (c) 2015-present, Facebook, Inc. react-error-overlay version 6.0.7 https://github.com/facebook/create-react-app
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> state-toggle version 1.0.3 https://github.com/wooorm/state-toggle
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/utf8 version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> hastscript version 5.1.2 https://github.com/syntax-tree/hastscript
+Copyright (c) 2017 Titus Wormer <tituswormer@gmail.com> vfile-message version 2.0.4 https://github.com/vfile/vfile-message
+Copyright (c) Isaac Z. Schlueter <i@izs.me> , James Talmage <james@talmage.io> (github.com/jamestalmage), and Contributors
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) chalk version 2.4.2 https://github.com/chalk/chalk
+Copyright (c) Tjarda Koster, https://jelloween.deviantart.com npm-lifecycle version 2.1.1 https://github.com/npm/lifecycle
+(c) Titus Wormer sane version 4.1.0 https://github.com/amasad/sane select version 1.1.2 https://github.com/zenorocha/select
+Copyright (c) 2015, Glen Maddern postcss-modules-values version 3.0.0 https://github.com/css-modules/postcss-modules-values
+Copyright (c) 2017 Evgeny Poberezkin json-schema-traverse version 0.4.1 https://github.com/epoberezkin/json-schema-traverse
+Copyright (c) Facebook, Inc. and its affiliates. react-dev-utils version 9.1.0 https://github.com/facebook/create-react-app
+Copyright Fedor Indutny, 2014. minimalistic-crypto-utils version 1.0.1 https://github.com/indutny/minimalistic-crypto-utils
+create-hash version 1.2.0 https://github.com/crypto-browserify/createHash Copyright (c) 2017 crypto-browserify contributors
+create-hmac version 1.1.7 https://github.com/crypto-browserify/createHmac Copyright (c) 2017 crypto-browserify contributors
+Copyright (c) 2013 James Halliday (mail@substack.net) shell-quote version 1.7.2 https://github.com/substack/node-shell-quote
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> vfile-location version 3.0.1 https://github.com/vfile/vfile-location
+Copyright 2010 - 2013 Sami Samhuri <sami@samhuri.net> good-listener version 1.2.2 https://github.com/zenorocha/good-listener
+Copyright 2014 Shape Security, Inc. babel-plugin-transform-regexp-constructors version 0.4.3 https://github.com/babel/minify
+Copyright (c) 2015 Jordan Harband string.prototype.matchall version 4.0.2 https://github.com/ljharb/String.prototype.matchAll
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-preset-minify version 0.5.1 https://github.com/babel/minify
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> is-hexadecimal version 1.0.4 https://github.com/wooorm/is-hexadecimal
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> web-namespaces version 1.1.4 https://github.com/wooorm/web-namespaces
+Copyright (c) 2017 ECMAScript Shims array.prototype.flatmap version 1.2.3 https://github.com/es-shims/Array.prototype.flatMap
+Copyright (c) 2017, Rebecca Turner <me@re-becca.org> promise-inflight version 1.0.1 https://github.com/iarna/promise-inflight
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/wasm-gen version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/wasm-opt version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). use version 3.1.1 https://github.com/jonschlinkert/use
+Copyright (c) Facebook, Inc. and its affiliates. jest-pnp-resolver version 1.2.2 https://github.com/arcanis/jest-pnp-resolver
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) del version 4.1.1 https://github.com/sindresorhus/del
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) got version 9.6.0 https://github.com/sindresorhus/got
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) mem version 1.1.0 https://github.com/sindresorhus/mem
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) opn version 5.5.0 https://github.com/sindresorhus/opn
+Copyright 2018 Copyright (c) Facebook, Inc. and its affiliates. jest-docblock version 24.9.0 https://github.com/facebook/jest
+Copyright (c) 2014 Yehuda Katz, Tom Dale, Stefan Penner and contributors rsvp version 4.8.5 https://github.com/tildeio/rsvp.js
+Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com statuses version 1.5.0 https://github.com/jshttp/statuses
+Copyright (c) 2017 Kent C. Dodds testing-library/react version 10.4.9 https://github.com/testing-library/react-testing-library
+Copyright (c) 2017-2018 Domenic Denicola <d@domenic.me> whatwg-mimetype version 2.3.0 https://github.com/jsdom/whatwg-mimetype
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/wasm-edit version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright JS Foundation and other contributors webpack-dev-server version 3.11.0 https://github.com/webpack/webpack-dev-server
+Copyright (c) 2016 Jordan Harband promise.prototype.finally version 3.1.2 https://github.com/es-shims/Promise.prototype.finally
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> is-alphabetical version 1.0.4 https://github.com/wooorm/is-alphabetical
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) lcid version 1.0.0 https://github.com/sindresorhus/lcid
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) open version 6.4.0 https://github.com/sindresorhus/open
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) pify version 3.0.0 https://github.com/sindresorhus/pify
+Copyright Joyent, Inc. and other Node contributors. define-properties version 1.1.3 https://github.com/ljharb/define-properties
+(c) James Talmage (http://github.com/jamestalmage) normalize-range version 0.1.2 https://github.com/jamestalmage/normalize-range
+Copyright (c) 2012-2016 Yusuke Suzuki (http://github.com/Constellation) esutils version 2.0.3 https://github.com/estools/esutils
+Copyright (c) 2013-2014 Yusuke Suzuki <utatane.tea@gmail.com> jest-changed-files version 24.9.0 https://github.com/facebook/jest
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) path-to-regexp version 0.1.7 https://github.com/component/path-to-regexp
+Copyright (c) 2014 Ibrahim Al-Rajhi <abrahamalrajhi@gmail.com> gud version 1.0.0 https://github.com/jamiebuilds/global-unique-id
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-plugin-utils version 7.10.4 https://babeljs.io
+Copyright (c) 2015 Eugene Sharygin remark-squeeze-paragraphs version 4.0.0 https://github.com/remarkjs/remark-squeeze-paragraphs
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> unist-util-is version 4.0.2 https://github.com/syntax-tree/unist-util-is
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> hast-util-raw version 6.0.0 https://github.com/syntax-tree/hast-util-raw
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/wasm-parser version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/wast-parser version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright Joyent, Inc. and other Node contributors. querystring-es3 version 0.2.1 https://github.com/mike-spainhower/querystring
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-simple-access version 7.10.4 https://babeljs.io
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/register version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2015 EcmaScript Shims string.prototype.padstart version 3.1.0 https://github.com/es-shims/String.prototype.padStart
+Copyright (c) 2016 Christian Speckner <cnspeckn@googlemail.com> worker-rpc version 0.1.1 https://github.com/DirtyHairy/worker-rpc
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> markdown-escapes version 1.0.4 https://github.com/wooorm/markdown-escapes
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/wast-printer version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) Isaac Z. Schlueter and Contributors json-stringify-safe version 5.0.1 https://github.com/isaacs/json-stringify-safe
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) execa version 1.0.0 https://github.com/sindresorhus/execa
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) leven version 3.1.0 https://github.com/sindresorhus/leven
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-map version 2.1.0 https://github.com/sindresorhus/p-map
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-try version 2.2.0 https://github.com/sindresorhus/p-try
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) slash version 2.0.0 https://github.com/sindresorhus/slash
+Copyright (c) Steven Vachon <contact@svachon.com> (svachon.com) relateurl version 0.2.7 https://github.com/stevenvachon/relateurl
+Copyright (c) 2013 Gary Court, Jens Taylor inline-style-parser version 0.1.1 https://github.com/remarkablemark/inline-style-parser
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-module-imports version 7.10.4 https://babeljs.io
+Copyright (c) 2015 Mathias Buus multicast-dns-service-types version 1.1.0 https://github.com/mafintosh/multicast-dns-service-types
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). extglob version 2.0.4 https://github.com/micromatch/extglob
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). is-glob version 4.0.1 https://github.com/micromatch/is-glob
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/helper-buffer version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) wrap-ansi version 5.1.0 https://github.com/chalk/wrap-ansi
+Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> pinkie-promise version 2.0.1 https://github.com/floatdrop/pinkie-promise
+Copyright (c) 2013-present, Facebook, Inc. react-lifecycles-compat version 3.0.4 https://github.com/reactjs/react-lifecycles-compat
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> is-alphanumerical version 1.0.4 https://github.com/wooorm/is-alphanumerical
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> is-word-character version 1.0.4 https://github.com/wooorm/is-word-character
+Copyright (c) 2017 Khaled Al-Ansari string.prototype.trimstart version 1.0.1 https://github.com/es-shims/String.prototype.trimStart
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). for-in version 1.0.2 https://github.com/jonschlinkert/for-in
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) arrify version 1.0.1 https://github.com/sindresorhus/arrify
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) globby version 8.0.2 https://github.com/sindresorhus/globby
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-npm version 3.0.0 https://github.com/sindresorhus/is-npm
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-obj version 1.0.1 https://github.com/sindresorhus/is-obj
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-wsl version 1.1.0 https://github.com/sindresorhus/is-wsl
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) pkg-up version 2.0.0 https://github.com/sindresorhus/pkg-up
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) redent version 3.0.0 https://github.com/sindresorhus/redent
+Copyright (c) 2013-2018 Ben Alman <cowboy@rj3.net> , Blaine Bublitz <blaine.bublitz@gmail.com> , and Eric Schoffstall <yo@contra.io>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com> type-is version 1.6.18 https://github.com/jshttp/type-is
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/preset-flow version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017, Rebecca Turner <me@re-becca.org> move-concurrently version 1.0.1 https://www.npmjs.com/package/move-concurrently
+Copyright (c) Facebook, Inc. and its affiliates. testing-library/jest-dom version 5.11.1 https://github.com/testing-library/jest-dom
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) ansi-regex version 5.0.0 https://github.com/chalk/ansi-regex
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) strip-ansi version 3.0.1 https://github.com/chalk/strip-ansi
+Copyright (c) 2010-2015 James Coglan flow-parser version 0.130.0 https://flow.org format version 0.2.2 http://samhuri.net/proj/format
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-module-transforms version 7.10.5 https://babeljs.io
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-regex version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com> mime-types version 2.1.27 https://github.com/jshttp/mime-types
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> character-entities version 1.2.4 https://github.com/wooorm/character-entities
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-replace version 0.5.0 https://github.com/babel/minify
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> html-void-elements version 1.0.5 https://github.com/wooorm/html-void-elements
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). kind-of version 3.2.2 https://github.com/jonschlinkert/kind-of
+Copyright (c) Isaac Z. Schlueter and Contributors fs-write-stream-atomic version 1.0.10 https://github.com/npm/fs-write-stream-atomic
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) find-up version 3.0.0 https://github.com/sindresorhus/find-up
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-root version 2.1.0 https://github.com/sindresorhus/is-root
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) onetime version 5.1.0 https://github.com/sindresorhus/onetime
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-limit version 2.3.0 https://github.com/sindresorhus/p-limit
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-retry version 3.0.1 https://github.com/sindresorhus/p-retry
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) pkg-dir version 3.0.0 https://github.com/sindresorhus/pkg-dir
+Copyright JS Foundation and other contributors webpack-dev-middleware version 3.7.2 https://github.com/webpack/webpack-dev-middleware
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net> agentkeepalive version 3.5.2 https://github.com/node-modules/agentkeepalive
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> unist-util-visit version 2.0.3 https://github.com/syntax-tree/unist-util-visit
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-builtins version 0.5.0 https://github.com/babel/minify
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-simplify version 0.5.1 https://github.com/babel/minify
+Copyright (c) 2016 - 2019, Brian Woodward (https://github.com/doowb). parse-passwd version 1.0.0 https://github.com/doowb/parse-passwd
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/cli
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/helper-code-frame version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) ansi-styles version 4.2.1 https://github.com/chalk/ansi-styles
+Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> is-retry-allowed version 1.2.0 https://github.com/floatdrop/is-retry-allowed
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). isobject version 3.0.1 https://github.com/jonschlinkert/isobject
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). to-regex version 3.0.2 https://github.com/jonschlinkert/to-regex
+Copyright (c) 2019 Jordan Harband es-array-method-boxes-properly version 1.0.0 https://github.com/ljharb/es-array-method-boxes-properly
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) dot-prop version 4.2.0 https://github.com/sindresorhus/dot-prop
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) globals version 11.12.0 https://github.com/sindresorhus/globals
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) has-ansi version 2.0.0 https://github.com/sindresorhus/has-ansi
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) has-flag version 3.0.0 https://github.com/sindresorhus/has-flag
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) has-yarn version 2.1.0 https://github.com/sindresorhus/has-yarn
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) ip-regex version 2.1.0 https://github.com/sindresorhus/ip-regex
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) make-dir version 2.1.0 https://github.com/sindresorhus/make-dir
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) mimic-fn version 1.2.0 https://github.com/sindresorhus/mimic-fn
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-locate version 3.0.0 https://github.com/sindresorhus/p-locate
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-reduce version 1.0.0 https://github.com/sindresorhus/p-reduce
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) path-key version 2.0.1 https://github.com/sindresorhus/path-key
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) read-pkg version 5.2.0 https://github.com/sindresorhus/read-pkg
+Copyright (c) 2011 Debuggable Limited <felix@debuggable.com> delayed-stream version 1.0.0 https://github.com/felixge/node-delayed-stream
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/runtime-corejs3 version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/ui version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/ui
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/helper-wasm-section version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-regenerator version 7.10.4 https://babeljs.io
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> collapse-white-space version 1.0.6 https://github.com/wooorm/collapse-white-space
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). get-value version 2.0.6 https://github.com/jonschlinkert/get-value
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). is-number version 3.0.0 https://github.com/jonschlinkert/is-number
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). map-cache version 0.2.2 https://github.com/jonschlinkert/map-cache
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). has-value version 1.0.0 https://github.com/jonschlinkert/has-value
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). map-visit version 1.0.0 https://github.com/jonschlinkert/map-visit
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). set-value version 2.0.1 https://github.com/jonschlinkert/set-value
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). word-wrap version 1.2.3 https://github.com/jonschlinkert/word-wrap
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/helper-wasm-bytecode version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). micromatch version 3.1.10 https://github.com/micromatch/micromatch
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). regex-not version 1.0.2 https://github.com/jonschlinkert/regex-not
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) callsites version 3.1.0 https://github.com/sindresorhus/callsites
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) camelcase version 5.3.1 https://github.com/sindresorhus/camelcase
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) cli-boxes version 2.2.0 https://github.com/sindresorhus/cli-boxes
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) gzip-size version 5.1.1 https://github.com/sindresorhus/gzip-size
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-docker version 2.0.0 https://github.com/sindresorhus/is-docker
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-stream version 1.1.0 https://github.com/sindresorhus/is-stream
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) os-locale version 2.1.0 https://github.com/sindresorhus/os-locale
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) os-tmpdir version 1.0.2 https://github.com/sindresorhus/os-tmpdir
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-finally version 1.0.0 https://github.com/sindresorhus/p-finally
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) path-type version 3.0.0 https://github.com/sindresorhus/path-type
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) sort-keys version 1.1.2 https://github.com/sindresorhus/sort-keys
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) strip-bom version 3.0.0 https://github.com/sindresorhus/strip-bom
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) strip-eof version 1.0.0 https://github.com/sindresorhus/strip-eof
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) term-size version 1.2.0 https://github.com/sindresorhus/term-size
+copyright header of example files e592c53 (https://github.com/http-party/node-http-proxy/commit/e592c53d1a23b7920d603a9e9ac294fc0e841f6d)
+Copyright (c) 2014 Yusuke Suzuki (https://github.com/Constellation) glob-to-regexp version 0.3.0 https://github.com/fitzgen/glob-to-regexp
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-define-map version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-syntax-jsx version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-mangle-names version 0.5.0 https://github.com/babel/minify
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> mdast-util-to-hast version 9.1.0 https://github.com/syntax-tree/mdast-util-to-hast
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/api version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/api
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/cli version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/cli
+Copyright (c) 2018 Sven Sauleau <sven@sauleau.com> webassemblyjs/helper-module-context version 1.9.0 https://github.com/xtuc/webassemblyjs
+Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> create-error-class version 3.0.2 https://github.com/floatdrop/create-error-class
+(c) Sindre Sorhus (https://sindresorhus.com), Paul Miller (https://paulmillr.com) boxen version 4.2.0 https://github.com/sindresorhus/boxen
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-syntax-flow version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). is-extglob version 2.1.1 https://github.com/jonschlinkert/is-extglob
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). lazy-cache version 1.0.4 https://github.com/jonschlinkert/lazy-cache
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). snapdragon version 0.8.2 https://github.com/jonschlinkert/snapdragon
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). cache-base version 1.0.1 https://github.com/jonschlinkert/cache-base
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). fill-range version 4.0.0 https://github.com/jonschlinkert/fill-range
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). has-values version 1.0.0 https://github.com/jonschlinkert/has-values
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). mixin-deep version 1.3.2 https://github.com/jonschlinkert/mixin-deep
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) array-uniq version 1.0.3 https://github.com/sindresorhus/array-uniq
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) cli-cursor version 3.1.0 https://github.com/sindresorhus/cli-cursor
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) decamelize version 1.2.0 https://github.com/sindresorhus/decamelize
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) get-stream version 4.1.0 https://github.com/sindresorhus/get-stream
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) import-cwd version 2.1.0 https://github.com/sindresorhus/import-cwd
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) os-homedir version 1.0.2 https://github.com/sindresorhus/os-homedir
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) parse-json version 4.0.0 https://github.com/sindresorhus/parse-json
+Copyright JS Foundation and other contributors terser-webpack-plugin version 3.0.8 https://github.com/webpack-contrib/terser-webpack-plugin
+Copyright (c) 2014-2018 Tyler Kellen <tyler@sleekcode.net> , Blaine Bublitz <blaine.bublitz@gmail.com> , and Eric Schoffstall <yo@contra.io>
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> unist-util-position version 3.1.0 https://github.com/syntax-tree/unist-util-position
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> hast-to-hyperscript version 9.0.0 https://github.com/syntax-tree/hast-to-hyperscript
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> hast-util-to-parse5 version 6.0.0 https://github.com/syntax-tree/hast-util-to-parse5
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/core version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/core
+Copyright (c) 2019, Nicolai Kamenzky and contributors request-promise-native version 1.0.8 https://github.com/request/request-promise-native
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) supports-color version 6.1.0 https://github.com/chalk/supports-color
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-function-name version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-wrap-function version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2015 Jordan Harband object.getownpropertydescriptors version 2.1.0 https://github.com/es-shims/object.getownpropertydescriptors
+Copyright (c) 2016 Jon Schlinkert (https://github.com/jonschlinkert) array-unique version 0.3.2 https://github.com/jonschlinkert/array-unique
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> space-separated-tokens version 1.1.5 https://github.com/wooorm/space-separated-tokens
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). object.pick version 1.3.0 https://github.com/jonschlinkert/object.pick
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). resolve-dir version 1.0.1 https://github.com/jonschlinkert/resolve-dir
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). arr-flatten version 1.1.0 https://github.com/jonschlinkert/arr-flatten
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). union-value version 1.0.1 https://github.com/jonschlinkert/union-value
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). unset-value version 1.0.0 https://github.com/jonschlinkert/unset-value
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) caller-path version 2.0.0 https://github.com/sindresorhus/caller-path
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) clean-stack version 2.2.0 https://github.com/sindresorhus/clean-stack
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) global-dirs version 0.1.1 https://github.com/sindresorhus/global-dirs
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) import-from version 2.1.0 https://github.com/sindresorhus/import-from
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) import-lazy version 2.1.0 https://github.com/sindresorhus/import-lazy
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) internal-ip version 4.3.0 https://github.com/sindresorhus/internal-ip
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-path-cwd version 2.2.0 https://github.com/sindresorhus/is-path-cwd
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-redirect version 1.0.0 https://github.com/sindresorhus/is-redirect
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) locate-path version 3.0.0 https://github.com/sindresorhus/locate-path
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) path-exists version 3.0.0 https://github.com/sindresorhus/path-exists
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) read-pkg-up version 4.0.0 https://github.com/sindresorhus/read-pkg-up
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) resolve-cwd version 2.0.0 https://github.com/sindresorhus/resolve-cwd
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) semver-diff version 2.1.0 https://github.com/sindresorhus/semver-diff
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) widest-line version 2.0.1 https://github.com/sindresorhus/widest-line
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) xdg-basedir version 3.0.0 https://github.com/sindresorhus/xdg-basedir
+Copyright (c) 2013 Julian Gruber <julian@juliangruber.com> cookie-signature version 1.0.6 https://github.com/visionmedia/node-cookie-signature
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com> compression version 1.7.4 https://github.com/expressjs/compression
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-replace-supers version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-constant-folding version 0.5.0 https://github.com/babel/minify
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> unist-util-generated version 1.1.5 https://github.com/syntax-tree/unist-util-generated
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/react version 5.3.19 https://github.com/storybookjs/storybook/tree/master/app/react
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) screenfull version 5.0.2 https://github.com/sindresorhus/screenfull.js
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-hoist-variables version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> is-whitespace-character version 1.0.4 https://github.com/wooorm/is-whitespace-character
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). expand-tilde version 2.0.2 https://github.com/jonschlinkert/expand-tilde
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). object-visit version 1.0.1 https://github.com/jonschlinkert/object-visit
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). split-string version 3.1.0 https://github.com/jonschlinkert/split-string
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) ansi-escapes version 3.2.0 https://github.com/sindresorhus/ansi-escapes
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) import-fresh version 2.0.0 https://github.com/sindresorhus/import-fresh
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) import-local version 2.0.0 https://github.com/sindresorhus/import-local
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-plain-obj version 1.1.0 https://github.com/sindresorhus/is-plain-obj
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) npm-run-path version 2.0.2 https://github.com/sindresorhus/npm-run-path
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-cancelable version 1.1.0 https://github.com/sindresorhus/p-cancelable
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) package-json version 6.5.0 https://github.com/sindresorhus/package-json
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) prepend-http version 1.0.4 https://github.com/sindresorhus/prepend-http
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) query-string version 4.3.4 https://github.com/sindresorhus/query-string
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) registry-url version 5.1.0 https://github.com/sindresorhus/registry-url
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) resolve-from version 5.0.0 https://github.com/sindresorhus/resolve-from
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) string-width version 2.1.1 https://github.com/sindresorhus/string-width
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) strip-indent version 3.0.0 https://github.com/sindresorhus/strip-indent
+Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors simplebar-react version 1.2.3 https://grsmto.github.io/simplebar
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net> https-proxy-agent version 2.2.4 https://github.com/TooTallNate/node-https-proxy-agent
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-annotate-as-pure version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-for-of version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-spread version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> hast-util-from-parse5 version 6.0.0 https://github.com/syntax-tree/hast-util-from-parse5
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/addons version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/addons
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/router version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/router
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). to-regex-range version 2.1.1 https://github.com/micromatch/to-regex-range
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-builder-react-jsx version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-syntax-typescript version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-classes version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-guarded-expressions version 0.4.4 https://github.com/babel/minify
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-transform-remove-undefined version 0.5.0 https://github.com/babel/minify
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). repeat-string version 1.6.1 https://github.com/jonschlinkert/repeat-string
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). is-descriptor version 1.0.2 https://github.com/jonschlinkert/is-descriptor
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). global-prefix version 3.0.0 https://github.com/jonschlinkert/global-prefix
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) code-point-at version 1.1.0 https://github.com/sindresorhus/code-point-at
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) indent-string version 4.0.0 https://github.com/sindresorhus/indent-string
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) normalize-url version 1.9.1 https://github.com/sindresorhus/normalize-url
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) number-is-nan version 1.0.1 https://github.com/sindresorhus/number-is-nan
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) object-assign version 4.1.1 https://github.com/sindresorhus/object-assign
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) p-each-series version 1.0.0 https://github.com/sindresorhus/p-each-series
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) parent-module version 1.0.1 https://github.com/sindresorhus/parent-module
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) shebang-regex version 1.0.0 https://github.com/sindresorhus/shebang-regex
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) string-length version 2.0.0 https://github.com/sindresorhus/string-length
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) unique-string version 1.0.0 https://github.com/sindresorhus/unique-string
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) url-parse-lax version 3.0.0 https://github.com/sindresorhus/url-parse-lax
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-get-function-arity version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-literals version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/codemod version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/codemod
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/theming version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/theming
+Copyright (c) Microsoft Corporation. types/scheduler version 0.16.2 https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scheduler
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-compilation-targets version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-jsx version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> character-entities-legacy version 1.1.4 https://github.com/wooorm/character-entities-legacy
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-plugin-minify-dead-code-elimination version 0.5.1 https://github.com/babel/minify
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). to-object-path version 0.3.0 https://github.com/jonschlinkert/to-object-path
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). normalize-path version 3.0.0 https://github.com/jonschlinkert/normalize-path
+Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert). repeat-element version 1.1.3 https://github.com/jonschlinkert/repeat-element
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) detect-newline version 2.1.0 https://github.com/sindresorhus/detect-newline
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-binary-path version 1.0.1 https://github.com/sindresorhus/is-binary-path
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-path-in-cwd version 2.1.0 https://github.com/sindresorhus/is-path-in-cwd
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-path-inside version 2.1.0 https://github.com/sindresorhus/is-path-inside
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) latest-version version 5.1.0 https://github.com/sindresorhus/latest-version
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) load-json-file version 4.0.0 https://github.com/sindresorhus/load-json-file
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) lowercase-keys version 1.0.1 https://github.com/sindresorhus/lowercase-keys
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) mimic-response version 1.0.1 https://github.com/sindresorhus/mimic-response
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) restore-cursor version 3.1.0 https://github.com/sindresorhus/restore-cursor
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) unzip-response version 2.0.1 https://github.com/sindresorhus/unzip-response
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-new-target version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-parameters version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/channels version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/channels
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) no-case version 3.0.3 https://github.com/blakeembrey/change-case/tree/master/packages/no-case
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-json-strings version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-modules-amd version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-modules-umd version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). snapdragon-util version 3.0.1 https://github.com/jonschlinkert/snapdragon-util
+Copyright (c) 2019, Jon Schlinkert (https://github.com/jonschlinkert). is-plain-object version 2.0.4 https://github.com/jonschlinkert/is-plain-object
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) aggregate-error version 3.0.1 https://github.com/sindresorhus/aggregate-error
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) caller-callsite version 2.0.0 https://github.com/sindresorhus/caller-callsite
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-absolute-url version 3.0.3 https://github.com/sindresorhus/is-absolute-url
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-generator-fn version 2.1.0 https://github.com/sindresorhus/is-generator-fn
+Copyright (c) 2014-2015 Jon Schlinkert (https://github.com/jonschlinkert) extend-shallow version 2.0.1 https://github.com/jonschlinkert/extend-shallow
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-syntax-top-level-await version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-object-super version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-sticky-regex version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> hast-util-parse-selector version 2.2.4 https://github.com/syntax-tree/hast-util-parse-selector
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> unist-util-visit-parents version 3.1.0 https://github.com/syntax-tree/unist-util-visit-parents
+copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/> lodash.uniq version 4.5.0 https://lodash.com
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) dot-case version 3.0.3 https://github.com/blakeembrey/change-case/tree/master/packages/dot-case
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-dynamic-import version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-syntax-class-properties version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-block-scoping version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-destructuring version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-function-name version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-typeof-symbol version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-unicode-regex version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2015 Titus Wormer <tituswormer@gmail.com> character-reference-invalid version 1.1.4 https://github.com/wooorm/character-reference-invalid
+Copyright (c) 2015-2016 Amjad Masad <amjad.masad@gmail.com> babel-helper-to-multiple-sequence-expressions version 0.5.0 https://github.com/babel/minify
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/addon-links version 5.3.19 https://github.com/storybookjs/storybook/tree/master/addons/links
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). collection-visit version 1.0.0 https://github.com/jonschlinkert/collection-visit
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) path-is-absolute version 1.0.1 https://github.com/sindresorhus/path-is-absolute
+Copyright (c) 2012, 2011 Ariya Hidayat (http://ariya.ofilabs.com/about) (twitter ariyahidayat (http://twitter.com/ariyahidayat)) and other contributors.
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-optimise-call-expression version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-remap-async-to-generator version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-split-export-declaration version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-syntax-numeric-separator version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-jsx-self version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-reserved-words version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/client-api version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/client-api
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/components version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/components
+copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/> lodash.sortby version 4.7.0 https://lodash.com
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-class-properties version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-arrow-functions version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-unicode-escapes version 7.10.4 https://github.com/babel/babel
+copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/> lodash.memoize version 4.1.2 https://lodash.com
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-optional-chaining version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-flow-strip-types version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-modules-commonjs version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-named-capturing-groups-regex version 7.10.4 https://babeljs.io
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-jsx-source version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> unist-util-remove-position version 2.0.1 https://github.com/syntax-tree/unist-util-remove-position
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/node-logger version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/node-logger
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) binary-extensions version 1.13.1 https://github.com/sindresorhus/binary-extensions
+copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/> lodash.debounce version 4.0.8 https://lodash.com
+copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/> lodash.throttle version 4.1.1 https://lodash.com
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) camel-case version 4.1.1 https://github.com/blakeembrey/change-case/tree/master/packages/camel-case
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) lower-case version 2.0.1 https://github.com/blakeembrey/change-case/tree/master/packages/lower-case
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) param-case version 3.0.3 https://github.com/blakeembrey/change-case/tree/master/packages/param-case
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-object-rest-spread version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-property-literals version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). is-data-descriptor version 1.0.0 https://github.com/jonschlinkert/is-data-descriptor
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) to-readable-stream version 1.0.0 https://github.com/sindresorhus/to-readable-stream
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-create-class-features-plugin version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-async-to-generator version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-display-name version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com) pascal-case version 3.1.1 https://github.com/blakeembrey/change-case/tree/master/packages/pascal-case
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-create-regexp-features-plugin version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-explode-assignable-expression version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-computed-properties version 7.10.4 https://github.com/babel/babel
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) decompress-response version 3.3.0 https://github.com/sindresorhus/decompress-response
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-builder-react-jsx-experimental version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-member-expression-to-functions version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-shorthand-properties version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/client-logger version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/client-logger
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-optional-catch-binding version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-jsx-development version 7.10.4 https://github.com/babel/babel
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) crypto-random-string version 1.0.0 https://github.com/sindresorhus/crypto-random-string
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) escape-string-regexp version 1.0.5 https://github.com/sindresorhus/escape-string-regexp
+Copyright Mathias Bynens <https://mathiasbynens.be/> regenerate-unicode-properties version 8.2.0 https://github.com/mathiasbynens/regenerate-unicode-properties
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-block-scoped-functions version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-pure-annotations version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com> unist-util-stringify-position version 2.0.3 https://github.com/syntax-tree/unist-util-stringify-position
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-exponentiation-operator version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-react-constant-elements version 7.10.4 https://github.com/babel/babel
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-installed-globally version 0.1.0 https://github.com/sindresorhus/is-installed-globally
+Copyright (c) 2012-2019 Paul Miller (https://paulmillr.com) & Elan Shanker constants-browserify version 1.0.0 https://github.com/juliangruber/constants-browserify
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-async-generator-functions version 7.10.5 https://github.com/babel/babel
+Copyright (c) 2017, Jon Schlinkert (https://github.com/jonschlinkert). is-accessor-descriptor version 1.0.0 https://github.com/jonschlinkert/is-accessor-descriptor
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-proposal-nullish-coalescing-operator version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2016, Jon Schlinkert (https://github.com/jonschlinkert). posix-character-classes version 0.1.1 https://github.com/jonschlinkert/posix-character-classes
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com) strip-json-comments version 3.1.1 https://github.com/sindresorhus/strip-json-comments
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com) is-fullwidth-code-point version 2.0.0 https://github.com/sindresorhus/is-fullwidth-code-point
+Copyright Mathias Bynens <https://mathiasbynens.be/> unicode-match-property-ecmascript version 1.0.4 https://github.com/mathiasbynens/unicode-match-property-ecmascript
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/helper-builder-binary-assignment-operator-visitor version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2017 Kadira Inc. <hello@kadira.io> storybook/channel-postmessage version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/channel-postmessage
+Copyright 2012-2015, Kit Cambridge, Benjamin Tan http://kit.mit-license.org webpack-hot-middleware version 2.25.0 https://github.com/webpack-contrib/webpack-hot-middleware
+Copyright Mathias Bynens <https://mathiasbynens.be/> unicode-property-aliases-ecmascript version 1.1.0 https://github.com/mathiasbynens/unicode-property-aliases-ecmascript
+Copyright (c) 2012-2015 Rod Vagg (https://github.com/rvagg) ( rvagg (https://twitter.com/rvagg)) es6-promisify version 5.0.0 https://github.com/digitaldesignlabs/es6-promisify
+Copyright Joyent, Inc. and other Node contributors. safe-regex version 1.1.0 https://github.com/substack/safe-regex text-table version 0.2.0 https://github.com/substack/text-table
+Copyright Mathias Bynens <https://mathiasbynens.be/> unicode-match-property-value-ecmascript version 1.2.0 https://github.com/mathiasbynens/unicode-match-property-value-ecmascript
+Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors storybook/core-events version 5.3.19 https://github.com/storybookjs/storybook/tree/master/lib/core-events
+Copyright Mathias Bynens <https://mathiasbynens.be/> unicode-canonical-property-names-ecmascript version 1.0.4 https://github.com/mathiasbynens/unicode-canonical-property-names-ecmascript
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/preset-react version 7.10.4 https://babeljs.io/ babel/preset-typescript version 7.10.4 https://github.com/babel/babel
+Copyright (c) 2014-present Sebastian McKenzie and other contributors babel/plugin-transform-dotall-regex version 7.10.4 https://babeljs.io/ babel/plugin-transform-duplicate-keys version 7.10.4 https://github.com/babel/babel
+Copyright (c) Facebook, Inc. and its affiliates. babel-plugin-add-react-displayname version 0.0.5 https://github.com/opbeat/babel-plugin-add-react-displayname readme babel-plugin-minify-flip-comparisons version 0.4.3 https://github.com/babel/minify
+
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+
 
 
 ------
@@ -11090,7 +12634,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** dns-packet; version 1.3.1 -- https://github.com/mafintosh/dns-packet
+** dns-packet; version 1.3.4 -- https://github.com/mafintosh/dns-packet
 Copyright (c) 2016 Mathias Buus
 
 The MIT License (MIT)
@@ -13393,7 +14937,7 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 
 ------
 
-** hosted-git-info; version 2.8.8 -- https://github.com/npm/hosted-git-info
+** hosted-git-info; version 2.8.9 -- https://github.com/npm/hosted-git-info
 Copyright (c) 2015, Rebecca Turner
 
 Copyright (c) 2015, Rebecca Turner
@@ -20880,7 +22424,7 @@ SOFTWARE.
 
 ------
 
-** lodash; version 4.17.19 -- https://lodash.com/
+** lodash; version 4.17.21 -- https://lodash.com/
 Copyright OpenJS Foundation and other contributors <https://openjsf.org/>
 Copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 copyright Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
@@ -21521,10 +23065,9 @@ Address all questions regarding this license to:
 
 ------
 
-** merge-deep; version 3.0.2 -- https://github.com/jonschlinkert/merge-deep
+** merge-deep; version 3.0.3 -- https://github.com/jonschlinkert/merge-deep
 Copyright (c) 2014-2015, Jon Schlinkert.
 Copyright (c) 2014-present, Jon Schlinkert.
-Copyright (c) 2018, Jon Schlinkert (https://github.com/jonschlinkert).
 ** micromatch; version 4.0.2 -- https://github.com/micromatch/micromatch
 Copyright (c) 2014-present, Jon Schlinkert.
 Copyright (c) 2019, Jon Schlinkert (https://github.com/jonschlinkert).
@@ -36664,7 +38207,7 @@ THE SOFTWARE.
 
 ------
 
-** ws; version 6.2.1 -- https://github.com/websockets/ws
+** ws; version 7.5.5 -- https://github.com/websockets/ws
 Copyright (c) 2011 Einar Otto Stangvik <einaros@gmail.com>
 
 The MIT License (MIT)

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "jquery": "1.11.1",
     "jquery.cookie": "1.4.1",
     "js-yaml": "^4.0.0",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "marked": "^0.7.0",
     "mobx": "^4.3.1",
     "mobx-react": "^5.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12692,22 +12692,7 @@ lodash.uniq@4.5.0, lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.13, lodash@^4.17.15, lodash@^4.17.5, lodash@~4.17.10:
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
-  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.0.1, lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.15.0, lodash@^4.16.2, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.15.0, lodash@^4.16.2, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -19493,18 +19493,13 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 ws@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
-  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.2.tgz#dd5cdbd57a9979916097652d78f1cc5faea0c32e"
+  integrity sha512-zmhltoSR8u1cnDsD43TX59mzoMZsLKqUweyYBAIvTngR3shc0W6aOZylZmq/7hqyVxPdi+5Ud2QInblgyE72fw==
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^7.2.3:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
-
-ws@^7.4.6:
+ws@^7.2.3, ws@^7.4.6:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.5.tgz#8b4bc4af518cfabd0473ae4f99144287b33eb881"
   integrity sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10342,9 +10342,9 @@ homedir-polyfill@^1.0.1:
     parse-passwd "^1.0.0"
 
 hosted-git-info@^2.1.4:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 hpack.js@^2.1.6:
   version "2.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13013,9 +13013,9 @@ meow@^3.7.0:
     trim-newlines "^1.0.0"
 
 merge-deep@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.2.tgz#f39fa100a4f1bd34ff29f7d2bf4508fbb8d83ad2"
-  integrity sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/merge-deep/-/merge-deep-3.0.3.tgz#1a2b2ae926da8b2ae93a0ac15d90cd1922766003"
+  integrity sha512-qtmzAS6t6grwEkNrunqTBdn0qKwFgNWvlxUbAV8es9M7Ot1EbyApytCnvE0jALPa46ZpKDUo527kKiaWplmlFA==
   dependencies:
     arr-union "^3.1.0"
     clone-deep "^0.2.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8036,9 +8036,9 @@ dns-equal@^1.0.0:
   integrity sha1-s55/HabrCnW6nBcySzR1PEfgZU0=
 
 dns-packet@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.1.tgz#12aa426981075be500b910eedcd0b47dd7deda5a"
-  integrity sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-1.3.4.tgz#e3455065824a2507ba886c55a89963bb107dec6f"
+  integrity sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==
   dependencies:
     ip "^1.1.0"
     safe-buffer "^5.0.1"


### PR DESCRIPTION
- Bump merge-deep from 3.0.2 to 3.0.3
- Bump dns-packet from 1.3.1 to 1.3.4
- Bump ws from 6.2.1 to 6.2.2
- Bump lodash from 4.17.19 to 4.17.21
- Bump hosted-git-info from 2.8.8 to 2.8.9
