### PR TITLE
Update gems for Jan 18, 2022

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '6.1.4.4'
 gem 'jbuilder', '~> 2.11'
-gem 'bootsnap', '~> 1.9', require: false # Large rails application booting enhancer
+gem 'bootsnap', '~> 1.10', require: false # Large rails application booting enhancer
 gem 'font_assets', '~> 0.1.14' # for serving fonts on cdn https://github.com/ericallam/font_assets
 gem 'hamster', '~> 3.0' # Thread-safe collection classes for Ruby
 gem 'puma', '~> 5.5'

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'sprockets', '~> 3.7'
 
 # Helpers
 gem 'chronic', '~> 0.10.2' # For nat lang parsing of dates
-gem 'countries', '~> 4.1'
+gem 'countries', '~> 4.2'
 gem 'i18n-js', '~> 3.8', git: 'https://github.com/houdiniproject/i18n-js.git', branch: 'houdini-tweaks'
 gem 'lograge', '~> 0.11.2' # make logging less terrible in rails
 gem 'rails-i18n', '~> 6.0.0', '~> 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,8 +122,8 @@ GEM
     async-io (1.32.2)
       async
     bcrypt (3.1.16)
-    bootsnap (1.9.3)
-      msgpack (~> 1.0)
+    bootsnap (1.10.1)
+      msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
     chronic (0.10.2)
@@ -468,7 +468,7 @@ PLATFORMS
 DEPENDENCIES
   action_mailer_matchers (~> 1.2)
   bess!
-  bootsnap (~> 1.9)
+  bootsnap (~> 1.10)
   byebug (~> 11.0, >= 11.0.1)
   chronic (~> 0.10.2)
   colorize (~> 0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     connection_pool (2.2.5)
     console (1.13.1)
       fiber-local
-    countries (4.1.3)
+    countries (4.2.1)
       i18n_data (~> 0.15.0)
       sixarm_ruby_unaccent (~> 1.1)
     crack (0.4.5)
@@ -472,7 +472,7 @@ DEPENDENCIES
   byebug (~> 11.0, >= 11.0.1)
   chronic (~> 0.10.2)
   colorize (~> 0.8.1)
-  countries (~> 4.1)
+  countries (~> 4.2)
   database_cleaner-active_record
   date (~> 3.0.2)
   devise (~> 4.8)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
       method_source
       rake (>= 0.13)
       thor (~> 1.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (12.3.3)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -378,7 +378,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
-    rubocop-rails (2.13.1)
+    rubocop-rails (2.13.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     fasterer (0.9.0)
       colorize (~> 0.7)
       ruby_parser (>= 3.14.1)
-    ffi (1.15.4)
+    ffi (1.15.5)
     fiber-local (1.0.0)
     font_assets (0.1.14)
       rack
@@ -227,7 +227,7 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     libv8-node (15.14.0.1)
-    listen (3.7.0)
+    listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -1094,7 +1094,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** countries; version 4.1.3 -- 
+** countries; version 4.2.1 -- 
 Copyright (c) 2012
 Copyright (c) 2016
 
@@ -2092,7 +2092,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** rainbow; version 3.0.0 -- 
+** rainbow; version 3.1.1 -- 
 Copyright (c) Marcin Kulik
 
 Copyright (c) Marcin Kulik
@@ -2373,7 +2373,7 @@ SOFTWARE.
 
 ------
 
-** listen; version 3.7.0 -- 
+** listen; version 3.7.1 -- 
 Copyright (c) 2013 Thibaud Guillaume-Gentil
 
 Copyright (c) 2013 Thibaud Guillaume-Gentil
@@ -2527,7 +2527,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** rubocop-rails; version 2.13.1 -- 
+** rubocop-rails; version 2.13.2 -- 
 
 Copyright (c) 2012-22 Bozhidar Batsov
 
@@ -3147,6 +3147,34 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+------
+
+** bootsnap; version 1.10.1 -- 
+Copyright (c) 2017-present Shopify, Inc.
+
+The MIT License (MIT)
+
+Copyright (c) 2017-present Shopify, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ------
@@ -3855,34 +3883,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-------
-
-** bootsnap; version 1.9.3 -- 
-Copyright (c) 2017 Shopify, Inc.
-
-The MIT License (MIT)
-
-Copyright (c) 2017 Shopify, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
 
 
 ------
@@ -4714,7 +4714,7 @@ https://mozilla.org/MPL/2.0/
 
 ------
 
-** ffi; version 1.15.4 -- 
+** ffi; version 1.15.5 -- 
 Copyright (c) 2013
 (c) 2008 Red Hat, Inc.
 (c) 2011 Anthony Green
@@ -4844,8 +4844,10 @@ Copyright (c) 2003, 2004, 2006, 2007, 2012 Kaz Kojima
 Copyright (c) 2013 Miodrag Vallat. <miod@openbsd.org>
 Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
 Copyright 1993 Bill Triggs <Bill.Triggs@inrialpes.fr>
+Copyright (c) 1994-2018 Free Software Foundation, Inc.
 Copyright (c) 1996, 2003-2004, 2007-2008 Red Hat, Inc.
 Copyright (c) 1996-2015 Free Software Foundation, Inc.
+Copyright (c) 1996-2018 Free Software Foundation, Inc.
 Copyright (c) 1999-2018 Free Software Foundation, Inc.
 Copyright (c) 2004-2015 Free Software Foundation, Inc.
 Copyright (c) 2007, 2008 Free Software Foundation, Inc


### PR DESCRIPTION
- Bump rubocop-rails from 2.13.1 to 2.13.2
- Bump listen from 3.7.0 to 3.7.1
- Bump bootsnap from 1.9.3 to 1.10.1
- Bump countries from 4.1.3 to 4.2.1
