### PR TITLE
Revert change to using transaction_id as param for transactions in routes

### DIFF
--- a/app/controllers/concerns/controllers/api/transaction/current.rb
+++ b/app/controllers/concerns/controllers/api/transaction/current.rb
@@ -10,7 +10,7 @@ module Controllers::Api::Transaction::Current
 		private
 
 		def current_transaction
-			@current_transaction ||= current_nonprofit.transactions.find(params[:transaction_id])
+			@current_transaction ||= current_nonprofit.transactions.find(params[:transaction_id] || params[:id])
 		end
 	end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
           resources :supporter_notes, only: [:index, :show]
         end
         resources :tag_definitions, only: [:index, :show]
-        resources :transactions, only: [:index, :show], param: :transaction_id
+        resources :transactions, only: [:index, :show]
       end
 
       resources :users, only: [] do


### PR DESCRIPTION
Rails routing does weird stuff when you rename the id for resources so this reverts the change﻿
