### PR TITLE
Work in progress on AmountStep and InfoStep

### DIFF
--- a/app/assets/stylesheets/body.css.scss
+++ b/app/assets/stylesheets/body.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'components/side_nav_dimensions';
+@import './components/side_nav_dimensions.css.scss';
 
 body { 
 	margin: 0; 

--- a/app/assets/stylesheets/bootstrap-tour.css.scss
+++ b/app/assets/stylesheets/bootstrap-tour.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 .btn {
   border: none;

--- a/app/assets/stylesheets/campaigns/edit/page.css.scss
+++ b/app/assets/stylesheets/campaigns/edit/page.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'common/image_uploader';
-@import 'mixins';
+@import './common/image_uploader.css.scss';
+@import './mixins.css.scss';
 
 #settings-modal {
 	.field {

--- a/app/assets/stylesheets/campaigns/index/page.css.scss
+++ b/app/assets/stylesheets/campaigns/index/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'common/fundraisers';
-@import 'campaigns/new/index';
+@import './mixins.css.scss';
+@import './common/fundraisers.css.scss';
+@import './campaigns/new/index.css.scss';
 

--- a/app/assets/stylesheets/campaigns/new/index.css.scss
+++ b/app/assets/stylesheets/campaigns/new/index.css.scss
@@ -1,8 +1,8 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'pikaday';
-@import 'common/image_uploader';
+@import './mixins.css.scss';
+@import './pikaday.css.scss';
+@import './common/image_uploader.css.scss';
 
 .globalFooter {
   margin-top: 50px;

--- a/app/assets/stylesheets/campaigns/peer_to_peer/page.css.scss
+++ b/app/assets/stylesheets/campaigns/peer_to_peer/page.css.scss
@@ -1,13 +1,13 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/q_and_a';
-@import 'components/timeline';
-@import 'components/type_ahead';
-@import 'components/simple_tabs';
-@import 'pikaday';
-@import 'common/image_uploader';
-@import '../common';
+@import './mixins.css.scss';
+@import './components/q_and_a.css.scss';
+@import './components/timeline.css.scss';
+@import './components/type_ahead.css.scss';
+@import './components/simple_tabs.css.scss';
+@import './pikaday.css.scss';
+@import './common/image_uploader.css.scss';
+@import './../common.css.scss';
 
 body {
 	padding: 0;

--- a/app/assets/stylesheets/campaigns/show/page.css.scss
+++ b/app/assets/stylesheets/campaigns/show/page.css.scss
@@ -1,20 +1,20 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'pikaday';
-@import 'bootstrap-tour';
-@import 'common/donate_button';
-@import 'common/editable';
-@import 'components/admin_top_nav';
-@import 'common/image_uploader';
-@import 'components/info_card';
-@import 'components/activity_feed';
-@import 'components/page_tabs';
-@import 'components/fixed_top_action';
-@import 'components/draggable';
-@import 'gift_levels';
-@import '../../nonprofits/donation_form/form';
-@import '../common';
+@import './mixins.css.scss';
+@import './pikaday.css.scss';
+@import './bootstrap-tour.css.scss';
+@import './common/donate_button.css.scss';
+@import './common/editable.css.scss';
+@import './components/admin_top_nav.css.scss';
+@import './common/image_uploader.css.scss';
+@import './components/info_card.css.scss';
+@import './components/activity_feed.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/fixed_top_action.css.scss';
+@import './components/draggable.css.scss';
+@import './gift_levels.css.scss';
+@import './../../nonprofits/donation_form/form.css.scss';
+@import './../common.css.scss';
 
 .button--gift {
 	font-size: 17px;

--- a/app/assets/stylesheets/campaigns/supporters/index/page.css.scss
+++ b/app/assets/stylesheets/campaigns/supporters/index/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/pagination';
-@import 'components/page_tabs';
+@import './mixins.css.scss';
+@import './components/pagination.css.scss';
+@import './components/page_tabs.css.scss';
 

--- a/app/assets/stylesheets/common/branded_campaign_button.css.scss
+++ b/app/assets/stylesheets/common/branded_campaign_button.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 // campaign widget
 // (cw = campaign widget)

--- a/app/assets/stylesheets/common/campaign_card.css.scss
+++ b/app/assets/stylesheets/common/campaign_card.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .campaign-card {
 	text-align: center;

--- a/app/assets/stylesheets/common/donate_button.css.scss
+++ b/app/assets/stylesheets/common/donate_button.css.scss
@@ -1,8 +1,8 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'supporters/form';
-@import 'nonprofits/donation_form/title_row';
-@import 'nonprofits/donation_form/footer';
-@import 'nonprofits/donation_form/form'; // for styling the actual form 
-@import 'nonprofits/donation_form/show/index'; // for styling the layout on /donate
+@import '../mixins.css.scss';
+@import '../supporters/form.css.scss';
+@import '../nonprofits/donation_form/title_row.css.scss';
+@import '../nonprofits/donation_form/footer.css.scss';
+@import '../nonprofits/donation_form/form.css.scss'; // for styling the actual form 
+@import '../nonprofits/donation_form/show/index.css.scss'; // for styling the layout on /donate

--- a/app/assets/stylesheets/common/editable.css.scss
+++ b/app/assets/stylesheets/common/editable.css.scss
@@ -1,6 +1,6 @@
 /* # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .editable,
 .editable--readOnly {

--- a/app/assets/stylesheets/common/fonts_special.css.scss
+++ b/app/assets/stylesheets/common/fonts_special.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .strong {font-weight: bold;}
 

--- a/app/assets/stylesheets/common/fundraisers.css.scss
+++ b/app/assets/stylesheets/common/fundraisers.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .fundraiser--active {
 	background-color: rgba($manila, 0.5);

--- a/app/assets/stylesheets/common/icons.css.scss
+++ b/app/assets/stylesheets/common/icons.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 // for styling icons and UI related psuedo elements.
 

--- a/app/assets/stylesheets/common/image_uploader.css.scss
+++ b/app/assets/stylesheets/common/image_uploader.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 .image-upload {
 	text-align: center;
 	margin: 0 auto;

--- a/app/assets/stylesheets/common/images.css.scss
+++ b/app/assets/stylesheets/common/images.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 img { 
 	max-width: 100%; 

--- a/app/assets/stylesheets/common/layouts.css.scss
+++ b/app/assets/stylesheets/common/layouts.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 [class*=" col-"].floatr {
 	clear: none;

--- a/app/assets/stylesheets/common/media_queries.css.scss
+++ b/app/assets/stylesheets/common/media_queries.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 // query by max-width
 

--- a/app/assets/stylesheets/common/minimal_vertically_center.css.scss
+++ b/app/assets/stylesheets/common/minimal_vertically_center.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 // used for minimal, single-purpose pages like the unsubscribe page
 

--- a/app/assets/stylesheets/common/page.css.scss
+++ b/app/assets/stylesheets/common/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .pageTitle {
 	position: absolute;

--- a/app/assets/stylesheets/common/promote_button.css.scss
+++ b/app/assets/stylesheets/common/promote_button.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .promote-button {
 	display: block;

--- a/app/assets/stylesheets/common/states.css.scss
+++ b/app/assets/stylesheets/common/states.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .is-stuck {
 	top: 0;

--- a/app/assets/stylesheets/common/successes.css.scss
+++ b/app/assets/stylesheets/common/successes.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 
 .successes-section {

--- a/app/assets/stylesheets/common/typography/base.css.scss
+++ b/app/assets/stylesheets/common/typography/base.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../../mixins.css.scss';
 
 // This file should'nt include any classes -
 // just HTML elements that are typographical.

--- a/app/assets/stylesheets/common/typography/special.css.scss
+++ b/app/assets/stylesheets/common/typography/special.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../../mixins.css.scss';
 
 .strong {
 	font-weight: bold;

--- a/app/assets/stylesheets/common/utils.css.scss
+++ b/app/assets/stylesheets/common/utils.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .hide {display: none; }
 .show {display: block;}

--- a/app/assets/stylesheets/components/activity_feed.css.scss
+++ b/app/assets/stylesheets/components/activity_feed.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .activityFeed table,
 .activityFeed tr  {

--- a/app/assets/stylesheets/components/admin_sidebar.css.scss
+++ b/app/assets/stylesheets/components/admin_sidebar.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .adminSidebar-body {
 	padding: 10px 15px;

--- a/app/assets/stylesheets/components/announcement_bar.css.scss
+++ b/app/assets/stylesheets/components/announcement_bar.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mixin announcementBar($bg) {
 	display: none;

--- a/app/assets/stylesheets/components/app_loading_bar.css.scss
+++ b/app/assets/stylesheets/components/app_loading_bar.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @-webkit-keyframes progress-bar-stripes{
 	from{background-position:40px 0}

--- a/app/assets/stylesheets/components/arrows.css.scss
+++ b/app/assets/stylesheets/components/arrows.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .sortArrows {
 	@include noselect;

--- a/app/assets/stylesheets/components/better_browser.css.scss
+++ b/app/assets/stylesheets/components/better_browser.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 #better-browser-message {
 	position: fixed;

--- a/app/assets/stylesheets/components/bulk_actions.css.scss
+++ b/app/assets/stylesheets/components/bulk_actions.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .bulkActions-checkbox {
 	display: inline-block;

--- a/app/assets/stylesheets/components/buttons.css.scss
+++ b/app/assets/stylesheets/components/buttons.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/animations';
+@import '../mixins.css.scss';
+@import './animations.css.scss';
 
 // don't add any more classes here
 

--- a/app/assets/stylesheets/components/campaign_preview_small.css.scss
+++ b/app/assets/stylesheets/components/campaign_preview_small.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .campaignPreview--small {
 	padding: 15px;

--- a/app/assets/stylesheets/components/cards.css.scss
+++ b/app/assets/stylesheets/components/cards.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .cardForm {
 	max-width: 380px;

--- a/app/assets/stylesheets/components/carousel.css.scss
+++ b/app/assets/stylesheets/components/carousel.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .carousel {
   position: relative;

--- a/app/assets/stylesheets/components/cc_pattern.css.scss
+++ b/app/assets/stylesheets/components/cc_pattern.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .ccPattern {
 	position: absolute;

--- a/app/assets/stylesheets/components/container.css.scss
+++ b/app/assets/stylesheets/components/container.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mixin container {
 	width: 100%;

--- a/app/assets/stylesheets/components/decorative.css.scss
+++ b/app/assets/stylesheets/components/decorative.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 hr {
 	border: 0;

--- a/app/assets/stylesheets/components/event_preview_small.css.scss
+++ b/app/assets/stylesheets/components/event_preview_small.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .eventPreview--small {
   position: relative;

--- a/app/assets/stylesheets/components/fade_in.css.scss
+++ b/app/assets/stylesheets/components/fade_in.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mi
 

--- a/app/assets/stylesheets/components/ff_modal.css.scss
+++ b/app/assets/stylesheets/components/ff_modal.css.scss
@@ -85,7 +85,7 @@ Full license explanation at https://github.com/houdiniproject/houdini/blob/main/
 [data-ff-modal-close-button]:before,
 .ff-modal-closeButton:before {
   content: '';
-  background-image: url('ui_components/close.svg');
+  // background-image: url('../../images/ui_components/close.svg');
   background-size: 24px 23px;
   width: 24px;
   height: 23px;
@@ -109,7 +109,7 @@ Full license explanation at https://github.com/houdiniproject/houdini/blob/main/
 [data-ff-modal-close-button]:before,
 .ff-modal-closeButton:before {
   content: '';
-  background-image: url('ui_components/close.svg');
+  // background-image: url('../../images/ui_components/close.svg');
   background-size: 24px 23px;
   width: 24px;
   height: 23px;

--- a/app/assets/stylesheets/components/focal_point.css.scss
+++ b/app/assets/stylesheets/components/focal_point.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .focalPointPreview {
 	position: relative;

--- a/app/assets/stylesheets/components/footer.css.scss
+++ b/app/assets/stylesheets/components/footer.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/press_row';
+@import '../mixins.css.scss';
+@import './/press_row.css.scss';
 
 .globalFooter--mosaic {
 	background: $mosaic;

--- a/app/assets/stylesheets/components/forms.css.scss
+++ b/app/assets/stylesheets/components/forms.css.scss
@@ -2,7 +2,7 @@
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
 // Errors and form statuses
 
-@import 'mixins';
+@import '../mixins.css.scss';
 
 form {
 	margin: 0;

--- a/app/assets/stylesheets/components/full_features.css.scss
+++ b/app/assets/stylesheets/components/full_features.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .fullFeatures .masonry-column > div {
 	margin-bottom: 30px;

--- a/app/assets/stylesheets/components/giving_indicator.css.scss
+++ b/app/assets/stylesheets/components/giving_indicator.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 $indicator_size: 16px;
 $indicator_color: $dark-grass;

--- a/app/assets/stylesheets/components/headers.css.scss
+++ b/app/assets/stylesheets/components/headers.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mixin fundraiserHeader {
 	width: 100%;

--- a/app/assets/stylesheets/components/inputs.css.scss
+++ b/app/assets/stylesheets/components/inputs.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mixin basicInputs {
 	input[type="text"], input, input[type="email"], input[type="number"], input[type="password"], input[type="tel"], select {
@@ -241,7 +241,7 @@ input[type='radio']:checked + label:before {
 	background-color: $bluegrass;
 }
 input[type='radio'].radio--both {
-	@extend input[type='radio'];
+	@extend input, [type='radio'];
 	& + label {
 		@include opacity(0.9);
 	}

--- a/app/assets/stylesheets/components/legend.css.scss
+++ b/app/assets/stylesheets/components/legend.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .legend > * {
   border: 1px solid white;

--- a/app/assets/stylesheets/components/loading.css.scss
+++ b/app/assets/stylesheets/components/loading.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .loading--overlay {
   position: relative;

--- a/app/assets/stylesheets/components/modals.css.scss
+++ b/app/assets/stylesheets/components/modals.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/ff_modal';
+@import '../mixins.css.scss';
+@import './/ff_modal.css.scss';
 
 .modal{
 	position: fixed;

--- a/app/assets/stylesheets/components/notification_alerts.css.scss
+++ b/app/assets/stylesheets/components/notification_alerts.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-// @import '/assets/ff-core/notification/index.css'
+@import '../mixins.css.scss';
+// @import './/assets/ff-core/notification/index.css.css.scss'
 
 $notice-red : lighten($red, 10); 
 $notice-green : lighten($grass, 60);  

--- a/app/assets/stylesheets/components/npo_card.css.scss
+++ b/app/assets/stylesheets/components/npo_card.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .npoCard {
 	@include transition(box-shadow 0.1s ease);

--- a/app/assets/stylesheets/components/page_tabs.css.scss
+++ b/app/assets/stylesheets/components/page_tabs.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .pageTabs {
 	position: absolute;

--- a/app/assets/stylesheets/components/panels_layout.css.scss
+++ b/app/assets/stylesheets/components/panels_layout.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 html {
 	height: 100%;

--- a/app/assets/stylesheets/components/parsley.css.scss
+++ b/app/assets/stylesheets/components/parsley.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .parsley-error-list {
 	padding: 4px;

--- a/app/assets/stylesheets/components/pastel_boxes.css.scss
+++ b/app/assets/stylesheets/components/pastel_boxes.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mixin pastelBox {
 	border: 1px solid rgba(black, 0.03);

--- a/app/assets/stylesheets/components/progress_bar.css.scss
+++ b/app/assets/stylesheets/components/progress_bar.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 @mixin progressBar {
 	width: 100%;

--- a/app/assets/stylesheets/components/q_and_a.css.scss
+++ b/app/assets/stylesheets/components/q_and_a.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'components/circle_text';
+@import './/circle_text.css.scss';
 
 .question,
 .answer {

--- a/app/assets/stylesheets/components/side_nav.css.scss
+++ b/app/assets/stylesheets/components/side_nav.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/side_nav_dimensions';
+@import '../mixins.css.scss';
+@import './/side_nav_dimensions.css.scss';
 
 $sideNav-spacing: 8px 15px;
 

--- a/app/assets/stylesheets/components/simple_tabs.css.scss
+++ b/app/assets/stylesheets/components/simple_tabs.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .simpleTabs-tab {
   background: $fog;

--- a/app/assets/stylesheets/components/tags.css.scss
+++ b/app/assets/stylesheets/components/tags.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 $tag_color: #ece6e0;
 

--- a/app/assets/stylesheets/components/ticket_button.css.scss
+++ b/app/assets/stylesheets/components/ticket_button.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .getTickets {
 	width: 100%;

--- a/app/assets/stylesheets/components/todos.css.scss
+++ b/app/assets/stylesheets/components/todos.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 .todos {
 	background: #f8f8f8;
 }

--- a/app/assets/stylesheets/components/toggle_buttons.css.scss
+++ b/app/assets/stylesheets/components/toggle_buttons.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 button[toggle] {
 	padding: 0;

--- a/app/assets/stylesheets/components/toggle_q_a.css.scss
+++ b/app/assets/stylesheets/components/toggle_q_a.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 .toggleQA-toggle {
   width: 100%;

--- a/app/assets/stylesheets/components/wizard_index.css.scss
+++ b/app/assets/stylesheets/components/wizard_index.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../mixins.css.scss';
 
 $chevron_height: 34px;
 

--- a/app/assets/stylesheets/coupons/page.css.scss
+++ b/app/assets/stylesheets/coupons/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 body {
 	padding: 0;

--- a/app/assets/stylesheets/events/index/page.css.scss
+++ b/app/assets/stylesheets/events/index/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'common/fundraisers';
-@import 'events/new/index';
+@import './mixins.css.scss';
+@import './common/fundraisers.css.scss';
+@import './events/new/index.css.scss';
 

--- a/app/assets/stylesheets/events/listing.css.scss
+++ b/app/assets/stylesheets/events/listing.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 .events {
 	text-align: left;

--- a/app/assets/stylesheets/events/new/index.css.scss
+++ b/app/assets/stylesheets/events/new/index.css.scss
@@ -1,8 +1,8 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'pikaday';
-@import 'common/image_uploader';
-@import 'mixins';
+@import './pikaday.css.scss';
+@import './common/image_uploader.css.scss';
+@import './mixins.css.scss';
 
 .dates-fields {
 	margin: 15px auto 0 auto;

--- a/app/assets/stylesheets/events/show/page.css.scss
+++ b/app/assets/stylesheets/events/show/page.css.scss
@@ -1,22 +1,22 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'pikaday';
-@import 'mixins';
-@import 'bootstrap-tour';
+@import './pikaday.css.scss';
+@import './mixins.css.scss';
+@import './bootstrap-tour.css.scss';
 
-@import 'common/image_uploader';
-@import 'components/activity_feed';
-@import 'components/admin_top_nav';
-@import 'common/editable';
-@import 'common/donate_button';
-@import 'common/fundraiser/metrics';
+@import './common/image_uploader.css.scss';
+@import './components/activity_feed.css.scss';
+@import './components/admin_top_nav.css.scss';
+@import './common/editable.css.scss';
+@import './common/donate_button.css.scss';
+@import './common/fundraiser/metrics.css.scss';
 
-@import 'components/info_card';
-@import 'components/page_tabs';
-@import 'components/ticket_button';
-@import 'events/show/settings';
-@import 'components/fixed_top_action';
-@import 'components/draggable';
+@import './components/info_card.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/ticket_button.css.scss';
+@import './events/show/settings.css.scss';
+@import './components/fixed_top_action.css.scss';
+@import './components/draggable.css.scss';
 
 .globalFooter {
 	margin-top: 40px;

--- a/app/assets/stylesheets/events/stats/page.css.scss
+++ b/app/assets/stylesheets/events/stats/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 html {
 	height: 100%;
 }

--- a/app/assets/stylesheets/experiment/global/dashboard.css
+++ b/app/assets/stylesheets/experiment/global/dashboard.css
@@ -1,6 +1,6 @@
 /* License: LGPL-3.0-or-later */
-@import 'ff-dashboard';
-@import './colors.css';
+@import './ff-dashboard.css.scss';
+@import '././colors.css.css.scss';
 
 [data-ff-dashboard-header] {
   background: white;

--- a/app/assets/stylesheets/experiment/global/modal.css
+++ b/app/assets/stylesheets/experiment/global/modal.css
@@ -1,5 +1,5 @@
 /* License: LGPL-3.0-or-later */
-@import 'flimflam/ui/modal/index.css';  /* npm */
+@import './flimflam/ui/modal/index.css.css.scss';  /* npm */
 
 [data-ff-modal-backdrop] {
   z-index: 2;

--- a/app/assets/stylesheets/experiment/global/page.css
+++ b/app/assets/stylesheets/experiment/global/page.css
@@ -1,22 +1,22 @@
 /* License: LGPL-3.0-or-later */
-@import 'commons.css';   /* npm */
-@import 'colors.css';  /* contains variables */
-@import 'shadows.css'; /* contains variables */
-/*@import 'typography.css';*/
-@import 'icons.css';
-@import 'containers.css';
-@import 'buttons.css';
-@import 'decorative.css';
-@import 'form-elements.css';
-@import 'modal.css';
-@import 'notification.css';
-@import 'confirmation.css';
-@import 'wizard.css';
-@import 'tooltip.css';
-@import 'tabswap.css';
-@import 'utils.css';
-@import 'loader.css';
-@import 'pre.css';
+@import './commons.css.css.scss';   /* npm */
+@import './colors.css.css.scss';  /* contains variables */
+@import './shadows.css.css.scss'; /* contains variables */
+/*@import './typography.css.css.scss';*/
+@import './icons.css.css.scss';
+@import './containers.css.css.scss';
+@import './buttons.css.css.scss';
+@import './decorative.css.css.scss';
+@import './form-elements.css.css.scss';
+@import './modal.css.css.scss';
+@import './notification.css.css.scss';
+@import './confirmation.css.css.scss';
+@import './wizard.css.css.scss';
+@import './tooltip.css.css.scss';
+@import './tabswap.css.css.scss';
+@import './utils.css.css.scss';
+@import './loader.css.css.scss';
+@import './pre.css.css.scss';
 
 /* add to commons */
 @media (max-width: 30rem) {

--- a/app/assets/stylesheets/experiment/global/tabswap.css
+++ b/app/assets/stylesheets/experiment/global/tabswap.css
@@ -1,5 +1,5 @@
 /* License: LGPL-3.0-or-later */
-@import 'flimflam/ui/tabswap/index.css'; /* npm */ 
+@import './flimflam/ui/tabswap/index.css.css.scss'; /* npm */ 
 
 [data-ff-tabswap-labels] {
   border-bottom: 2px solid var(--grey-4);

--- a/app/assets/stylesheets/experiment/global/tooltip.css
+++ b/app/assets/stylesheets/experiment/global/tooltip.css
@@ -1,5 +1,5 @@
 /* License: LGPL-3.0-or-later */
-@import 'data-tooltip'; /* npm */
+@import './data-tooltip.css.scss'; /* npm */
 
 [data-ff-field] { position: relative; }
 

--- a/app/assets/stylesheets/explore/page.css.scss
+++ b/app/assets/stylesheets/explore/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 body {
 	padding: 0;

--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -1,48 +1,48 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'resets';
-@import 'common/typography/base';
-@import 'common/typography/special';
+@import './mixins.css.scss';
+@import './resets.css.scss';
+@import './common/typography/base.css.scss';
+@import './common/typography/special.css.scss';
 
-@import 'components/container';
-@import 'body';
-@import 'components/buttons';
+@import './components/container.css.scss';
+@import './body.css.scss';
+@import './components/buttons.css.scss';
 
-@import 'common/images';
+@import './common/images.css.scss';
 
-@import 'components/headers';
-@import 'components/side_nav';
+@import './components/headers.css.scss';
+@import './components/side_nav.css.scss';
 
-@import 'components/footer';
-@import 'common/layouts';
-@import 'common/page';
-@import 'common/utils';
-@import 'common/states';
-@import 'common/icons';
+@import './components/footer.css.scss';
+@import './common/layouts.css.scss';
+@import './common/page.css.scss';
+@import './common/utils.css.scss';
+@import './common/states.css.scss';
+@import './common/icons.css.scss';
 
-@import 'components/announcement_bar';
-@import 'components/notification_alerts';
-@import 'components/forms';
-@import 'components/modals';
-@import 'components/inputs';
-@import 'components/wizard_index';
-@import 'components/decorative';
-@import 'components/progress_bar'; 
-@import 'components/better_browser';
-@import 'components/parsley';
-@import 'components/tables';
-@import 'components/arrows';
-@import 'components/cards';
-@import 'components/pastel_boxes';
-@import 'components/full_screen_loading';
-@import 'components/loading';
-@import 'components/tooltips';
-@import 'components/top_nav';
+@import './components/announcement_bar.css.scss';
+@import './components/notification_alerts.css.scss';
+@import './components/forms.css.scss';
+@import './components/modals.css.scss';
+@import './components/inputs.css.scss';
+@import './components/wizard_index.css.scss';
+@import './components/decorative.css.scss';
+@import './components/progress_bar.css.scss'; 
+@import './components/better_browser.css.scss';
+@import './components/parsley.css.scss';
+@import './components/tables.css.scss';
+@import './components/arrows.css.scss';
+@import './components/cards.css.scss';
+@import './components/pastel_boxes.css.scss';
+@import './components/full_screen_loading.css.scss';
+@import './components/loading.css.scss';
+@import './components/tooltips.css.scss';
+@import './components/top_nav.css.scss';
 
-@import 'common/media_queries';
-@import 'common/z_indices';
-@import 'common/ios_hack';
-@import 'common/minimal';
+@import './common/media_queries.css.scss';
+@import './common/z_indices.css.scss';
+@import './common/ios_hack.scss';
+@import './common/minimal.css.scss';
 
-@import 'common/focusable'
+@import './common/_focusable.scss'

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'common/colors';
-@import 'common/backgrounds';
+@import './common/colors.css.scss';
+@import './common/backgrounds.css.scss';
 
 // COMMON EFFECTS:
 $cubic_bevier: cubic-bezier(.5,1.2,.6,1);

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import './common/colors.css.scss';
-@import './common/backgrounds.css.scss';
+@import '././common/colors.css.scss';
+@import '././common/backgrounds.css.scss';
 
 // COMMON EFFECTS:
 $cubic_bevier: cubic-bezier(.5,1.2,.6,1);

--- a/app/assets/stylesheets/mixins.css.scss
+++ b/app/assets/stylesheets/mixins.css.scss
@@ -248,11 +248,12 @@ $cubic_bevier: cubic-bezier(.5,1.2,.6,1);
 @mixin gradient($dir, $from, $to) {
 	$ie-hex-from: ie-hex-str($from);
 	$ie-hex-to: ie-hex-str($to);
-	background-image: -webkit-linear-gradient($dir,$from,$to);
 	background-image: -moz-linear-gradient($dir,$from,$to);
 	background-image: -ms-linear-gradient($dir,$from,$to);
 	background-image: -o-linear-gradient($dir,$from,$to);
 	background-image: linear-gradient($dir,$from,$to);
+	// changing this one to be the last one of the list worked for the donation wizard index, not sure why
+	background-image: -webkit-linear-gradient($dir,$from,$to);
 	// For IE7-9:
 	$gradientType: 0;
 	@if $dir == 'left' { $gradientType: 1;}

--- a/app/assets/stylesheets/nonprofits/btn/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/btn/page.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/animations';
+@import './mixins.css.scss';
+@import './components/animations.css.scss';
 
 @include keyframes(popUp) {
 	0% { @include transform(translateY(80px)); }

--- a/app/assets/stylesheets/nonprofits/button/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/button/page.css.scss
@@ -1,11 +1,11 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'nonprofits/btn/page';
-@import 'components/page_tabs';
-@import 'components/steps_menu';
-@import 'components/help_box';
-@import 'components/animations';
+@import './mixins.css.scss';
+@import './nonprofits/btn/page.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/steps_menu.css.scss';
+@import './components/help_box.css.scss';
+@import './components/animations.css.scss';
 
 .stepsMenu { 
 	margin-top: 15px;

--- a/app/assets/stylesheets/nonprofits/dashboard/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/dashboard/page.css.scss
@@ -1,15 +1,15 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'bootstrap-tour';
-@import 'components/activity_feed';
-@import 'components/event_preview_small';
-@import 'campaigns/new/index';
-@import 'events/new/index';
-@import 'components/todos';
-@import 'components/nonprofit_bank_accounts';
-@import 'components/google_maps';
-@import 'components/info_card';
+@import './mixins.css.scss';
+@import './bootstrap-tour.css.scss';
+@import './components/activity_feed.css.scss';
+@import './components/event_preview_small.css.scss';
+@import './campaigns/new/index.css.scss';
+@import './events/new/index.css.scss';
+@import './components/todos.css.scss';
+@import './components/nonprofit_bank_accounts.css.scss';
+@import './components/google_maps.css.scss';
+@import './components/info_card.css.scss';
 
 .globalFooter {
 	margin-top: 40px;

--- a/app/assets/stylesheets/nonprofits/donate/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/donate/page.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'common/donate_button';
+@import '../../common/donate_button.css.scss';
 
 body#donate {
 	background-color: transparent;

--- a/app/assets/stylesheets/nonprofits/donation_form/footer.css.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/footer.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../../mixins.css.scss';
 
 .donateForm-footer {
 	background: $fog;

--- a/app/assets/stylesheets/nonprofits/donation_form/form.css.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/form.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../../mixins.css.scss';
 
 $mint-milk : #E7F3ED;
 

--- a/app/assets/stylesheets/nonprofits/donation_form/show/index.css.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/show/index.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../../../mixins.css.scss';
 
 $width: 400px; // same as .modal.skinny
 

--- a/app/assets/stylesheets/nonprofits/donation_form/title_row.css.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/title_row.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import '../../mixins.css.scss';
 
 .titleRow {
 	padding: 15px 15px 10px 15px;

--- a/app/assets/stylesheets/nonprofits/payments/index/filter_panel.css.scss
+++ b/app/assets/stylesheets/nonprofits/payments/index/filter_panel.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 
 .filterPanel-section .field {

--- a/app/assets/stylesheets/nonprofits/payments/index/main_panel.css.scss
+++ b/app/assets/stylesheets/nonprofits/payments/index/main_panel.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 .mainPanel td:last-of-type {
 	@include ellipsis;

--- a/app/assets/stylesheets/nonprofits/payments/index/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/payments/index/page.css.scss
@@ -1,13 +1,13 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'pikaday';
-@import 'bootstrap-tour';
-@import 'components/pagination';
-@import './main_panel';
-@import 'components/page_tabs';
-@import 'components/panels_layout';
-@import 'components/tables/filtering/meta_status';
+@import './mixins.css.scss';
+@import './pikaday.css.scss';
+@import './bootstrap-tour.css.scss';
+@import './components/pagination.css.scss';
+@import '././main_panel.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/panels_layout.css.scss';
+@import './components/tables/filtering/meta_status.css.scss';
 
 .panelsLayout.is-showingSidePanel {
 	.mainPanel td:nth-of-type(5),

--- a/app/assets/stylesheets/nonprofits/payouts/index/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/payouts/index/page.css.scss
@@ -1,11 +1,11 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'pikaday';
-@import 'components/page_tabs';
-@import 'components/nonprofit_bank_accounts';
-@import 'components/todos';
-@import 'components/identity_verification';
+@import './mixins.css.scss';
+@import './pikaday.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/nonprofit_bank_accounts.css.scss';
+@import './components/todos.css.scss';
+@import './components/identity_verification.css.scss';
 
 .payout-history .succeeded {
 	color: $bluegrass;

--- a/app/assets/stylesheets/nonprofits/recurring_donations/index/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/recurring_donations/index/page.css.scss
@@ -1,14 +1,14 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'recurring_donations/modal';
-@import 'recurring_donations/edit';
-@import 'pikaday';
-@import 'supporters/form';
-@import 'bootstrap-tour';
-@import 'components/page_tabs';
-@import 'components/pagination';
-@import 'components/panels_layout';
+@import './mixins.css.scss';
+@import './recurring_donations/modal.css.scss';
+@import './recurring_donations/edit.css.scss';
+@import './pikaday.css.scss';
+@import './supporters/form.css.scss';
+@import './bootstrap-tour.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/pagination.css.scss';
+@import './components/panels_layout.css.scss';
 
 .sidePanel,
 .panelsLayout.is-showingSidePanel .mainPanel {

--- a/app/assets/stylesheets/nonprofits/show/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/show/page.css.scss
@@ -1,24 +1,24 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'bootstrap-tour';
+@import './mixins.css.scss';
+@import './bootstrap-tour.css.scss';
 
-@import 'campaigns/new/index';
-@import 'common/donate_button';
-@import 'common/campaign_card';
-@import 'common/editable';
-@import 'events/new/index';
-@import 'events/listing';
-@import 'components/admin_sidebar';
-@import 'components/admin_top_nav';
-@import 'common/image_uploader';
-@import 'components/activity_feed';
-@import 'components/carousel';
-@import 'components/todos';
-@import 'components/info_card';
-@import 'components/fixed_top_action';
-@import './settings_modal';
-@import '../donation_form/form';
+@import './campaigns/new/index.css.scss';
+@import './common/donate_button.css.scss';
+@import './common/campaign_card.css.scss';
+@import './common/editable.css.scss';
+@import './events/new/index.css.scss';
+@import './events/listing.css.scss';
+@import './components/admin_sidebar.css.scss';
+@import './components/admin_top_nav.css.scss';
+@import './common/image_uploader.css.scss';
+@import './components/activity_feed.css.scss';
+@import './components/carousel.css.scss';
+@import './components/todos.css.scss';
+@import './components/info_card.css.scss';
+@import './components/fixed_top_action.css.scss';
+@import '././settings_modal.css.scss';
+@import './../donation_form/form.css.scss';
 
 .globalFooter {
 	margin-top: 40px;

--- a/app/assets/stylesheets/nonprofits/supporters/custom_fields.css.scss
+++ b/app/assets/stylesheets/nonprofits/supporters/custom_fields.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 button[toggle='remove'] {
 	@include transform(translateY(3px));

--- a/app/assets/stylesheets/nonprofits/supporters/index/page.css.scss
+++ b/app/assets/stylesheets/nonprofits/supporters/index/page.css.scss
@@ -1,21 +1,21 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/pagination';
-@import 'supporters/form';
-@import 'pikaday';
-@import 'components/panels_layout';
-@import 'side_panel';
-@import 'components/tags';
-@import 'components/bulk_actions';
-@import 'components/page_tabs';
-@import 'components/toggle_buttons';
-@import 'components/drop_down';
-@import 'components/google_maps';
-@import 'common/editable';
-@import 'nonprofits/supporters/custom_fields';
-@import 'components/tables/filtering/meta_status';
-@import 'bootstrap-tour';
+@import './mixins.css.scss';
+@import './components/pagination.css.scss';
+@import './supporters/form.css.scss';
+@import './pikaday.css.scss';
+@import './components/panels_layout.css.scss';
+@import './side_panel.css.scss';
+@import './components/tags.css.scss';
+@import './components/bulk_actions.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/toggle_buttons.css.scss';
+@import './components/drop_down.css.scss';
+@import './components/google_maps.css.scss';
+@import './common/editable.css.scss';
+@import './nonprofits/supporters/custom_fields.css.scss';
+@import './components/tables/filtering/meta_status.css.scss';
+@import './bootstrap-tour.css.scss';
 
 .supportersMap {
 	border: 2px solid rgba(black, 0.2);

--- a/app/assets/stylesheets/nonprofits/supporters/index/side_panel.css.scss
+++ b/app/assets/stylesheets/nonprofits/supporters/index/side_panel.css.scss
@@ -1,7 +1,7 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'timeline';
+@import './mixins.css.scss';
+@import './timeline.css.scss';
 
 .sidePanel-rightSide {
 	width: 65%;

--- a/app/assets/stylesheets/nonprofits/supporters/index/timeline.css.scss
+++ b/app/assets/stylesheets/nonprofits/supporters/index/timeline.css.scss
@@ -1,6 +1,6 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
+@import './mixins.css.scss';
 
 ul.timeline-activities {
 	margin: 0;

--- a/app/assets/stylesheets/profiles/show/page.css.scss
+++ b/app/assets/stylesheets/profiles/show/page.css.scss
@@ -1,9 +1,9 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/page_tabs';
-@import 'components/tags';
-@import 'common/fundraisers';
+@import './mixins.css.scss';
+@import './components/page_tabs.css.scss';
+@import './components/tags.css.scss';
+@import './common/fundraisers.css.scss';
 
 .donorProfileHeader {
 	background: lighten($grey, 40);

--- a/app/assets/stylesheets/recurring_donations/edit.css.scss
+++ b/app/assets/stylesheets/recurring_donations/edit.css.scss
@@ -1,4 +1,4 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'components/cards';
-@import 'common/donate_button';
+@import './components/cards.css.scss';
+@import './common/donate_button.css.scss';

--- a/app/assets/stylesheets/recurring_donations/edit/page.css.scss
+++ b/app/assets/stylesheets/recurring_donations/edit/page.css.scss
@@ -1,4 +1,4 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'components/cards';
-@import 'common/donate_button';
+@import './components/cards.css.scss';
+@import './common/donate_button.css.scss';

--- a/app/assets/stylesheets/recurring_donations/modal.css.scss
+++ b/app/assets/stylesheets/recurring_donations/modal.css.scss
@@ -1,3 +1,3 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'supporters/form';
+@import './supporters/form.css.scss';

--- a/app/assets/stylesheets/settings/index/branding.css.scss
+++ b/app/assets/stylesheets/settings/index/branding.css.scss
@@ -1,9 +1,9 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'common/vendor/colpick';
-@import 'nonprofits/btn/page';
-@import 'common/branded_campaign_button';
+@import './mixins.css.scss';
+@import './common/vendor/colpick.css.scss';
+@import './nonprofits/btn/page.css.scss';
+@import './common/branded_campaign_button.css.scss';
 
 
 .branding-settings-wrapper {

--- a/app/assets/stylesheets/settings/index/page.css.scss
+++ b/app/assets/stylesheets/settings/index/page.css.scss
@@ -1,14 +1,14 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/nonprofit_bank_accounts';
-@import 'components/todos';
-@import 'common/image_uploader';
-@import 'common/vendor/colpick';
-@import 'common/editable';
-@import './branding';
-@import 'nonprofits/show/settings_modal';
-@import 'components/browser_border';
+@import './mixins.css.scss';
+@import './components/nonprofit_bank_accounts.css.scss';
+@import './components/todos.css.scss';
+@import './common/image_uploader.css.scss';
+@import './common/vendor/colpick.css.scss';
+@import './common/editable.css.scss';
+@import '././branding.css.scss';
+@import './nonprofits/show/settings_modal.css.scss';
+@import './components/browser_border.css.scss';
 
 .settings-nav li {
 	cursor: pointer;

--- a/app/assets/stylesheets/tickets/index/page.css.scss
+++ b/app/assets/stylesheets/tickets/index/page.css.scss
@@ -1,8 +1,8 @@
 /* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
-@import 'mixins';
-@import 'components/pagination';
-@import 'common/donate_button';
+@import './mixins.css.scss';
+@import './components/pagination.css.scss';
+@import './common/donate_button.css.scss';
 
 .table--plaid td.supporterName {
 	@include ellipsis;

--- a/app/assets/stylesheets/ui_components/close.svg
+++ b/app/assets/stylesheets/ui_components/close.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="32px"
+	 height="31.75px" viewBox="-1.125 -1.125 32 31.75" enable-background="new -1.125 -1.125 32 31.75" xml:space="preserve">
+<g id="Layer_2">
+	<circle fill="#969696" stroke="#9E9E9E" stroke-width="3" stroke-miterlimit="10" cx="14.837" cy="14.837" r="13.837"/>
+</g>
+<g id="Layer_1">
+	<circle fill="#969696" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" cx="14.837" cy="14.77" r="13.837"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" x1="7.754" y1="22.083" x2="21.92" y2="7.917"/>
+	<line fill="none" stroke="#FFFFFF" stroke-width="2" stroke-miterlimit="10" x1="22.083" y1="22.083" x2="7.917" y2="7.917"/>
+</g>
+</svg>

--- a/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
+++ b/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
@@ -25,7 +25,7 @@ export default function Wizard(props: WizardProps): JSX.Element {
 
 
 
-	const isCompleted = stepManager.activeStep === stepManager.steps.length - 1;
+	const isCompleted = currentStep === stepManager.steps.length - 1;
 	return (
 		<WizardContext.Provider value={stepManager}>
 			<div className={'ff-wizard-body'}>

--- a/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
+++ b/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
@@ -89,11 +89,16 @@ function StepHeader({ width, jump, name, idx, currentStep }: { width: string, na
 	}
 	if (currentStep > idx) {
 		classNames.push('ff-wizard-index-label--accessible');
+		return (<span
+			className={classNames.join(' ')}
+			style={{ width: width }}
+			onClick={() => jump(idx)} >
+			{name}
+		</span>)
 	}
 	return (<span
 		className={classNames.join(' ')}
-		style={{ width: width }}
-		onClick={() => jump(idx)} >
+		style={{ width: width }}>
 		{name}
 	</span>);
 

--- a/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
+++ b/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types */
 import useSteps, { InputStepsState, KeyedStep, StepsObject } from '../../../../../hooks/useSteps';
-import React, { createContext } from 'react';
+import React, { createContext, useContext } from 'react';
 import { noop } from 'lodash';
 
 // from ff-core/wizard
@@ -17,7 +17,7 @@ export const WizardContext = createContext<StepsObject<{ body: JSX.Element, titl
 export default function Wizard(props: WizardProps): JSX.Element {
 
 	const {
-		steps, followup,
+		steps, followup
 	} = props;
 	const stepManager = useSteps<{ body: JSX.Element, title: string }>({ steps, addStep: noop, removeStep: noop });
 

--- a/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
+++ b/app/javascript/components/legacy/_dependencies/ff-core/wizard/index.tsx
@@ -25,7 +25,8 @@ export default function Wizard(props: WizardProps): JSX.Element {
 
 
 
-	const isCompleted = currentStep === stepManager.steps.length - 1;
+	const isCompleted = currentStep === stepManager.steps.length;
+
 	return (
 		<WizardContext.Provider value={stepManager}>
 			<div className={'ff-wizard-body'}>
@@ -40,7 +41,7 @@ export default function Wizard(props: WizardProps): JSX.Element {
 				</Body>
 				<Followup isCompleted={isCompleted}>
 					{followup()}
-				</Followup>;
+				</Followup>
 			</div>
 		</WizardContext.Provider>);
 }
@@ -100,7 +101,7 @@ function StepHeader({ width, jump, name, idx, currentStep }: { width: string, na
 
 function Body({ currentStep, isCompleted, children }: React.PropsWithChildren<{ currentStep: number, isCompleted: boolean }>) {
 	return <div className={'ff-wizard-steps'} style={{
-		display: isCompleted ? 'block' : 'none',
+		display: isCompleted ? 'none' : 'block',
 	}}>
 
 		{React.Children.map(children, (child, idx) => (

--- a/app/javascript/components/legacy/components/styles/branded-wizard.tsx
+++ b/app/javascript/components/legacy/components/styles/branded-wizard.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles({
 		'.wizard-steps div.is-selected, .wizard-steps button.is-selected': {
 			backgroundColor: (props: MakeStylesProps) => `${colors(props.nonprofitColor).lighter} !important`,
 		},
-		'wizard-steps .button.white': {
+		'.wizard-steps .button.white': {
 			'color': '#494949',
 		},
 		'.wizard-steps a:not(.button--small), .ff-wizard-index-label.ff-wizard-index-label--accessible, .wizard-index-label.is-accessible': {

--- a/app/javascript/components/legacy/nonprofits/donate/InfoStep.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/InfoStep.tsx
@@ -1,0 +1,147 @@
+// License: LGPL-3.0-or-later
+import React from 'react';
+import { useIntl } from "../../../intl";
+import { SupporterType, RequiredFieldsType } from './wizard';
+
+// const h = require('snabbdom/h')
+// const R = require('ramda')
+// const flyd = require('flyd')
+// const uuid = require('uuid')
+// const supporterFields = require('../../components/supporter-fields')
+// const button = require('ff-core/button')
+// const dedicationForm = require('./dedication-form')
+// const serialize = require('form-serialize')
+// const request = require('../../common/request')
+// const format = require('../../common/format')
+
+// const sepaTab = 'sepa'
+// const cardTab = 'credit_card'
+
+interface InfoStepProps {
+  required: RequiredFieldsType;
+  supporter: SupporterType;
+  hideDedication: boolean;
+};
+
+export function InfoStep(props: InfoStepProps): JSX.Element {
+  return (
+    <div className={'wizard-step info-step u-padding--10'}>
+      <form>
+        <RecurringMessage />
+        <SupporterFields required={props.required} supporter={props.supporter} hideDedication={props.hideDedication} />
+        <CustomFields />
+        <DedicationLink hideDedication={props.hideDedication} />
+        <AnonymousCheckbox />
+      </form>
+    </div>
+  );
+};
+
+interface SupporterAddress {
+  address: string;
+  city: string;
+  stateCode: string;
+  zipCode: string;
+}
+
+interface SupporterFieldsProps {
+  required: RequiredFieldsType;
+  supporter: SupporterType;
+  hideDedication: boolean;
+}
+
+interface AddressProps {
+  address: string;
+  city: string;
+  stateCode: string;
+  country: string;
+  zipCode: string;
+}
+
+interface DedicationLinkProps {
+  hideDedication: boolean;
+}
+
+function SupporterFields(props: SupporterFieldsProps): JSX.Element {
+  const { formatMessage } = useIntl();
+  const emailRequired = formatMessage({ id: 'nonprofits.donate.info.supporter.email_required' });
+  const emailTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.email' }) + `${props.required.email ? `${emailRequired}` : ''}`;
+  const firstNameTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.first_name' });
+  const lastNameTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.last_name' });
+  const phoneTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.phone' });
+
+  return (
+      <div className={'u-marginY--10'}>
+        <input type="hidden" name="profile_id" value={props.supporter.profileId} />
+        <input type="hidden" name="nonprofit_id" value={props.supporter.nonprofitId} />
+        <fieldset>
+          <input type="email" name="email" title={emailTitle} required={props.required.email} value={props.supporter.email} placeholder={emailTitle} />
+          <section className={'group'}>
+            <fieldset className={'u-marginBottom--0 u-floatL col-right-4'}>
+              <input type="text" name="first_name" placeholder={firstNameTitle} required={props.required.firstName} title={firstNameTitle} value={props.supporter.firstName} />
+            </fieldset>
+            <fieldset className={'u-marginBottom--0 u-floatL col-right-4'}>
+              <input type="text" name="last_name" placeholder={lastNameTitle} required={props.required.lastName} title={lastNameTitle} value={props.supporter.lastName} />
+            </fieldset>
+            <fieldset className={'u-marginBottom--0 u-floatL col-right-4'}>
+              <input type="text" name="phone" placeholder={phoneTitle} required={props.required.phone} title={phoneTitle} value={props.supporter.phone} />
+            </fieldset>
+          </section>
+        </fieldset>
+        <ManualAddress address={'Some Address'} city={'City'} stateCode={'State Code'} zipCode={'Postal Code'} country={'Country'}/>
+      </div>
+  );
+};
+
+function ManualAddress(props: AddressProps): JSX.Element {
+  const { formatMessage } = useIntl();
+  const addressTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.address' });
+  const cityTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.city' });
+  const stateCodeTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.stateCode' });
+  const zipCodeTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.postal_code' });
+
+  return (
+    <section className={'group pastelBox--grey u-padding--5'}>
+      {/* TODO: props.toShip? */}
+      <fieldset className={'col-8 u-fontSize--14'}>
+        <input type="text" title={addressTitle} placeholder={addressTitle} name={'address'} value={props.address} />
+      </fieldset>
+      <fieldset className={'col-8 u-fontSize--14'}>
+        <input type="text" title={cityTitle} placeholder={cityTitle} name={'city'} value={props.city} />
+      </fieldset>
+      <fieldset className={'u-marginBottom--0 u-floatL col-4'}>
+        <input type="text" title={stateCodeTitle} placeholder={stateCodeTitle} name={'state_code'} value={props.stateCode} />
+      </fieldset>
+      <fieldset className={'u-marginBottom--0 u-floatL col-right-4 u-fontSize--14'}>
+        <input type="text" title={zipCodeTitle} placeholder={zipCodeTitle} name={'zip_code'} value={props.zipCode} />
+      </fieldset>
+      <fieldset className={'u-marginBottom--0.u-floatL.col-right-8'}>
+        <input type="text" name={'country'} value={props.country} />
+      </fieldset>
+    </section>
+  );
+};
+
+function CustomFields(): JSX.Element {
+  return (
+    <div>CustomFields</div>
+  )
+};
+
+function DedicationLink(props: DedicationLinkProps): JSX.Element {
+  return (
+    <div>DedicationLink</div>
+  );
+};
+
+function RecurringMessage(): JSX.Element {
+  return (
+    <div>RecurringMessage</div>
+  );
+};
+
+function AnonymousCheckbox(): JSX.Element {
+  return (
+    <div>AnonymousCheckbox</div>
+  );
+};

--- a/app/javascript/components/legacy/nonprofits/donate/InfoStep.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/InfoStep.tsx
@@ -1,9 +1,10 @@
 // License: LGPL-3.0-or-later
 import { Money } from '../../../../common/money';
-import React, { useContext } from 'react';
-import { useIntl } from "../../../intl";
-import { SupporterType, RequiredFieldsType, DonationWizardContext } from './wizard';
+import React, { useContext, useState } from 'react';
+import { SupporterType, RequiredFieldsType, ActionType, AddressProps } from './wizard';
 import { WizardContext } from '../../_dependencies/ff-core/wizard';
+import { Formik, useFormikContext } from 'formik';
+import { useIntl } from "../../../intl";
 
 // const h = require('snabbdom/h')
 // const R = require('ramda')
@@ -19,6 +20,7 @@ import { WizardContext } from '../../_dependencies/ff-core/wizard';
 // const cardTab = 'credit_card'
 
 interface InfoStepProps {
+  address: AddressProps;
   required: RequiredFieldsType;
   supporter: SupporterType;
   hideDedication: boolean;
@@ -26,44 +28,51 @@ interface InfoStepProps {
   weekly: boolean;
   amount: Money;
   currencySymbol: string;
+  stateDispatch: (action: ActionType) => void;
 };
+
+interface FormikFormValues {
+  supporter: SupporterType;
+  address: AddressProps;
+}
 
 export function InfoStep(props: InfoStepProps): JSX.Element {
   const stepManagerContext = useContext(WizardContext);
 
   return (
     <div className={'wizard-step info-step u-padding--10'}>
-      <form>
-        <RecurringMessage isRecurring={props.isRecurring} weekly={props.weekly} currencySymbol={props.currencySymbol} amount={props.amount} />
-        <SupporterFields required={props.required} supporter={props.supporter} hideDedication={props.hideDedication} />
-        <CustomFields />
-        <DedicationLink hideDedication={props.hideDedication} />
-        <AnonymousCheckbox />
-        <div>DedicationForm</div>
-      </form>
+      <Formik onSubmit={(values) => {
+        // post supporter data
+        props.stateDispatch({
+          type: 'setSupporter',
+          supporter: values.supporter,
+          address: values.address,
+          next: stepManagerContext.next
+        });
+      }} initialValues={{ supporter: props.supporter, address: props.address } as FormikFormValues}>
+        <SupporterFields
+          required={props.required}
+          supporter={props.supporter}
+          hideDedication={props.hideDedication}
+          address={props.address}
+          isRecurring={props.isRecurring}
+          weekly={props.weekly}
+          amount={props.amount}
+          currencySymbol={props.currencySymbol} />
+      </Formik>
     </div>
   );
 };
-
-interface SupporterAddress {
-  address: string;
-  city: string;
-  stateCode: string;
-  zipCode: string;
-}
 
 interface SupporterFieldsProps {
   required: RequiredFieldsType;
   supporter: SupporterType;
   hideDedication: boolean;
-}
-
-interface AddressProps {
-  address: string;
-  city: string;
-  stateCode: string;
-  country: string;
-  zipCode: string;
+  address: AddressProps;
+  isRecurring: boolean;
+  weekly: boolean;
+  amount: Money;
+  currencySymbol: string;
 }
 
 interface DedicationLinkProps {
@@ -71,60 +80,199 @@ interface DedicationLinkProps {
 }
 
 function SupporterFields(props: SupporterFieldsProps): JSX.Element {
+  const { values, setFieldValue, submitForm } = useFormikContext<FormikFormValues>();
   const { formatMessage } = useIntl();
   const emailRequired = formatMessage({ id: 'nonprofits.donate.info.supporter.email_required' });
   const emailTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.email' }) + `${props.required.email ? `${emailRequired}` : ''}`;
   const firstNameTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.first_name' });
   const lastNameTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.last_name' });
   const phoneTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.phone' });
+  const next = formatMessage({ id: 'nonprofits.donate.amount.next' });
+
+  const [address, setAddress] = useState<AddressProps>(props.address);
+  function setAddressFields(field: string, value: string) {
+    setAddress({...address, [field]: value });
+    setFieldValue('address', address);
+  }
+
+  const [supporter, setSupporter] = useState<SupporterType>(props.supporter);
+  function setSupporterFields(field: string, value: string) {
+    setSupporter({...supporter, [field]: value });
+    setFieldValue('supporter', supporter);
+  }
 
   return (
+    <>
+      <RecurringMessage isRecurring={props.isRecurring} weekly={props.weekly} currencySymbol={props.currencySymbol} amount={props.amount} />
       <div className={'u-marginY--10'}>
-        <input type="hidden" name="profile_id" value={props.supporter.profileId} />
-        <input type="hidden" name="nonprofit_id" value={props.supporter.nonprofitId} />
+        <input type="hidden" name="profile_id" value={props.supporter?.profileId} />
+        <input type="hidden" name="nonprofit_id" value={props.supporter?.nonprofitId} />
         <fieldset>
-          <input type="email" name="email" title={emailTitle} required={props.required.email} value={props.supporter.email} placeholder={emailTitle} />
+          <input
+            type="email"
+            name="email"
+            title={emailTitle}
+            required={props.required.email}
+            value={props.supporter?.email}
+            placeholder={emailTitle}
+            onChange={
+              (e) => {
+                setSupporterFields('email', e.target.value);
+              }
+            } />
           <section className={'group'}>
             <fieldset className={'u-marginBottom--0 u-floatL col-right-4'}>
-              <input type="text" name="first_name" placeholder={firstNameTitle} required={props.required.firstName} title={firstNameTitle} value={props.supporter.firstName} />
+              <input
+                type="text"
+                name="first_name"
+                placeholder={firstNameTitle}
+                required={props.required.firstName}
+                title={firstNameTitle}
+                value={props.supporter?.firstName}
+                onChange={
+                  (e) => {
+                    setSupporterFields('firstName', e.target.value);
+                  }
+                } />
             </fieldset>
             <fieldset className={'u-marginBottom--0 u-floatL col-right-4'}>
-              <input type="text" name="last_name" placeholder={lastNameTitle} required={props.required.lastName} title={lastNameTitle} value={props.supporter.lastName} />
+              <input
+                type="text"
+                name="last_name"
+                placeholder={lastNameTitle}
+                required={props.required.lastName}
+                title={lastNameTitle}
+                value={props.supporter?.lastName}
+                onChange={
+                  (e) => {
+                    setSupporterFields('lastName', e.target.value);
+                  }
+                }/>
             </fieldset>
             <fieldset className={'u-marginBottom--0 u-floatL col-right-4'}>
-              <input type="text" name="phone" placeholder={phoneTitle} required={props.required.phone} title={phoneTitle} value={props.supporter.phone} />
+              <input
+                type="text"
+                name="phone"
+                placeholder={phoneTitle}
+                required={props.required.phone}
+                title={phoneTitle}
+                value={props.supporter?.phone}
+                onChange={
+                  (e) => {
+                    setSupporterFields('phone', e.target.value);
+                  }
+                }/>
             </fieldset>
           </section>
         </fieldset>
-        <ManualAddress address={'Some Address'} city={'City'} stateCode={'State Code'} zipCode={'Postal Code'} country={'Country'}/>
+        <ManualAddress
+          address={address}
+          setAddressFields={setAddressFields} />
       </div>
+      <CustomFields />
+      <DedicationLink hideDedication={props.hideDedication} />
+      <AnonymousCheckbox />
+      <div>DedicationForm</div>
+      <PaymentButton submitForm={submitForm}/>
+    </>
   );
 };
 
-function ManualAddress(props: AddressProps): JSX.Element {
+function PaymentButton(props: { submitForm: () => void }): JSX.Element {
+  const { formatMessage } = useIntl();
+  const buttonText = formatMessage({ id: 'nonprofits.donate.payment.card.submit' });
+
+  return (
+    <div className={`ff-buttonWrapper u-floatL u-marginBottom--10`}>
+      <p className={`ff-button-error`}>Error</p>
+      <button
+        className={`ff-button`}
+        type={'submit'}
+        onClick={() => { props.submitForm(); }}
+      >{buttonText}</button>
+    </div>
+  );
+}
+
+function ManualAddress(props: { address: AddressProps, setAddressFields: (field: string, value: string) => void }): JSX.Element {
   const { formatMessage } = useIntl();
   const addressTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.address' });
   const cityTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.city' });
-  const stateCodeTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.stateCode' });
   const zipCodeTitle = formatMessage({ id: 'nonprofits.donate.info.supporter.postal_code' });
 
   return (
     <section className={'group pastelBox--grey u-padding--5'}>
       {/* TODO: props.toShip? */}
       <fieldset className={'col-8 u-fontSize--14'}>
-        <input type="text" title={addressTitle} placeholder={addressTitle} name={'address'} value={props.address} />
+        <input
+          type="text"
+          className={'u-marginBottom--0'}
+          title={addressTitle}
+          placeholder={addressTitle}
+          name={'address'}
+          value={props.address?.address}
+          onChange={
+            (e) => {
+              props.setAddressFields('address', e.target.value);
+            }
+          }
+        />
       </fieldset>
-      <fieldset className={'col-8 u-fontSize--14'}>
-        <input type="text" title={cityTitle} placeholder={cityTitle} name={'city'} value={props.city} />
+      <fieldset className={'col-right-4 u-fontSize--14'}>
+        <input
+          type="text"
+          className={'u-marginBottom--0'}
+          title={cityTitle}
+          placeholder={cityTitle}
+          name={'city'}
+          value={props.address?.city}
+          onChange={
+            (e) => {
+              props.setAddressFields('city', e.target.value);
+            }
+          }
+        />
       </fieldset>
       <fieldset className={'u-marginBottom--0 u-floatL col-4'}>
-        <input type="text" title={stateCodeTitle} placeholder={stateCodeTitle} name={'state_code'} value={props.stateCode} />
+        <input
+          type="text"
+          className={'select u-fontSize--14 u-marginBottom--0'}
+          name={'state_code'}
+          value={props.address?.stateCode}
+          onChange={
+            (e) => {
+              props.setAddressFields('stateCode', e.target.value);
+            }
+          }
+        />
       </fieldset>
       <fieldset className={'u-marginBottom--0 u-floatL col-right-4 u-fontSize--14'}>
-        <input type="text" title={zipCodeTitle} placeholder={zipCodeTitle} name={'zip_code'} value={props.zipCode} />
+        <input
+          type="text"
+          className={'u-marginBottom--0'}
+          title={zipCodeTitle}
+          placeholder={zipCodeTitle}
+          name={'zip_code'}
+          value={props.address?.zipCode}
+          onChange={
+            (e) => {
+              props.setAddressFields('zipCode', e.target.value);
+            }
+          }
+        />
       </fieldset>
-      <fieldset className={'u-marginBottom--0.u-floatL.col-right-8'}>
-        <input type="text" name={'country'} value={props.country} />
+      <fieldset className={'u-marginBottom--0 u-floatL col-right-8'}>
+        <input
+          type="text"
+          className={'select u-fontSize--14 u-marginBottom--0'}
+          name={'country'}
+          value={props.address?.country}
+          onChange={
+            (e) => {
+              props.setAddressFields('country', e.target.value);
+            }
+          }
+        />
       </fieldset>
     </section>
   );
@@ -151,7 +299,7 @@ function numberWithCommas(n: string): String {
 function centsToDollars(amount: Money, noCents: boolean = false): String {
   if (!!!amount) return '0';
   if (amount.cents === undefined) return '0';
-  return numberWithCommas((amount.cents/100.0).toFixed(noCents ? 0 : 2).toString()).replace(/\.00$/, '');
+  return numberWithCommas((amount.cents / 100.0).toFixed(noCents ? 0 : 2).toString()).replace(/\.00$/, '');
 }
 
 // Originally from app/javascript/legacy/common/format.js:weeklyToMonthly
@@ -174,7 +322,7 @@ function RecurringMessage(props: RecurringMessageProps): JSX.Element {
   let amountLabel = props.isRecurring ? montlhyRecurring : oneTime;
   let weekly = <></>;
 
-  if(props.weekly && props.isRecurring) {
+  if (props.weekly && props.isRecurring) {
     const weeklyLabel = formatMessage({ id: 'nonprofits.donate.amount.weekly' });
     amountLabel = amountLabel.replace(montlhyRecurring, weeklyLabel) + '*';
     weekly = <div className='u-centered notice'>

--- a/app/javascript/components/legacy/nonprofits/donate/InfoStep.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/InfoStep.tsx
@@ -128,7 +128,7 @@ function SupporterFields(props: SupporterFieldsProps): JSX.Element {
             name="email"
             title={emailTitle}
             required={props.required.email}
-            value={props.supporter?.email}
+            value={supporter?.email}
             placeholder={emailTitle}
             onChange={
               (e) => {
@@ -143,7 +143,7 @@ function SupporterFields(props: SupporterFieldsProps): JSX.Element {
                 placeholder={firstNameTitle}
                 required={props.required.firstName}
                 title={firstNameTitle}
-                value={props.supporter?.firstName}
+                value={supporter?.firstName}
                 onChange={
                   (e) => {
                     setSupporterFields('firstName', e.target.value);
@@ -157,7 +157,7 @@ function SupporterFields(props: SupporterFieldsProps): JSX.Element {
                 placeholder={lastNameTitle}
                 required={props.required.lastName}
                 title={lastNameTitle}
-                value={props.supporter?.lastName}
+                value={supporter?.lastName}
                 onChange={
                   (e) => {
                     setSupporterFields('lastName', e.target.value);
@@ -171,7 +171,7 @@ function SupporterFields(props: SupporterFieldsProps): JSX.Element {
                 placeholder={phoneTitle}
                 required={props.required.phone}
                 title={phoneTitle}
-                value={props.supporter?.phone}
+                value={supporter?.phone}
                 onChange={
                   (e) => {
                     setSupporterFields('phone', e.target.value);

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -18,12 +18,11 @@ interface AmountStepProps {
 	showRecurring: boolean;
 }
 
-
-
 interface FormikFormValues {
 	recurring: boolean;
 	amount: Money | null;
 }
+
 export function AmountStep(props: AmountStepProps): JSX.Element {
 	const stepManagerContext = useContext(WizardContext);
 	return (<div className={"wizard-step amount-step"} >

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -16,6 +16,7 @@ interface AmountStepProps {
 	singleAmount: string | null;
 	isRecurring: boolean;
 	showRecurring: boolean;
+	weekly: boolean;
 }
 
 interface FormikFormValues {
@@ -190,7 +191,7 @@ function AmountFields(props: AmountFieldsProps): JSX.Element {
 						<button className={`button u-width--full white amount ${weAreSelected && buttonAmountSelected ? 'is-selected' : ''}`}
 							onClick={() => {
 								setButtonAmountSelected(true);
-								setFieldValue("amount", amt);
+								convertAmountToMoney(amt.cents.toString(), setFieldValue);
 								setCustomAmount('');
 								submitForm();
 							}}

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -232,8 +232,6 @@ interface SingleAmountProps {
 	singleAmount: string;
 	currencySymbol: string;
 	isRecurring: boolean;
-	// recurringWeekly: boolean;
-	// periodicAmount: number;
 }
 
 

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -95,10 +95,10 @@ function prependCurrencyClassname(currency_symbol: string) {
 }
 
 function getCurrencySymbol(amount: Money) {
-	if (amount.currency == 'EUR') {
+	if (amount.currency.toLowerCase() == 'eur') {
 		return '€';
 	}
-	else if (amount.currency == 'USD') {
+	else if (amount.currency.toLowerCase() == 'usd') {
 		return '$';
 	}
 }

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -116,22 +116,26 @@ function AmountFields(props: AmountFieldsProps): JSX.Element {
 	const {values, setFieldValue, submitForm} = useFormikContext<FormikFormValues>();
 	// if (props.singleAmount) {
 	// 	return <></>;
-	// }s
+	// }
 	return (<div className={'u-inline fieldsetLayout--three--evenPadding'}>
 		<span>
 			{props.amounts.map(amt => {
-				const weAreSelected = values.amount.equals(amt);
-				return (<fieldset key={JSON.stringify(amt.toJSON())}>
-					<button className={`button u-width--full white amount ${weAreSelected ? 'is-selected' : ''}`}
-						onClick={() => {
-							setFieldValue("amount", amt);
-							submitForm();
-						}}
-					>
-						<span className={'dollar'}>{getCurrencySymbol(amt)}</span>
-						{amt.cents}
-					</button>
-				</fieldset>);
+				let weAreSelected = false;
+				if(values.amount !== null) {
+					weAreSelected = values.amount.equals(amt);
+				}
+				return (
+					<fieldset key={JSON.stringify(amt.toJSON())}>
+						<button className={`button u-width--full white amount ${weAreSelected ? 'is-selected' : ''}`}
+							onClick={() => {
+								setFieldValue("amount", amt);
+								submitForm();
+							}}
+						>
+							<span className={'dollar'}>{getCurrencySymbol(amt)}</span>
+							{amt.cents}
+						</button>
+					</fieldset>);
 			})}
 		</span>
 
@@ -156,7 +160,7 @@ function AmountFields(props: AmountFieldsProps): JSX.Element {
 }
 
 AmountFields.defaultProps = {
-	amounts: [],
+	amounts: [100, 500, 1000, 2500, 5000].map((i)=> Money.fromCents(i, 'usd')),
 };
 
 

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -5,11 +5,12 @@ import { Formik, useFormikContext } from 'formik';
 import { ActionType, DonationWizardContext } from './wizard';
 import { useIntl } from "../../../intl";
 import { format } from 'sinon';
+import { WizardContext } from '../../_dependencies/ff-core/wizard';
 
 interface AmountStepProps {
 	amount: Money|null;
 	amountOptions: Money[];
-	goToNextStep: () => void;
+	stateDispatch: (action: ActionType) => void;
 }
 
 
@@ -18,14 +19,14 @@ interface FormikFormValues {
 	amount: Money|null;
 }
 export function AmountStep(props: AmountStepProps): JSX.Element {
-	const {dispatch:dispatchAction} = useContext(DonationWizardContext);
+	const stepManagerContext = useContext(WizardContext);
 	return (<div className={"wizard-step amount-step"} >
 		<Formik onSubmit={(values) => {
-			dispatchAction({type: 'setAmount', amount: values.amount});
+			props.stateDispatch({type: 'setAmount', amount: values.amount, next: stepManagerContext.next});
 		}} initialValues={{amount: props.amount} as FormikFormValues} enableReinitialize={true}>
 			{/* <RecurringCheckbox />
 			<RecurringMessage /> */}
-			<AmountFields amounts={props.amountOptions} goToNextStep={props.goToNextStep}/>
+			<AmountFields amounts={props.amountOptions} />
 		</Formik>
 	</div>);
 }
@@ -118,7 +119,6 @@ function nextStepDisabled(): boolean {
 interface AmountFieldsProps {
 	// singleAmount: string;
 	amounts: Money[];
-	goToNextStep: () => void;
 	// buttonAmountSelected: boolean;
 	//currencySymbol: string;
 }
@@ -165,8 +165,8 @@ function AmountFields(props: AmountFieldsProps): JSX.Element {
 		<fieldset>
 			<button className={'button u-width--full btn-next'}
 				type={'submit'}
-				disabled={nextStepDisabled()}
-				onClick={() => { props.goToNextStep } }
+				disabled={ nextStepDisabled() }
+				onClick={() => { submitForm(); } }
 			>
 				{ next }
 			</button>

--- a/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/amount-step.tsx
@@ -3,10 +3,13 @@ import { useId } from "@reach/auto-id";
 import { Money } from '../../../../common/money';
 import { Formik, useFormikContext } from 'formik';
 import { ActionType, DonationWizardContext } from './wizard';
-declare const I18n: any;
+import { useIntl } from "../../../intl";
+import { format } from 'sinon';
+
 interface AmountStepProps {
 	amount: Money|null;
 	amountOptions: Money[];
+	goToNextStep: () => void;
 }
 
 
@@ -16,14 +19,13 @@ interface FormikFormValues {
 }
 export function AmountStep(props: AmountStepProps): JSX.Element {
 	const {dispatch:dispatchAction} = useContext(DonationWizardContext);
-
 	return (<div className={"wizard-step amount-step"} >
 		<Formik onSubmit={(values) => {
 			dispatchAction({type: 'setAmount', amount: values.amount});
 		}} initialValues={{amount: props.amount} as FormikFormValues} enableReinitialize={true}>
 			{/* <RecurringCheckbox />
 			<RecurringMessage /> */}
-			<AmountFields amounts={props.amountOptions} />
+			<AmountFields amounts={props.amountOptions} goToNextStep={props.goToNextStep}/>
 		</Formik>
 	</div>);
 }
@@ -36,6 +38,10 @@ interface RecurringCheckboxProps {
 
 function RecurringCheckbox(props: RecurringCheckboxProps): JSX.Element {
 	const checkboxId = useId();
+	const { formatMessage } = useIntl();
+
+	const nonprofitsDonateAmountSustaining = formatMessage({ id: 'nonprofits.donate.amount.sustaining' });
+	const nonprofitsDonateAmountSustainingBold = formatMessage({ id: 'nonprofits.donate.amount.sustaining_bold' });
 
 	if (props.showRecurring) {
 
@@ -45,8 +51,8 @@ function RecurringCheckbox(props: RecurringCheckboxProps): JSX.Element {
 				<input id={checkboxId} type={'checkbox'} checked={props.isRecurring || undefined} onChange={e => props.setRecurring(!props.isRecurring)} />
 				<label htmlFor={checkboxId}>
 					<ComposeTranslation
-						full={I18n.t('nonprofits.donate.amount.sustaining')}
-						bold={I18n.t('nonprofits.donate.amount.sustaining_bold')} />
+						full={nonprofitsDonateAmountSustaining}
+						bold={nonprofitsDonateAmountSustainingBold} />
 				</label>
 			</div>
 		</section>);
@@ -71,11 +77,13 @@ function ComposeTranslation(props: { full: string, bold: string }): JSX.Element 
 function RecurringMessage(props: { isRecurring: boolean, recurringWeekly: boolean, periodicAmount: number, singleAmount: string }): JSX.Element {
 	if (!props.isRecurring) return <></>;
 
-	let label = I18n.t('nonprofits.donate.amount.sustaining_selected');
-	let bolded = I18n.t('nonprofits.donate.amount.sustaining_selected_bold');
+	const { formatMessage } = useIntl();
+
+	let label = formatMessage({ id: 'nonprofits.donate.amount.sustaining_selected' });
+	let bolded = formatMessage({ id: 'nonprofits.donate.amount.sustaining_selected_bold' });
 	if (props.recurringWeekly) {
-		label = label.replace(I18n.t('nonprofits.donate.amount.monthly'), I18n.t('nonprofits.donate.amount.weekly'));
-		bolded = I18n.t('nonprofits.donate.amount.weekly');
+		label = label.replace(formatMessage({ id: 'nonprofits.donate.amount.monthly' }), formatMessage({ id: 'nonprofits.donate.amount.weekly' }));
+		bolded = formatMessage({ id: 'nonprofits.donate.amount.weekly' });
 	}
 	return (<section className={"donate-recurringMessage group"}>
 		<p className={`u-paddingX--5 u-centered ${!props.isRecurring ? 'u-hide' : ''}`}>
@@ -103,9 +111,14 @@ function getCurrencySymbol(amount: Money) {
 	}
 }
 
+function nextStepDisabled(): boolean {
+	return false;
+}
+
 interface AmountFieldsProps {
 	// singleAmount: string;
 	amounts: Money[];
+	goToNextStep: () => void;
 	// buttonAmountSelected: boolean;
 	//currencySymbol: string;
 }
@@ -114,6 +127,8 @@ interface AmountFieldsProps {
 
 function AmountFields(props: AmountFieldsProps): JSX.Element {
 	const {values, setFieldValue, submitForm} = useFormikContext<FormikFormValues>();
+	const { formatMessage } = useIntl();
+	const next = formatMessage({ id: 'nonprofits.donate.amount.next'});
 	// if (props.singleAmount) {
 	// 	return <></>;
 	// }
@@ -141,21 +156,21 @@ function AmountFields(props: AmountFieldsProps): JSX.Element {
 
 		{/* <fieldset className={prependCurrencyClassname(props.currencySymbol)}>
 			<input className={'amount other'} name={'amount'} step='any' type='number' min={1}
-				placeholder={I18n.t('nonprofits.donate.amount.custom')}
+				placeholder={'nonprofits.donate.amount.custom'}
 				onFocus={() => { throw new Error('onFocus not implemented'); }}
 				onChange={() => { throw new Error('onChange not implemented'); }}
 			/>
-		</fieldset>
+		</fieldset> */}
 
 		<fieldset>
 			<button className={'button u-width--full btn-next'}
 				type={'submit'}
-				disabled={nextStepDisabled}
-				onClick={() => props.goToNextStep()}
+				disabled={nextStepDisabled()}
+				onClick={() => { props.goToNextStep } }
 			>
-				{I18n.t('nonprofits.donate.amount.next')}
+				{ next }
 			</button>
-		</fieldset> */}
+		</fieldset>
 	</div>);
 }
 

--- a/app/javascript/components/legacy/nonprofits/donate/followup-step.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/followup-step.tsx
@@ -2,7 +2,7 @@
 // based on app/javascript/legacy/nonprofits/donate/followup-step.js
 import React from 'react';
 import noop from 'lodash/noop';
-declare const I18n: any;
+import { useIntl } from "../../../intl";
 interface FollowupStepProps {
 	supporterEmail?: string | null;
 	thankYouMessage?: string | null;
@@ -12,14 +12,19 @@ interface FollowupStepProps {
 
 }
 export default function FollowupStep(props: FollowupStepProps): JSX.Element {
+	const { formatMessage } = useIntl();
+	const nonprofitsDonateFollowupSuccess = formatMessage({ id: 'nonprofits.donate.followup.success' });
+	const nonprofitsDonateFollowupReceiptInfo = formatMessage({ id: 'nonprofits.donate.followup.receipt_info' });
+	const nonprofitsDonateFollowupMessage = formatMessage({ id: 'nonprofits.donate.followup.message' });
+	const nonprofitsDonateFollowupFinish = formatMessage({ id: 'nonprofits.donate.followup.finish' })
 
 	return (<div className="u-padding--10 u-centered">
 		<h6 className={'u-marginTop--15'}>
-			{I18n.t('nonprofits.donate.followup.success')}
+			{nonprofitsDonateFollowupSuccess}
 		</h6>
-		{ props.supporterEmail ? <p>{`${I18n.t('nonprofits.donate.followup.receipt_info')} ${props.supporterEmail}`}</p> : ''}
+		{ props.supporterEmail ? <p>{`${nonprofitsDonateFollowupReceiptInfo} ${props.supporterEmail}`}</p> : ''}
 		<p>
-			{props.thankYouMessage || `${props.nonprofitName} ${I18n.t('nonprofits.donate.followup.message')}`}
+			{props.thankYouMessage || `${props.nonprofitName} ${nonprofitsDonateFollowupMessage}`}
 		</p>
 
 
@@ -44,7 +49,7 @@ export default function FollowupStep(props: FollowupStepProps): JSX.Element {
 
 		{ props.showFinishButton ?
 			<div>
-				<button className={'button finish'} onClick={props.clickFinish}>{I18n.t('nonprofits.donate.followup.finish')}</button>
+				<button className={'button finish'} onClick={props.clickFinish}>{nonprofitsDonateFollowupFinish}</button>
 			</div> : ''
 		}
 	</div>);

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.stories.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.stories.tsx
@@ -22,10 +22,8 @@ function SWRWrapper(props: React.PropsWithChildren<unknown>) {
 	</SWRConfig>;
 }
 
-// Simple wizard
-
 export default {
-	title: 'donate/wizard',
+	title: 'Donate/Wizard',
 	argTypes: {
 		brandColor: {
 			type: { name: 'string' },
@@ -50,10 +48,6 @@ export default {
 		nonprofitName: {
 			type: { name: 'string' },
 			defaultValue: 'Nonprofit',
-		},
-		amountOptions: {
-			type: { name: 'typeof Money[]' },
-			defaultValue: [100, 500, 1000, 2500, 5000].map((i)=> Money.fromCents(i, 'usd')),
 		}
 	}
 };
@@ -89,6 +83,45 @@ const Template = (args: TemplateArgs) => {
 	</OuterWrapper>);
 };
 
-export const DonateWizardDefault = Template.bind({});
-DonateWizardDefault.story = {};
+export const Default = Template.bind({});
+Default.story = {};
 
+const SingleAmountTemplate = (args: TemplateArgs) => {
+	return (<OuterWrapper key={Math.random()}>
+		<SWRWrapper key={Math.random()}>
+			<DonateWizard
+				brandColor={args.brandColor}
+				offsite={args.offsite}
+				embedded={args.embedded}
+				title={args.title}
+				logo={args.logo}
+				nonprofitName={args.nonprofitName}
+				onClose={action('onClose')}
+				singleAmount={'10'}
+			/>
+		</SWRWrapper>
+	</OuterWrapper>);
+};
+
+export const SingleAmount = SingleAmountTemplate.bind({});
+SingleAmount.story = {};
+
+// const RecurringTemplate = (args: TemplateArgs) => {
+// 	return (<OuterWrapper key={Math.random()}>
+// 		<SWRWrapper key={Math.random()}>
+// 			<DonateWizard
+// 				brandColor={args.brandColor}
+// 				offsite={args.offsite}
+// 				embedded={args.embedded}
+// 				title={args.title}
+// 				logo={args.logo}
+// 				nonprofitName={args.nonprofitName}
+// 				onClose={action('onClose')}
+// 				isRecurring={true}
+// 			/>
+// 		</SWRWrapper>
+// 	</OuterWrapper>);
+// };
+
+// export const Recurring = RecurringTemplate.bind({});
+// Recurring.story = {};

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.stories.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.stories.tsx
@@ -86,7 +86,28 @@ const Template = (args: TemplateArgs) => {
 export const Default = Template.bind({});
 Default.story = {};
 
-const SingleAmountTemplate = (args: TemplateArgs) => {
+const NoRecurringOptionTemplate = (args: TemplateArgs) => {
+	return (<OuterWrapper key={Math.random()}>
+		<SWRWrapper key={Math.random()}>
+			<DonateWizard
+				brandColor={args.brandColor}
+				offsite={args.offsite}
+				embedded={args.embedded}
+				title={args.title}
+				logo={args.logo}
+				nonprofitName={args.nonprofitName}
+				amountOptions={args.amountOptions}
+				onClose={action('onClose')}
+				showRecurring={false}
+			/>
+		</SWRWrapper>
+	</OuterWrapper>);
+};
+
+export const NoRecurringOption = NoRecurringOptionTemplate.bind({});
+NoRecurringOption.story = {};
+
+const SingleAmountWithRecurringOptionTemplate = (args: TemplateArgs) => {
 	return (<OuterWrapper key={Math.random()}>
 		<SWRWrapper key={Math.random()}>
 			<DonateWizard
@@ -103,25 +124,48 @@ const SingleAmountTemplate = (args: TemplateArgs) => {
 	</OuterWrapper>);
 };
 
-export const SingleAmount = SingleAmountTemplate.bind({});
-SingleAmount.story = {};
+export const SingleAmountWithRecurringOption = SingleAmountWithRecurringOptionTemplate.bind({});
+SingleAmountWithRecurringOption.story = {};
 
-// const RecurringTemplate = (args: TemplateArgs) => {
-// 	return (<OuterWrapper key={Math.random()}>
-// 		<SWRWrapper key={Math.random()}>
-// 			<DonateWizard
-// 				brandColor={args.brandColor}
-// 				offsite={args.offsite}
-// 				embedded={args.embedded}
-// 				title={args.title}
-// 				logo={args.logo}
-// 				nonprofitName={args.nonprofitName}
-// 				onClose={action('onClose')}
-// 				isRecurring={true}
-// 			/>
-// 		</SWRWrapper>
-// 	</OuterWrapper>);
-// };
+const RecurringSingleAmountTemplate = (args: TemplateArgs) => {
+	return (<OuterWrapper key={Math.random()}>
+		<SWRWrapper key={Math.random()}>
+			<DonateWizard
+				brandColor={args.brandColor}
+				offsite={args.offsite}
+				embedded={args.embedded}
+				title={args.title}
+				logo={args.logo}
+				nonprofitName={args.nonprofitName}
+				onClose={action('onClose')}
+				singleAmount={'10'}
+				isRecurring={true}
+				showRecurring={false}
+			/>
+		</SWRWrapper>
+	</OuterWrapper>);
+};
 
-// export const Recurring = RecurringTemplate.bind({});
-// Recurring.story = {};
+export const RecurringSingleAmount = RecurringSingleAmountTemplate.bind({});
+RecurringSingleAmount.story = {};
+
+const RecurringTemplate = (args: TemplateArgs) => {
+	return (<OuterWrapper key={Math.random()}>
+		<SWRWrapper key={Math.random()}>
+			<DonateWizard
+				brandColor={args.brandColor}
+				offsite={args.offsite}
+				embedded={args.embedded}
+				title={args.title}
+				logo={args.logo}
+				nonprofitName={args.nonprofitName}
+				onClose={action('onClose')}
+				isRecurring={true}
+				showRecurring={false}
+			/>
+		</SWRWrapper>
+	</OuterWrapper>);
+};
+
+export const Recurring = RecurringTemplate.bind({});
+Recurring.story = {};

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.stories.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.stories.tsx
@@ -3,7 +3,92 @@ import * as React from 'react';
 import { action } from '@storybook/addon-actions';
 
 import DonateWizard from './wizard';
+import { SWRConfig } from 'swr';
+import { Money } from '../../../../common/money';
 
 
+function SWRWrapper(props: React.PropsWithChildren<unknown>) {
+	return <SWRConfig value={
+		{
+			dedupingInterval: 0, // we need to make SWR not dedupe
+			revalidateOnMount: true,
+			revalidateOnFocus: true,
+			revalidateOnReconnect: true,
+			focusThrottleInterval: 0,
+			provider: () => new Map(),
+		}
+	}>
+		{props.children}
+	</SWRConfig>;
+}
 
+// Simple wizard
+
+export default {
+	title: 'donate/wizard',
+	argTypes: {
+		brandColor: {
+			type: { name: 'string' },
+			defaultValue: '#0095a6',
+		},
+		offsite: {
+			type: { name: 'boolean' },
+			defaultValue: false,
+		},
+		embedded: {
+			type: { name: 'boolean' },
+			defaultValue: false,
+		},
+		title: {
+			type: { name: 'string' },
+			defaultValue: 'Donate',
+		}, // app.campaign.name || app.nonprofit.name
+		logo: {
+			type: { name: 'string' },
+			defaultValue: 'somelogourl',
+		}, //app.nonprofit.logo.normal
+		nonprofitName: {
+			type: { name: 'string' },
+			defaultValue: 'Nonprofit',
+		},
+		amountOptions: {
+			type: { name: 'typeof Money[]' },
+			defaultValue: [100, 500, 1000, 2500, 5000].map((i)=> Money.fromCents(i, 'usd')),
+		}
+	}
+};
+
+interface TemplateArgs {
+	brandColor: string;
+	offsite: boolean;
+	embedded: boolean;
+	onClose: () => void;
+	title: string; // app.campaign.name || app.nonprofit.name
+	logo: string; //app.nonprofit.logo.normal
+	nonprofitName: string;
+	amountOptions: Money[];
+}
+
+function OuterWrapper(props: React.PropsWithChildren<Record<string, unknown>>) {
+	return <> {props.children}</>;
+}
+const Template = (args: TemplateArgs) => {
+	return (<OuterWrapper key={Math.random()}>
+		<SWRWrapper key={Math.random()}>
+			<DonateWizard
+				brandColor={args.brandColor}
+				offsite={args.offsite}
+				embedded={args.embedded}
+				title={args.title}
+				logo={args.logo}
+				nonprofitName={args.nonprofitName}
+				amountOptions={args.amountOptions}
+				onClose={action('onClose')}
+			/>
+		</SWRWrapper>
+	</OuterWrapper>);
+};
+
+export const DonateWizardDefault = Template.bind({});
+DonateWizardDefault.story = {};
 

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -30,12 +30,15 @@ export interface DonateWizardProps {
 	logo: string; //app.nonprofit.logo.normal
 	nonprofitName: string;
 	amountOptions: Money[];
+	currencySymbol: string;
+	singleAmount: string | null;
 }
 
 export type ActionType = {
 	type: 'setAmount';
 	amount: Money;
 	next: () => void;
+	recurring: boolean;
 } | {type: 'setError', error: string} | {type: 'setLoading', loading: boolean};
 
 
@@ -108,7 +111,7 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 					</p>
 				</div>
 			</div>
-			<WizardWrapper nonprofitName={props.nonprofitName} amount={donateWizardState.amount} amountOptions={props.amountOptions} stateDispatch={stateDispatch} />
+			<WizardWrapper nonprofitName={props.nonprofitName} amount={donateWizardState.amount} amountOptions={props.amountOptions} currencySymbol={props.currencySymbol} stateDispatch={stateDispatch} singleAmount={props.singleAmount} />
 
 			{/* I'm not putting in the footer because it's not realy a useful feature */}
 
@@ -121,9 +124,8 @@ DonateWizard.defaultProps = {
 	onClose: noop,
 	embedded: false,
 	offsite: false,
-	amountOptions: [100, 500, 1000, 2500, 5000].map((i) => Money.fromCents(i, 'usd')),
-
-
+	amountOptions: [10, 25, 50, 100, 250, 500, 1000].map((i) => Money.fromCents(i, 'usd')),
+	currencySymbol: '$'
 } as DonateWizardProps;
 
 function HeaderDesignation(props: { brandColor: string, designation_desc?: string | null }): JSX.Element {
@@ -145,6 +147,8 @@ interface WizardWrapperProps {
 	amountOptions: Money[];
 	nonprofitName: string;
 	stateDispatch: (action: ActionType) => void;
+	currencySymbol: string;
+	singleAmount: string | null;
 }
 
 
@@ -164,7 +168,7 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 					{
 						title: nonprofitsDonateAmountLabel,
 						key: nonprofitsDonateAmountLabel,
-						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'} stateDispatch={props.stateDispatch} />,
+						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'} stateDispatch={props.stateDispatch} currencySymbol={props.currencySymbol} singleAmount={'10'} />,
 					},
 					{
 						title: nonprofitsDonateInfoLabel,

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -32,6 +32,8 @@ export interface DonateWizardProps {
 	amountOptions: Money[];
 	currencySymbol: string;
 	singleAmount: string | null;
+	isRecurring: boolean;
+	showRecurring: boolean;
 }
 
 export type ActionType = {
@@ -39,10 +41,10 @@ export type ActionType = {
 	amount: Money;
 	next: () => void;
 	recurring: boolean;
-} | {type: 'setError', error: string} | {type: 'setLoading', loading: boolean};
+} | { type: 'setError', error: string } | { type: 'setLoading', loading: boolean };
 
 
-function useDonateWizardState(initialState: DonateWizardOutputState) : [DonateWizardOutputState, (action:ActionType) => void] {
+function useDonateWizardState(initialState: DonateWizardOutputState): [DonateWizardOutputState, (action: ActionType) => void] {
 	const [donateWizardState, stateDispatch] = useReducer(wizardOutputReducer, initialState);
 
 	const reducerAction = (action: ActionType) => {
@@ -66,7 +68,7 @@ function wizardOutputReducer(state: DonateWizardOutputState, action: ActionType)
 		case 'setAmount':
 			return { ...state, amount: action.amount };
 		case 'setLoading':
-			return { ...state, loading: action.loading};
+			return { ...state, loading: action.loading };
 		default:
 			throw new Error();
 	}
@@ -111,7 +113,15 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 					</p>
 				</div>
 			</div>
-			<WizardWrapper nonprofitName={props.nonprofitName} amount={donateWizardState.amount} amountOptions={props.amountOptions} currencySymbol={props.currencySymbol} stateDispatch={stateDispatch} singleAmount={props.singleAmount} />
+			<WizardWrapper
+				nonprofitName={props.nonprofitName}
+				amount={donateWizardState.amount}
+				amountOptions={props.amountOptions}
+				currencySymbol={props.currencySymbol}
+				stateDispatch={stateDispatch}
+				singleAmount={props.singleAmount}
+				isRecurring={props.isRecurring}
+				showRecurring={props.showRecurring} />
 
 			{/* I'm not putting in the footer because it's not realy a useful feature */}
 
@@ -125,7 +135,9 @@ DonateWizard.defaultProps = {
 	embedded: false,
 	offsite: false,
 	amountOptions: [10, 25, 50, 100, 250, 500, 1000].map((i) => Money.fromCents(i, 'usd')),
-	currencySymbol: '$'
+	currencySymbol: '$',
+	isRecurring: false,
+	showRecurring: true
 } as DonateWizardProps;
 
 function HeaderDesignation(props: { brandColor: string, designation_desc?: string | null }): JSX.Element {
@@ -149,6 +161,8 @@ interface WizardWrapperProps {
 	stateDispatch: (action: ActionType) => void;
 	currencySymbol: string;
 	singleAmount: string | null;
+	isRecurring: boolean;
+	showRecurring: boolean;
 }
 
 
@@ -168,7 +182,15 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 					{
 						title: nonprofitsDonateAmountLabel,
 						key: nonprofitsDonateAmountLabel,
-						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'} stateDispatch={props.stateDispatch} currencySymbol={props.currencySymbol} singleAmount={'10'} />,
+						body: <AmountStep
+							amountOptions={props.amountOptions}
+							amount={props.amount}
+							key={'AmountStep'}
+							stateDispatch={props.stateDispatch}
+							currencySymbol={props.currencySymbol}
+							singleAmount={props.singleAmount}
+							isRecurring={props.isRecurring}
+							showRecurring={props.showRecurring} />,
 					},
 					{
 						title: nonprofitsDonateInfoLabel,

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -46,15 +46,34 @@ export type ActionType = {
 	amount: Money;
 	next: () => void;
 	recurring: boolean;
-} | { type: 'setError', error: string } | { type: 'setLoading', loading: boolean };
+} | {
+	type: 'setError',
+	error: string
+} | {
+	type: 'setLoading',
+	loading: boolean
+} | {
+	type: 'setSupporter',
+	supporter: SupporterType,
+	address: AddressProps,
+	next: () => void
+};
 
 export type SupporterType = {
 	firstName: string;
-  lastName: string;
-  email: string;
-  phone: string;
-  profileId: string;
-  nonprofitId: string;
+	lastName: string;
+	email: string;
+	phone: string;
+	profileId: string;
+	nonprofitId: string;
+}
+
+export type AddressProps = {
+	address: string;
+	city: string;
+	stateCode: string;
+	country: string;
+	zipCode: string;
 }
 
 export type RequiredFieldsType = {
@@ -75,6 +94,11 @@ function useDonateWizardState(initialState: DonateWizardOutputState): [DonateWiz
 				action.next();
 				break;
 			}
+			case 'setSupporter': {
+				stateDispatch(action);
+				action.next();
+				break;
+			}
 
 			default: {
 				stateDispatch(action);
@@ -90,6 +114,8 @@ function wizardOutputReducer(state: DonateWizardOutputState, action: ActionType)
 			return { ...state, amount: action.amount, recurring: action.recurring };
 		case 'setLoading':
 			return { ...state, loading: action.loading };
+		case 'setSupporter':
+			return { ...state, supporter: action.supporter, address: action.address };
 		default:
 			throw new Error();
 	}
@@ -104,12 +130,14 @@ export interface DonateWizardOutputState {
 	loading: boolean | null;
 	error: string | null;
 	recurring: boolean | null;
+	supporter: SupporterType | null;
+	address: AddressProps | null;
 }
 
 export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 	useBrandedWizard(props.brandColor);
 
-	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null, recurring: false });
+	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null, recurring: false, supporter: null, address: null });
 
 	const canClose = props.offsite || !props.embedded;
 	const hiddenCloseButton = !props.offsite || !props.embedded;
@@ -143,14 +171,8 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 				isRecurring={donateWizardState.recurring}
 				weekly={props.weekly}
 				showRecurring={props.showRecurring}
-				supporter={{
-					firstName: '',
-					lastName: '',
-					email: '',
-					phone: '',
-					profileId: '',
-					nonprofitId: ''
-				}}
+				supporter={donateWizardState.supporter}
+				address = {donateWizardState.address}
 				required={{
 					email: props.required.email,
 					firstName: props.required.firstName,
@@ -209,6 +231,7 @@ interface WizardWrapperProps {
 	showRecurring: boolean;
 	supporter: SupporterType;
 	required: RequiredFieldsType;
+	address: AddressProps | null;
 }
 
 
@@ -242,14 +265,17 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 					{
 						title: nonprofitsDonateInfoLabel,
 						key: nonprofitsDonateInfoLabel,
-						body: <InfoStep key={'InfoStep'}
+						body: <InfoStep
+							key={'InfoStep'}
 							required={props.required}
 							supporter={props.supporter}
 							hideDedication={props.hideDedication}
 							isRecurring={props.isRecurring}
-							weekly={false}
+							weekly={props.weekly}
 							amount={props.amount}
-							currencySymbol={props.currencySymbol}/>,
+							stateDispatch={props.stateDispatch}
+							currencySymbol={props.currencySymbol}
+							address={undefined}/>,
 					},
 					{
 						title: nonprofitsDonatePaymentLabel,

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -92,7 +92,6 @@ function useDonateWizardState(initialState: DonateWizardOutputState): [DonateWiz
 	const [donateWizardState, stateDispatch] = useReducer(wizardOutputReducer, initialState);
 
 	const reducerAction = (action: ActionType) => {
-		console.log(action);
 		switch (action.type) {
 			case 'setAmount': {
 				stateDispatch(action);

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -5,6 +5,7 @@ import React, { useReducer, useState, Dispatch, createContext } from 'react';
 import { useBrandedWizard } from '../../components/styles/branded-wizard';
 import Wizard, { WizardContext } from '../../_dependencies/ff-core/wizard';
 import { AmountStep } from './amount-step';
+import { InfoStep } from './InfoStep';
 import { Money } from '../../../../common/money';
 import { useIntl } from "../../../intl";
 
@@ -22,6 +23,7 @@ import { useContext } from 'react';
 import { result } from 'lodash';
 
 export interface DonateWizardProps {
+	hideDedication: boolean;
 	brandColor: string;
 	offsite: boolean;
 	embedded: boolean;
@@ -34,6 +36,8 @@ export interface DonateWizardProps {
 	singleAmount: string | null;
 	isRecurring: boolean;
 	showRecurring: boolean;
+	required: RequiredFieldsType;
+	supporter: SupporterType;
 }
 
 export type ActionType = {
@@ -42,6 +46,22 @@ export type ActionType = {
 	next: () => void;
 	recurring: boolean;
 } | { type: 'setError', error: string } | { type: 'setLoading', loading: boolean };
+
+export type SupporterType = {
+	firstName: string;
+  lastName: string;
+  email: string;
+  phone: string;
+  profileId: string;
+  nonprofitId: string;
+}
+
+export type RequiredFieldsType = {
+  email: boolean;
+  firstName: boolean;
+  lastName: boolean;
+  phone: boolean;
+}
 
 
 function useDonateWizardState(initialState: DonateWizardOutputState): [DonateWizardOutputState, (action: ActionType) => void] {
@@ -121,7 +141,22 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 				stateDispatch={stateDispatch}
 				singleAmount={props.singleAmount}
 				isRecurring={props.isRecurring}
-				showRecurring={props.showRecurring} />
+				showRecurring={props.showRecurring}
+				supporter={{
+					firstName: '',
+					lastName: '',
+					email: '',
+					phone: '',
+					profileId: '',
+					nonprofitId: ''
+				}}
+				required={{
+					email: props.required.email,
+					firstName: props.required.firstName,
+					lastName: props.required.lastName,
+					phone: props.required.phone
+				}}
+				hideDedication={props.hideDedication} />
 
 			{/* I'm not putting in the footer because it's not realy a useful feature */}
 
@@ -137,7 +172,13 @@ DonateWizard.defaultProps = {
 	amountOptions: [10, 25, 50, 100, 250, 500, 1000].map((i) => Money.fromCents(i, 'usd')),
 	currencySymbol: '$',
 	isRecurring: false,
-	showRecurring: true
+	showRecurring: true,
+	required: {
+		email: true,
+		firstName: true,
+		lastName: true,
+		phone: true
+	}
 } as DonateWizardProps;
 
 function HeaderDesignation(props: { brandColor: string, designation_desc?: string | null }): JSX.Element {
@@ -155,6 +196,7 @@ HeaderDesignation.defaultProps = {
 };
 
 interface WizardWrapperProps {
+	hideDedication: boolean;
 	amount: Money;
 	amountOptions: Money[];
 	nonprofitName: string;
@@ -163,6 +205,8 @@ interface WizardWrapperProps {
 	singleAmount: string | null;
 	isRecurring: boolean;
 	showRecurring: boolean;
+	supporter: SupporterType;
+	required: RequiredFieldsType;
 }
 
 
@@ -195,7 +239,7 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 					{
 						title: nonprofitsDonateInfoLabel,
 						key: nonprofitsDonateInfoLabel,
-						body: <div key={'InfoStep'}>InfoStep</div>,
+						body: <InfoStep key={'InfoStep'} required={props.required} supporter={props.supporter} hideDedication={props.hideDedication}/>,
 					},
 					{
 						title: nonprofitsDonatePaymentLabel,

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -35,6 +35,7 @@ export interface DonateWizardProps {
 	currencySymbol: string;
 	singleAmount: string | null;
 	isRecurring: boolean;
+	weekly: boolean;
 	showRecurring: boolean;
 	required: RequiredFieldsType;
 	supporter: SupporterType;
@@ -86,7 +87,7 @@ function useDonateWizardState(initialState: DonateWizardOutputState): [DonateWiz
 function wizardOutputReducer(state: DonateWizardOutputState, action: ActionType): DonateWizardOutputState {
 	switch (action.type) {
 		case 'setAmount':
-			return { ...state, amount: action.amount };
+			return { ...state, amount: action.amount, recurring: action.recurring };
 		case 'setLoading':
 			return { ...state, loading: action.loading };
 		default:
@@ -102,14 +103,13 @@ export interface DonateWizardOutputState {
 	amount: Money | null;
 	loading: boolean | null;
 	error: string | null;
+	recurring: boolean | null;
 }
 
 export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 	useBrandedWizard(props.brandColor);
 
-
-
-	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null });
+	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null, recurring: false });
 
 	const canClose = props.offsite || !props.embedded;
 	const hiddenCloseButton = !props.offsite || !props.embedded;
@@ -140,7 +140,8 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 				currencySymbol={props.currencySymbol}
 				stateDispatch={stateDispatch}
 				singleAmount={props.singleAmount}
-				isRecurring={props.isRecurring}
+				isRecurring={donateWizardState.recurring}
+				weekly={props.weekly}
 				showRecurring={props.showRecurring}
 				supporter={{
 					firstName: '',
@@ -204,6 +205,7 @@ interface WizardWrapperProps {
 	currencySymbol: string;
 	singleAmount: string | null;
 	isRecurring: boolean;
+	weekly: boolean;
 	showRecurring: boolean;
 	supporter: SupporterType;
 	required: RequiredFieldsType;
@@ -234,12 +236,20 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 							currencySymbol={props.currencySymbol}
 							singleAmount={props.singleAmount}
 							isRecurring={props.isRecurring}
+							weekly={props.weekly}
 							showRecurring={props.showRecurring} />,
 					},
 					{
 						title: nonprofitsDonateInfoLabel,
 						key: nonprofitsDonateInfoLabel,
-						body: <InfoStep key={'InfoStep'} required={props.required} supporter={props.supporter} hideDedication={props.hideDedication}/>,
+						body: <InfoStep key={'InfoStep'}
+							required={props.required}
+							supporter={props.supporter}
+							hideDedication={props.hideDedication}
+							isRecurring={props.isRecurring}
+							weekly={false}
+							amount={props.amount}
+							currencySymbol={props.currencySymbol}/>,
 					},
 					{
 						title: nonprofitsDonatePaymentLabel,

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -148,7 +148,7 @@ export interface DonateWizardOutputState {
 export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 	useBrandedWizard(props.brandColor);
 
-	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null, recurring: false, supporter: null, address: null, selectedPayment: null });
+	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null, recurring: props.isRecurring, supporter: null, address: null, selectedPayment: null });
 
 	const canClose = props.offsite || !props.embedded;
 	const hiddenCloseButton = !props.offsite || !props.embedded;

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -140,7 +140,7 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 					{
 						title: nonprofitsDonateAmountLabel,
 						key: nonprofitsDonateAmountLabel,
-						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'}/>,
+						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'} goToNextStep={console.log}/>,
 					},
 					{
 						title: nonprofitsDonateInfoLabel,

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -14,6 +14,10 @@ import '../../../../../assets/stylesheets/global.css.scss';
 import '../../../../../assets/stylesheets/nonprofits/donate/page.css.scss';
 import '../../../../../assets/stylesheets/components/wizard_index.css.scss';
 import '../../../../../assets/stylesheets/donate-button/donate-button.v2.css';
+import '../../../../../assets/stylesheets/nonprofits/donation_form/show/index.css.scss';
+import '../../../../../assets/stylesheets/nonprofits/donation_form/title_row.css.scss';
+import '../../../../../assets/stylesheets/nonprofits/donation_form/footer.css.scss';
+import '../../../../../assets/stylesheets/nonprofits/donation_form/form.css.scss';
 
 export interface DonateWizardProps {
   brandColor: string;

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -133,17 +133,17 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 						title: nonprofitsDonateAmountLabel,
 
 						key: nonprofitsDonateAmountLabel,
-						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} />,
+						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'}/>,
 					},
 					{
 						title: nonprofitsDonateInfoLabel,
 						key: nonprofitsDonateInfoLabel,
-						body: <div>InfoStep</div>,
+						body: <div key={'InfoStep'}>InfoStep</div>,
 					},
 					{
 						title: nonprofitsDonatePaymentLabel,
 						key: nonprofitsDonatePaymentLabel,
-						body: <div>PaymentStep</div>,
+						body: <div key={'PaymentStep'}>PaymentStep</div>,
 					},
 				]
 			} />

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -10,7 +10,8 @@ import { useIntl } from "../../../intl";
 
 import closeSvg from './close.svg';
 import FollowupStep from './followup-step';
-
+// import '../../../../../assets/stylesheets/donate-button/donate-button.v2.css';
+import '../../../../../assets/stylesheets/components/wizard_index.css.scss';
 export interface DonateWizardProps {
   brandColor: string;
   offsite: boolean;

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -67,7 +67,7 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 	const hiddenCloseButton = !props.offsite || !props.embedded;
 
 	return (
-		<div className={'js-donateForm' + props.offsite ? ' is-modal' : ''}>
+		<div className={props.offsite ? 'js-donateForm is-modal' : 'js-donateForm'}>
 			<img className={'closeButton' + (hiddenCloseButton ? ' u-hide' : '')} src={closeSvg} onClick={_e => {
 				if (canClose) {
 					props.onClose();
@@ -139,7 +139,6 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 				[
 					{
 						title: nonprofitsDonateAmountLabel,
-
 						key: nonprofitsDonateAmountLabel,
 						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'}/>,
 					},

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -6,13 +6,12 @@ import { useBrandedWizard } from '../../components/styles/branded-wizard';
 import Wizard from '../../_dependencies/ff-core/wizard';
 import { AmountStep } from './amount-step';
 import { Money } from '../../../../common/money';
+import { useIntl } from "../../../intl";
 
 import closeSvg from './close.svg';
 import FollowupStep from './followup-step';
 
-
-declare const I18n: any;
-interface DonateWizardProps {
+export interface DonateWizardProps {
   brandColor: string;
   offsite: boolean;
   embedded: boolean;
@@ -54,14 +53,14 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 	const [error, setError] = useState<any | null>();
 	const [loading, setLoading] = useState<boolean>(false);
 
-	const [donateWizardState, stateDispatch] = useReducer(wizardOutputReducer,{amount: null});
+	const [donateWizardState, stateDispatch] = useReducer(wizardOutputReducer,{amount: null}); // what is it supposed to do?
 
 	const canClose = props.offsite || !props.embedded;
 	const hiddenCloseButton = !props.offsite || !props.embedded;
 
 	return (
 		<div className={'js-donateForm' + props.offsite ? ' is-modal' : ''}>
-			<img className={'closeButton' + hiddenCloseButton ? ' u-hide' : ''} src={closeSvg} onClick={_e => {
+			<img className={'closeButton' + (hiddenCloseButton ? ' u-hide' : '')} src={closeSvg} onClick={_e => {
 				if (canClose) {
 					props.onClose();
 				}
@@ -97,9 +96,11 @@ DonateWizard.defaultProps = {
 } as DonateWizardProps;
 
 function HeaderDesignation(props: { brandColor: string, designation_desc?: string | null }): JSX.Element {
+	const { formatMessage } = useIntl();
+	const donateAmountDesignationLabel = formatMessage({ id: 'nonprofits.donate.amount.designation.label'});
 	return (<span>
 		<i className={"fa fa-star"} style={{ color: props.brandColor }} />
-		<strong>{I18n.t('nonprofits.donate.amount.designation.label')}</strong>
+		<strong>{donateAmountDesignationLabel}</strong>
 		{props.designation_desc ? <span><br /><small>{props.designation_desc}</small></span> : null}
 	</span>);
 }
@@ -117,6 +118,11 @@ interface WizardWrapperProps {
 
 
 function WizardWrapper(props: WizardWrapperProps): JSX.Element {
+	const { formatMessage } = useIntl();
+	const nonprofitsDonateAmountLabel = formatMessage({ id: 'nonprofits.donate.amount.label'});
+	const nonprofitsDonateInfoLabel = formatMessage({ id: 'nonprofits.donate.info.label'});
+	const nonprofitsDonatePaymentLabel = formatMessage({ id: 'nonprofits.donate.payment.label'});
+
 	return <div className={'wizard-steps donation-steps'} >
 		<Wizard
 			followup={() => <FollowupStep nonprofitName={props.nonprofitName} />}
@@ -124,19 +130,19 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 			steps={
 				[
 					{
-						title: I18n.t('nonprofits.donate.amount.label'),
+						title: nonprofitsDonateAmountLabel,
 
-						key: I18n.t('nonprofits.donate.amount.label'),
+						key: nonprofitsDonateAmountLabel,
 						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} />,
 					},
 					{
-						title: I18n.t('nonprofits.donate.info.label'),
-						key: I18n.t('nonprofits.donate.info.label'),
+						title: nonprofitsDonateInfoLabel,
+						key: nonprofitsDonateInfoLabel,
 						body: <div>InfoStep</div>,
 					},
 					{
-						title: I18n.t('nonprofits.donate.payment.label'),
-						key: I18n.t('nonprofits.donate.payment.label'),
+						title: nonprofitsDonatePaymentLabel,
+						key: nonprofitsDonatePaymentLabel,
 						body: <div>PaymentStep</div>,
 					},
 				]

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -10,8 +10,11 @@ import { useIntl } from "../../../intl";
 
 import closeSvg from './close.svg';
 import FollowupStep from './followup-step';
-// import '../../../../../assets/stylesheets/donate-button/donate-button.v2.css';
+import '../../../../../assets/stylesheets/global.css.scss';
+import '../../../../../assets/stylesheets/nonprofits/donate/page.css.scss';
 import '../../../../../assets/stylesheets/components/wizard_index.css.scss';
+import '../../../../../assets/stylesheets/donate-button/donate-button.v2.css';
+
 export interface DonateWizardProps {
   brandColor: string;
   offsite: boolean;

--- a/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
+++ b/app/javascript/components/legacy/nonprofits/donate/wizard.tsx
@@ -35,18 +35,18 @@ export interface DonateWizardProps {
 export type ActionType = {
 	type: 'setAmount';
 	amount: Money;
+	next: () => void;
 } | {type: 'setError', error: string} | {type: 'setLoading', loading: boolean};
 
 
 function useDonateWizardState(initialState: DonateWizardOutputState) : [DonateWizardOutputState, (action:ActionType) => void] {
 	const [donateWizardState, stateDispatch] = useReducer(wizardOutputReducer, initialState);
-	const stepManagerContext = useContext(WizardContext);
 
 	const reducerAction = (action: ActionType) => {
 		switch (action.type) {
 			case 'setAmount': {
 				stateDispatch(action);
-				stepManagerContext.next();
+				action.next();
 				break;
 			}
 
@@ -84,7 +84,7 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 
 
 
-	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null }); // what is it supposed to do?
+	const [donateWizardState, stateDispatch] = useDonateWizardState({ amount: null, loading: false, error: null });
 
 	const canClose = props.offsite || !props.embedded;
 	const hiddenCloseButton = !props.offsite || !props.embedded;
@@ -108,7 +108,7 @@ export default function DonateWizard(props: DonateWizardProps): JSX.Element {
 					</p>
 				</div>
 			</div>
-			<WizardWrapper nonprofitName={props.nonprofitName} amount={donateWizardState.amount} amountOptions={props.amountOptions} />
+			<WizardWrapper nonprofitName={props.nonprofitName} amount={donateWizardState.amount} amountOptions={props.amountOptions} stateDispatch={stateDispatch} />
 
 			{/* I'm not putting in the footer because it's not realy a useful feature */}
 
@@ -144,6 +144,7 @@ interface WizardWrapperProps {
 	amount: Money;
 	amountOptions: Money[];
 	nonprofitName: string;
+	stateDispatch: (action: ActionType) => void;
 }
 
 
@@ -163,7 +164,7 @@ function WizardWrapper(props: WizardWrapperProps): JSX.Element {
 					{
 						title: nonprofitsDonateAmountLabel,
 						key: nonprofitsDonateAmountLabel,
-						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'} goToNextStep={console.log} />,
+						body: <AmountStep amountOptions={props.amountOptions} amount={props.amount} key={'AmountStep'} stateDispatch={props.stateDispatch} />,
 					},
 					{
 						title: nonprofitsDonateInfoLabel,


### PR DESCRIPTION
This is a WIP for the migration of the Donate Wizard to React. It includes:

* Storybook support with a few different scenarios;
* Wizard styling;
* AmountStep including custom amounts, or inserting a different amount, selecting recurring donation;
* InfoStep including the supporter fields component, different payment methods and other details.

This is how it looks now:
![donate-wizard](https://user-images.githubusercontent.com/15739610/146822252-0e09bfc4-cc14-4599-814e-b8024fc3d203.gif)

The style on InfoStep looks off because we're still not using the select input to choose the country and the state and the payment buttons need a review to check what's missing on the styles.

What's next:
* Post the supporter when choosing a payment method;
* Add designation on the AmountStep;
* Missing components on the InfoStep;
  * CustomFields;
  * DedicationLink;
  * AnonymousCheckbox;
  * DedicationForm;
* Fix the styles on the InfoStep;
* Load countries and cities information on the InfoStep;
* PaymentStep;
* FollowupStep.


