### PR TITLE
More updates for January 24, 2022

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -101,7 +101,7 @@ gem 'bess', path: 'gems/bess'
 
 gem 'houdini_full_contact', path: 'gems/houdini_full_contact'
 
-gem "react_on_rails", "12.5.2"
+gem "react_on_rails", "12.6.0"
 gem 'mini_racer', platforms: :ruby
 
 gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
     mime-types-data (3.2021.0901)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.7.1)
     mini_racer (0.4.0)
       libv8-node (~> 15.14.0.0)
     minitest (5.15.0)
@@ -259,8 +259,8 @@ GEM
     multi_xml (0.6.0)
     netrc (0.11.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.21.0)
@@ -286,7 +286,7 @@ GEM
     rack (2.2.3)
     rack-attack (5.4.2)
       rack (>= 1.0, < 3)
-    rack-proxy (0.7.0)
+    rack-proxy (0.7.2)
       rack
     rack-ssl (1.4.1)
       rack
@@ -327,7 +327,7 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    react_on_rails (12.5.2)
+    react_on_rails (12.6.0)
       addressable
       connection_pool
       execjs (~> 2.5)
@@ -420,7 +420,7 @@ GEM
     table_print (1.5.7)
     test-unit (3.5.3)
       power_assert
-    thor (1.1.0)
+    thor (1.2.1)
     tilt (2.0.10)
     timecop (0.9.4)
     timers (4.3.3)
@@ -508,7 +508,7 @@ DEPENDENCIES
   rails (= 6.1.4.4)
   rails-i18n (~> 6.0.0, ~> 6)
   rake (~> 12.3.2)
-  react_on_rails (= 12.5.2)
+  react_on_rails (= 12.6.0)
   rspec (~> 3.10.0)
   rspec-rails (~> 4.1.2)
   rubocop (~> 1.25.0)

--- a/NOTICE-js
+++ b/NOTICE-js
@@ -20183,7 +20183,7 @@ SOFTWARE.
 
 ------
 
-** node-fetch; version 2.6.1 -- https://github.com/bitinn/node-fetch
+** node-fetch; version 2.6.7 -- https://github.com/bitinn/node-fetch
 Copyright (c) 2016 David Frank
 
 The MIT License (MIT)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -1544,7 +1544,7 @@ THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ------
 
-** mini_portile2; version 2.6.1 -- 
+** mini_portile2; version 2.7.1 -- 
 Copyright (c) 2011-2016 Luis Lavena and Mike Dalessio
 
 Copyright (c) 2011-2016 Luis Lavena and Mike Dalessio
@@ -2695,7 +2695,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** rack-proxy; version 0.7.0 -- 
+** rack-proxy; version 0.7.2 -- 
 Copyright (c) 2013 Jacek Becela jacek.becela@gmail.com
 
 The MIT License (MIT)
@@ -3435,7 +3435,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** thor; version 1.1.0 -- 
+** thor; version 1.2.1 -- 
 Copyright (c) 2003, 2004 Jim Weirich
 Copyright (c) 2008 Yehuda Katz, Eric Hodel
 
@@ -3655,7 +3655,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** react_on_rails; version 12.5.2 -- 
+** react_on_rails; version 12.6.0 -- 
 Copyright (c) 2017, 2018 Justin Gordon and ShakaCode, http://www.shakacode.com
 Copyright (c) 2018, 2019 Justin Gordon and ShakaCode, http://www.shakacode.com
 
