### PR TITLE
Remove old IE warning

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -29,22 +29,3 @@
 		<%= render 'components/footer_sub' %>
 	</footer>
 <% end %>
-
-<!--[if lte IE 9]>
-  <div class='modal inView'>
-  	<div class='modal-body u-strong'>
-      <div class='pastelBox--orange u-padding--10'>
-    		<p>
-          It looks like you're using an older version of Internet Explorer.  Because Microsoft is no longer offering support or security updates to your version of Internet Explorer, we strongly suggest you update your browser to avoid security and display issues.
-        </p>
-    		<p>
-          <a href='http://www.mozilla.org/'>Try Firefox,</a>
-          a browser made by a nonprofit.
-        </p>
-    		<p>
-          Or, <a href='http://windows.microsoft.com/en-us/internet-explorer/download-ie'>update your version of Internet Explorer.</a>
-        </p>
-      </div>
-  	</div>
-  </div>
-<![endif]-->


### PR DESCRIPTION
We had a warning to tell people that they need to upgrade their to at least IE9. We don't support anything lower than IE11 and only barely that. Let's remove this.﻿
