### PR TITLE
Only use path parameters to calculate current_nonprofit/event/transaction/etc

### DIFF
--- a/app/controllers/concerns/controllers/api/transaction/current.rb
+++ b/app/controllers/concerns/controllers/api/transaction/current.rb
@@ -10,7 +10,7 @@ module Controllers::Api::Transaction::Current
 		private
 
 		def current_transaction
-			@current_transaction ||= current_nonprofit.transactions.find(params[:transaction_id] || params[:id])
+			@current_transaction ||= current_nonprofit.transactions.find(request.path_parameters[:transaction_id] || request.path_parameters[:id])
 		end
 	end
 end

--- a/app/controllers/concerns/controllers/campaign/current.rb
+++ b/app/controllers/concerns/controllers/campaign/current.rb
@@ -10,7 +10,7 @@ module Controllers::Campaign::Current
 		private
 
 		def current_campaign
-			@campaign ||= FetchCampaign.with_params params, current_nonprofit
+			@campaign ||= FetchCampaign.with_params request.path_parameters, current_nonprofit
 			raise ActionController::RoutingError, 'Campaign not found' if @campaign.nil?
 
 			@campaign

--- a/app/controllers/concerns/controllers/event/current.rb
+++ b/app/controllers/concerns/controllers/event/current.rb
@@ -10,7 +10,7 @@ module Controllers::Event::Current
 		private
 
 		def current_event
-			@event ||= FetchEvent.with_params params, current_nonprofit
+			@event ||= FetchEvent.with_params request.path_parameters, current_nonprofit
 			raise ActionController::RoutingError, 'Event not found' if @event.nil?
 
 			@event

--- a/app/controllers/concerns/controllers/nonprofit/current.rb
+++ b/app/controllers/concerns/controllers/nonprofit/current.rb
@@ -15,7 +15,7 @@ module Controllers::Nonprofit::Current
 		end
 
 		def current_nonprofit_without_exception
-			FetchNonprofit.with_params params, administered_nonprofit
+			FetchNonprofit.with_params request.path_parameters, administered_nonprofit
 		end
 	end
 end

--- a/app/controllers/concerns/controllers/supporter/current.rb
+++ b/app/controllers/concerns/controllers/supporter/current.rb
@@ -9,7 +9,7 @@ module Controllers::Supporter::Current
 		private
 
 		def current_supporter
-			current_nonprofit.supporters.find(params[:supporter_id] || params[:id])
+			current_nonprofit.supporters.find(request.path_parameters[:supporter_id] || request.path_parameters[:id])
 		end
 	end
 end

--- a/app/models/concerns/model/jbuilder.rb
+++ b/app/models/concerns/model/jbuilder.rb
@@ -233,7 +233,7 @@ module Model::Jbuilder
 		def add_builder_expansion( ... )
 			builder_expansions = BuilderExpansionSet.new
 			builder_expansions.add_builder_expansion( ... )
-			builder_expansions.each_key do |k|
+			builder_expansions.keys.each do |k| # fastener was wrong here, we need "keys.each"
 				if expand.include? k
 					set! builder_expansions.get_by_key(k).json_attribute, builder_expansions.get_by_key(k).to_builder.(model)
 				else


### PR DESCRIPTION
In some controllers, we decide what the current nonprofit is based upon the path itself. For example, in `/api/nonprofits/:nonprofit_id`, we set `current_nonprofit` in the controller to whatever nonprofit corresponds with that `nonprofit_id`. We do this similarly for events, campaigns, supporters and transactions.

A problem exists when a user also sends a parameter, either via query parameters, POST parameters, or JSON being POSTed and the parameter has the same name as the path parameter. In that case, the parameter passed would override the value in the request param. For example, for `/api/nonprofit/np_houid1?nonprofit_id=np_houid2`, the `current_nonprofit` would be loaded as the one with `houid2`. This is not correct.

This fix changes the `current_` methods so they only look at the path_parameters passed via the request.


Additionally, this fixed a bug caused by running fastener.