@@ -3951,39 +3951,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** nokogiri; version 1.12.5 -- 
-Copyright 2010 Google Inc.
-Copyright 2011 Google Inc.
-Copyright 2018 Craig Barnes.
-Copyright 2018 Stephen Checkoway
-Copyright 2017-2018 Craig Barnes.
-(c) Copyright 2002-2005, Andy Clark.
-Copyright (c) 1998-2003 Daniel Veillard.
-Copyright (c) 1998-2012 Daniel Veillard.
-Copyright (c) 2001-2002 Daniel Veillard.
-copyrighted by the Free Software Foundation
-Copyright (c) 1991 Free Software Foundation, Inc.
-Copyright 1992-2018 Free Software Foundation, Inc.
-Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler
-Copyright (c) 2001-2003 Thai Open Source Software Center Ltd
-Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
-Copyright (c) 2001-2002 Thomas Broyer, Charlie Bozeman and Daniel Veillard.
-Copyright (c) 2001-2002, SourceForge ISO-RELAX Project (ASAMI Tomoharu, Daisuke Okajima, Kohsuke Kawaguchi, and MURATA Makoto)
-Copyright 2008 2021 by Mike Dalessio, Aaron Patterson, Yoko Harada, Akinori MUSHA, John Shahid, Karol Bucek, Sam Ruby, Craig Barnes, Stephen Checkoway, Lars Kanis, Sergio Arbeo, Timothy Elliott, Nobuyoshi Nakada, Charles Nutter, Patrick Mahoney.
-
-The MIT License
-
-Copyright 2008 -- 2021 by Mike Dalessio, Aaron Patterson, Yoko Harada, Akinori MUSHA, John Shahid, Karol Bucek, Sam Ruby, Craig Barnes, Stephen Checkoway, Lars Kanis, Sergio Arbeo, Timothy Elliott, Nobuyoshi Nakada, Charles Nutter, Patrick Mahoney.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-------
-
 ** actiontext; version 6.1.4.4 -- 
 
 MIT License
@@ -4200,6 +4167,39 @@ Exceptions
 ----------
 
   * lib/test/unit/diff.rb: This license and PSF license
+
+
+------
+
+** nokogiri; version 1.13.1 -- 
+Copyright 2010 Google Inc.
+Copyright 2011 Google Inc.
+Copyright 2018 Craig Barnes.
+Copyright 2018 Stephen Checkoway
+Copyright 2017-2018 Craig Barnes.
+(c) Copyright 2002-2005, Andy Clark.
+Copyright (c) 1998-2003 Daniel Veillard.
+Copyright (c) 1998-2012 Daniel Veillard.
+Copyright (c) 2001-2002 Daniel Veillard.
+copyrighted by the Free Software Foundation
+Copyright (c) 1991 Free Software Foundation, Inc.
+Copyright 1992-2018 Free Software Foundation, Inc.
+Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler
+Copyright (c) 2001-2003 Thai Open Source Software Center Ltd
+Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+Copyright (c) 2001-2002 Thomas Broyer, Charlie Bozeman and Daniel Veillard.
+Copyright (c) 2001-2002, SourceForge ISO-RELAX Project (ASAMI Tomoharu, Daisuke Okajima, Kohsuke Kawaguchi, and MURATA Makoto)
+Copyright 2008 2021 by Mike Dalessio, Aaron Patterson, Yoko Harada, Akinori MUSHA, John Shahid, Karol Bucek, Sam Ruby, Craig Barnes, Stephen Checkoway, Lars Kanis, Sergio Arbeo, Timothy Elliott, Nobuyoshi Nakada, Charles Nutter, Patrick Mahoney.
+
+The MIT License
+
+Copyright 2008 -- 2021 by Mike Dalessio, Aaron Patterson, Yoko Harada, Akinori MUSHA, John Shahid, Karol Bucek, Sam Ruby, Craig Barnes, Stephen Checkoway, Lars Kanis, Sergio Arbeo, Timothy Elliott, Nobuyoshi Nakada, Charles Nutter, Patrick Mahoney.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ------

--- a/yarn.lock
+++ b/yarn.lock
@@ -11273,9 +11273,11 @@ node-dir@^0.1.10:
     minimatch "^3.0.2"
 
 node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -15614,6 +15616,11 @@ tr46@^2.1.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -16301,6 +16308,11 @@ web-namespaces@^1.0.0:
   resolved "https://registry.yarnpkg.com/web-namespaces/-/web-namespaces-1.1.4.tgz#bc98a3de60dadd7faefc403d1076d529f5e030ec"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-5.0.0.tgz#ae59c8a00b121543a2acc65c0434f57b0fc11aff"
@@ -16495,6 +16507,14 @@ whatwg-mimetype@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^8.0.0, whatwg-url@^8.5.0:
   version "8.7.0"


### PR DESCRIPTION
- Bump react_on_rails from 12.5.2 to 12.6.0
- Bump node-fetch from 2.6.1 to 2.6.7

