### PR TITLE
Rename subtransaction_payments to payment

### DIFF
--- a/app/controllers/api/payments_controller.rb
+++ b/app/controllers/api/payments_controller.rb
@@ -10,16 +10,16 @@ class Api::PaymentsController < Api::ApiController
 	before_action :authenticate_nonprofit_user!
 
 	def index
-		@subtransaction_payments =
+		@payments =
 			current_subtransaction
-			.subtransaction_payments
+			.payments
 			.order('created DESC')
 			.page(params[:page])
 			.per(params[:per])
 	end
 
 	def show
-		@subtransaction_payment = current_payment
+		@payment = current_payment
 	end
 
 	private
@@ -29,6 +29,6 @@ class Api::PaymentsController < Api::ApiController
 	end
 
 	def current_payment
-		current_subtransaction.subtransaction_payments.where(paymentable_id: params[:id])
+		current_subtransaction.payments.where(paymentable_id: params[:id])
 	end
 end

--- a/app/controllers/api/subtransaction/payments_controller.rb
+++ b/app/controllers/api/subtransaction/payments_controller.rb
@@ -27,6 +27,6 @@ class Api::Subtransaction::PaymentsController < Api::ApiController
 		@payment =
 			current_transaction
 			.subtransaction
-			.subtransaction_payments.find_by(paymentable_id: params[:id]).paymentable
+			.payments.find_by(paymentable_id: params[:id]).paymentable
 	end
 end

--- a/app/legacy_lib/insert_donation.rb
+++ b/app/legacy_lib/insert_donation.rb
@@ -46,8 +46,8 @@ module InsertDonation
     update_donation_keys(result)
     don = trx.donations.build(amount: result['donation'].amount, legacy_donation: result['donation'])
     stripe_t = trx.build_subtransaction(
-      subtransactable: StripeTransaction.new(amount: data['amount']), 
-      subtransaction_payments:[
+      subtransactable: StripeTransaction.new(amount: data['amount']),
+      payments:[
         SubtransactionPayment.new(
           paymentable: StripeCharge.new(payment: Payment.find(result['payment']['id'])))
         ],
@@ -56,7 +56,7 @@ module InsertDonation
     trx.save!
     don.save!
     stripe_t.save!
-    stripe_t.subtransaction_payments.each(&:publish_created)
+    stripe_t.payments.each(&:publish_created)
     stripe_t.publish_created
     don.publish_created
     trx.publish_created
@@ -90,7 +90,7 @@ module InsertDonation
     result = { 'donation' => insert_donation(data.except('offsite_payment'), entities) }
     trx = entities[:supporter_id].transactions.build(amount: data['amount'], created: data['date'])
     don = trx.donations.build(amount: result['donation'].amount, legacy_donation: result['donation'])
-    
+
     result['payment'] = insert_payment('OffsitePayment', 0, result['donation']['id'], data)
     result['offsite_payment'] = Psql.execute(
       Qexpr.new.insert(:offsite_payments, [
@@ -106,8 +106,8 @@ module InsertDonation
     ).first
 
     off_t = trx.build_subtransaction(
-      subtransactable: OfflineTransaction.new(amount: data['amount']), 
-      subtransaction_payments:[
+      subtransactable: OfflineTransaction.new(amount: data['amount']),
+      payments:[
         SubtransactionPayment.new(
           paymentable: OfflineTransactionCharge.new(payment: Payment.find(result['payment']['id'])))
         ],
@@ -116,7 +116,7 @@ module InsertDonation
     trx.save!
     don.save!
     off_t.save!
-    off_t.subtransaction_payments.each(&:publish_created)
+    off_t.payments.each(&:publish_created)
     off_t.publish_created
     don.publish_created
     trx.publish_created

--- a/app/legacy_lib/insert_recurring_donation.rb
+++ b/app/legacy_lib/insert_recurring_donation.rb
@@ -59,8 +59,8 @@ module InsertRecurringDonation
       end
     end
 
-    
-   
+
+
 
     # Create the donation record
     result['donation'] = InsertDonation.insert_donation(data, entities)
@@ -74,8 +74,8 @@ module InsertRecurringDonation
       trx = entities[:supporter_id].transactions.build(amount: data['amount'], created: data['date'])
       don = trx.donations.build(amount: result['donation'].amount, legacy_donation: result['donation'])
       stripe_t = trx.build_subtransaction(
-        subtransactable: StripeTransaction.new(amount: data['amount']), 
-        subtransaction_payments:[
+        subtransactable: StripeTransaction.new(amount: data['amount']),
+        payments:[
           SubtransactionPayment.new(
             paymentable: StripeCharge.new(payment: Payment.find(result['payment']['id'])))
           ],
@@ -84,7 +84,7 @@ module InsertRecurringDonation
       trx.save!
       don.save!
       stripe_t.save!
-      stripe_t.subtransaction_payments.each(&:publish_created)
+      stripe_t.payments.each(&:publish_created)
       stripe_t.publish_created
       don.publish_created
       trx.publish_created

--- a/app/legacy_lib/insert_refunds.rb
+++ b/app/legacy_lib/insert_refunds.rb
@@ -67,7 +67,7 @@ module InsertRefunds
     transaction = Transaction.find(transaction_id)
 
     transaction.amount += gross
-    refund_subtransaction_payment = transaction.subtransaction.subtransaction_payments.create(paymentable: stripe_transaction_refund)
+    refund_subtransaction_payment = transaction.subtransaction.payments.create(paymentable: stripe_transaction_refund)
 
     stripe_transaction_refund.save!
     refund_subtransaction_payment.save!

--- a/app/models/concerns/model/subtransactable.rb
+++ b/app/models/concerns/model/subtransactable.rb
@@ -15,6 +15,6 @@ module Model::Subtransactable
 		has_one :supporter, through: :trx
 		has_one :nonprofit, through: :trx
 
-		has_many :payments, through: :subtransaction
+		has_many :subtransaction_payments, through: :subtransaction
 	end
 end

--- a/app/models/concerns/model/subtransactable.rb
+++ b/app/models/concerns/model/subtransactable.rb
@@ -15,6 +15,6 @@ module Model::Subtransactable
 		has_one :supporter, through: :trx
 		has_one :nonprofit, through: :trx
 
-		has_many :subtransaction_payments, through: :subtransaction
+		has_many :payments, through: :subtransaction
 	end
 end

--- a/app/models/offline_transaction.rb
+++ b/app/models/offline_transaction.rb
@@ -12,7 +12,7 @@ class OfflineTransaction < ApplicationRecord
 	end
 
 	def net_amount
-		subtransaction_payments.sum(&:net_amount)
+		payments.sum(&:net_amount)
 	end
 
 	def net_amount_as_money
@@ -38,11 +38,11 @@ class OfflineTransaction < ApplicationRecord
 				end
 
 				if expand.include? :payments
-					json.payments subtransaction_payments do |py|
+					json.payments payments do |py|
 						json.merge! py.to_builder.attributes!
 					end
 				else
-					json.payments subtransaction_payments do |py|
+					json.payments payments do |py|
 						json.merge! py.to_id.attributes!
 					end
 				end

--- a/app/models/stripe_transaction.rb
+++ b/app/models/stripe_transaction.rb
@@ -7,7 +7,7 @@ class StripeTransaction < ApplicationRecord
 	delegate :created, to: :subtransaction
 
 	def net_amount
-		subtransaction_payments.sum(&:net_amount)
+		payments.sum(&:net_amount)
 	end
 
 	concerning :JBuilder do # rubocop:disable Metrics/BlockLength
@@ -29,11 +29,11 @@ class StripeTransaction < ApplicationRecord
 				end
 
 				if expand.include? :payments
-					json.payments subtransaction_payments do |py|
+					json.payments payments do |py|
 						json.merge! py.to_builder.attributes!
 					end
 				else
-					json.payments subtransaction_payments do |py|
+					json.payments payments do |py|
 						json.merge! py.to_id.attributes!
 					end
 				end

--- a/app/models/subtransaction.rb
+++ b/app/models/subtransaction.rb
@@ -16,7 +16,7 @@ class Subtransaction < ApplicationRecord
 	has_one :supporter, through: :trx
 	has_one :nonprofit, through: :trx
 
-	has_many :subtransaction_payments # rubocop:disable Rails/HasManyOrHasOneDependent
+	has_many :payments, class_name: 'SubtransactionPayment' # rubocop:disable Rails/HasManyOrHasOneDependent
 
 	delegated_type :subtransactable, types: %w[OfflineTransaction StripeTransaction]
 

--- a/app/views/api/payments/index.json.jbuilder
+++ b/app/views/api/payments/index.json.jbuilder
@@ -2,8 +2,8 @@
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
-json.data @payments, partial: '/api/payments/subtransaction_payment',
-																					as: :subtransaction_payment
+json.data @subtransaction_payments, partial: '/api/subtransaction_payments/subtransaction_payment',
+																																				as: :subtransaction_payment
 
 json.current_page @payments.current_page
 json.first_page @payments.first_page?

--- a/app/views/api/payments/index.json.jbuilder
+++ b/app/views/api/payments/index.json.jbuilder
@@ -2,11 +2,11 @@
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
-json.data @subtransaction_payments, partial: '/api/subtransaction_payments/subtransaction_payment',
-																																				as: :subtransaction_payment
+json.data @payments, partial: '/api/payments/subtransaction_payment',
+																					as: :subtransaction_payment
 
-json.current_page @subtransaction_payments.current_page
-json.first_page @subtransaction_payments.first_page?
-json.last_page @subtransaction_payments.last_page?
-json.requested_size @subtransaction_payments.limit_value
-json.total_count @subtransaction_payments.total_count
+json.current_page @payments.current_page
+json.first_page @payments.first_page?
+json.last_page @payments.last_page?
+json.requested_size @payments.limit_value
+json.total_count @payments.total_count

--- a/app/views/api/payments/index.json.jbuilder
+++ b/app/views/api/payments/index.json.jbuilder
@@ -2,8 +2,7 @@
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
-json.data @subtransaction_payments, partial: '/api/subtransaction_payments/subtransaction_payment',
-																																				as: :subtransaction_payment
+json.data @payments, partial: '/api/subtransaction_payments/subtransaction_payment', as: :subtransaction_payment
 
 json.current_page @payments.current_page
 json.first_page @payments.first_page?

--- a/app/views/api/subtransactions/_subtransaction.json.jbuilder
+++ b/app/views/api/subtransactions/_subtransaction.json.jbuilder
@@ -11,7 +11,7 @@ json.transaction subtransaction.trx.id
 
 json.partial! subtransaction.subtransactable, as: :subtransactable
 
-json.payments subtransaction.subtransaction_payments do |py|
+json.payments subtransaction.payments do |py|
 	json.partial! py, as: :subtransaction_payment
 end
 

--- a/app/views/api/transactions/_transaction.json.jbuilder
+++ b/app/views/api/transactions/_transaction.json.jbuilder
@@ -22,7 +22,7 @@ json.transaction_assignments transaction.transaction_assignments do |tra|
 	json.merge! tra.to_id.attributes!
 end
 
-json.payments transaction.subtransaction_payments do |subt_p|
+json.payments transaction.payments do |subt_p|
 	json.merge! subt_p.to_id.attributes!
 end
 

--- a/spec/factories/subtransactions.rb
+++ b/spec/factories/subtransactions.rb
@@ -5,7 +5,7 @@
 FactoryBot.define do
 	factory :subtransaction do
 		subtransactable { create(:offline_transaction) }
-		subtransaction_payments do
+		payments do
 			[
 				create(:subtransaction_payment_with_offline_charge)
 			]

--- a/spec/legacy_lib/insert/insert_donation_spec.rb
+++ b/spec/legacy_lib/insert/insert_donation_spec.rb
@@ -254,7 +254,7 @@ describe InsertDonation do
 						},
 						'created' => created_time.to_i,
 						'subtransaction' => stripe_transaction_id_only,
-						'subtransaction_payments' => [stripe_transaction_charge_id_only],
+						'payments' => [stripe_transaction_charge_id_only],
 						'transaction_assignments' => [donation_id_only]
 					}
 				)
@@ -265,7 +265,7 @@ describe InsertDonation do
 					common_builder_expanded,
 					{
 						'subtransaction' => stripe_transaction_builder,
-						'subtransaction_payments' => [stripe_transaction_charge_builder],
+						'payments' => [stripe_transaction_charge_builder],
 						'transaction_assignments' => [donation_builder]
 					}
 				)
@@ -968,7 +968,7 @@ describe InsertDonation do
 							},
 							'created' => created_time.to_i,
 							'subtransaction' => offline_transaction_id_only,
-							'subtransaction_payments' => [offline_transaction_charge_id_only],
+							'payments' => [offline_transaction_charge_id_only],
 							'transaction_assignments' => [donation_id_only]
 						}
 					)
@@ -979,7 +979,7 @@ describe InsertDonation do
 						common_builder_expanded,
 						{
 							'subtransaction' => offline_transaction_builder,
-							'subtransaction_payments' => [offline_transaction_charge_builder],
+							'payments' => [offline_transaction_charge_builder],
 							'transaction_assignments' => [donation_builder]
 						}
 					)

--- a/spec/legacy_lib/insert/insert_recurring_donation_spec.rb
+++ b/spec/legacy_lib/insert/insert_recurring_donation_spec.rb
@@ -153,14 +153,14 @@ describe InsertRecurringDonation do
 						{ 'supporter' => supporter.id,
 								'nonprofit' => nonprofit.id }
 					end
-		
+
 					let(:common_builder_expanded) do
 						{
 							'supporter' => supporter_builder_expanded,
 							'nonprofit' => np_builder_expanded
 						}
 					end
-		
+
 					let(:common_builder_with_trx_id) do
 						common_builder.merge(
 							{
@@ -168,7 +168,7 @@ describe InsertRecurringDonation do
 							}
 						)
 					end
-		
+
 					let(:common_builder_with_trx) do
 						common_builder.merge(
 							{
@@ -176,7 +176,7 @@ describe InsertRecurringDonation do
 							}
 						)
 					end
-		
+
 					let(:np_builder_expanded) do
 						{
 							'id' => nonprofit.id,
@@ -184,11 +184,11 @@ describe InsertRecurringDonation do
 							'object' => 'nonprofit'
 						}
 					end
-		
+
 					let(:supporter_builder_expanded) do
 						supporter_to_builder_base.merge({ 'name' => 'Fake Supporter Name' })
 					end
-		
+
 					let(:transaction_builder) do
 						common_builder.merge(
 							{
@@ -200,23 +200,23 @@ describe InsertRecurringDonation do
 								},
 								'created' => created_time.to_i,
 								'subtransaction' => stripe_transaction_id_only,
-								'subtransaction_payments' => [stripe_transaction_charge_id_only],
+								'payments' => [stripe_transaction_charge_id_only],
 								'transaction_assignments' => [donation_id_only]
 							}
 						)
 					end
-		
+
 					let(:transaction_builder_expanded) do
 						transaction_builder.merge(
 							common_builder_expanded,
 							{
 								'subtransaction' => stripe_transaction_builder,
-								'subtransaction_payments' => [stripe_transaction_charge_builder],
+								'payments' => [stripe_transaction_charge_builder],
 								'transaction_assignments' => [donation_builder]
 							}
 						)
 					end
-		
+
 					let(:stripe_transaction_id_only) do
 						{
 							'id' => match_houid('stripetrx'),
@@ -224,7 +224,7 @@ describe InsertRecurringDonation do
 							'type' => 'subtransaction'
 						}
 					end
-		
+
 					let(:stripe_transaction_builder) do
 						stripe_transaction_id_only.merge(
 							common_builder_with_trx_id,
@@ -233,18 +233,18 @@ describe InsertRecurringDonation do
 									'cents' => charge_amount,
 									'currency' => 'usd'
 								},
-		
+
 								'net_amount' => {
 									'cents' => 67,
 									'currency' => 'usd'
 								},
-		
+
 								'payments' => [stripe_transaction_charge_id_only],
 								'created' => created_time.to_i
 							}
 						)
 					end
-		
+
 					let(:stripe_transaction_builder_expanded) do
 						stripe_transaction_builder.merge(
 							common_builder_with_trx,
@@ -254,7 +254,7 @@ describe InsertRecurringDonation do
 							}
 						)
 					end
-		
+
 					let(:stripe_transaction_charge_id_only) do
 						{
 							'id' => match_houid('stripechrg'),
@@ -262,7 +262,7 @@ describe InsertRecurringDonation do
 							'type' => 'payment'
 						}
 					end
-		
+
 					let(:stripe_transaction_charge_builder) do
 						stripe_transaction_charge_id_only.merge(
 							common_builder_with_trx_id,
@@ -285,7 +285,7 @@ describe InsertRecurringDonation do
 							}
 						)
 					end
-		
+
 					let(:stripe_transaction_charge_builder_expanded) do
 						stripe_transaction_charge_builder.merge(
 							common_builder_with_trx,
@@ -295,7 +295,7 @@ describe InsertRecurringDonation do
 							}
 						)
 					end
-		
+
 					let(:donation_id_only) do
 						{
 							'id' => match_houid('don'),
@@ -303,7 +303,7 @@ describe InsertRecurringDonation do
 							'type' => 'trx_assignment'
 						}
 					end
-		
+
 					let(:donation_builder) do
 						donation_id_only.merge(common_builder_with_trx_id, {
 																														'amount' => {
@@ -317,16 +317,16 @@ describe InsertRecurringDonation do
 																														}
 																													})
 					end
-		
+
 					let(:donation_builder_expanded) do
 						donation_builder.merge(common_builder_with_trx, common_builder_expanded)
 					end
 
-					let(:recurrence_builder_expanded) do 
-						
+					let(:recurrence_builder_expanded) do
+
 					end
-		
-		
+
+
 					describe 'general donations' do
 						subject do
 							process_general_donation(recurring_donation: { paydate: Time.now.day, interval: 1, time_unit: 'month', start_date: Time.now.beginning_of_day }) do
@@ -339,12 +339,12 @@ describe InsertRecurringDonation do
 										profile_id: profile.id,
 										dedication: { 'name' => 'a name', 'type' => 'honor' },
 										designation: 'designation'
-		
+
 									}.with_indifferent_access
 								)
 							end
 						end
-		
+
 						it 'has fired transaction.created' do
 							expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
@@ -365,7 +365,7 @@ describe InsertRecurringDonation do
 							expect(Houdini.event_publisher).to receive(:announce).with(:recurrence_created, any_args)
 							subject
 						end
-		
+
 						it 'has fired stripe_transaction_charge.created' do
 							expect(Houdini.event_publisher).to receive(:announce).with(
 								:stripe_transaction_charge_created,
@@ -386,7 +386,7 @@ describe InsertRecurringDonation do
 							expect(Houdini.event_publisher).to receive(:announce).with(:recurrence_created, any_args)
 							subject
 						end
-		
+
 						it 'has fired payment.created' do
 							expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(
@@ -404,10 +404,10 @@ describe InsertRecurringDonation do
 							expect(Houdini.event_publisher).to receive(:announce).with(:donation_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:trx_assignment_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:transaction_created, any_args)
-		
+
 							subject
 						end
-		
+
 						it 'has fired stripe_transaction.created' do
 							expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
@@ -422,14 +422,14 @@ describe InsertRecurringDonation do
 									}
 								}
 							)
-		
+
 							expect(Houdini.event_publisher).to receive(:announce).with(:donation_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:trx_assignment_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:transaction_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:recurrence_created, any_args)
 							subject
 						end
-		
+
 						it 'has fired donation.created' do
 							expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
@@ -450,7 +450,7 @@ describe InsertRecurringDonation do
 							expect(Houdini.event_publisher).to receive(:announce).with(:recurrence_created, any_args)
 							subject
 						end
-		
+
 						it 'has fired trx_assignment.created' do
 							expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 							expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
@@ -488,13 +488,13 @@ describe InsertRecurringDonation do
 										'object' => 'recurrence',
 								'id' => match_houid('recur'),
 								'start_date' => Time.new(2020, 5, 4).utc.to_i,
-								'recurrences' => [ 
+								'recurrences' => [
 								{
 									'start' => Time.new(2020, 5, 4).utc.to_i,
 									'interval' => 1,
 									'type' => 'monthly'
 								}],
-								'invoice_template' =>  { 
+								'invoice_template' =>  {
 									'supporter' => supporter.id,
 									'amount' => {'cents' => charge_amount, 'currency' => 'usd'},
 									'payment_method' =>  {'type' =>  'stripe'},
@@ -511,7 +511,7 @@ describe InsertRecurringDonation do
 							subject
 						end
 					end
-		
+
 					# describe 'campaign donations' do
 					# 	subject do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:campaign_create, any_args)
@@ -529,11 +529,11 @@ describe InsertRecurringDonation do
 					# 			)
 					# 		end
 					# 	end
-		
+
 					# 	before do
 					# 		before_each_success
 					# 	end
-		
+
 					# 	it 'has fired transaction.created' do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
@@ -552,7 +552,7 @@ describe InsertRecurringDonation do
 					# 		)
 					# 		subject
 					# 	end
-		
+
 					# 	it 'has fired stripe_transaction_charge.created' do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(
 					# 			:stripe_transaction_charge_created,
@@ -570,10 +570,10 @@ describe InsertRecurringDonation do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:donation_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:trx_assignment_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:transaction_created, any_args)
-		
+
 					# 		subject
 					# 	end
-		
+
 					# 	it 'has fired payment.created' do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(
@@ -591,10 +591,10 @@ describe InsertRecurringDonation do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:donation_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:trx_assignment_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:transaction_created, any_args)
-		
+
 					# 		subject
 					# 	end
-		
+
 					# 	it 'has fired stripe_transaction.created' do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
@@ -609,13 +609,13 @@ describe InsertRecurringDonation do
 					# 				}
 					# 			}
 					# 		)
-		
+
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:donation_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:trx_assignment_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:transaction_created, any_args)
 					# 		subject
 					# 	end
-		
+
 					# 	it 'has fired donation.created' do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
@@ -635,7 +635,7 @@ describe InsertRecurringDonation do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:transaction_created, any_args)
 					# 		subject
 					# 	end
-		
+
 					# 	it 'has fired trx_assignment.created' do
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:stripe_transaction_charge_created, any_args)
 					# 		expect(Houdini.event_publisher).to receive(:announce).with(:payment_created, any_args)
@@ -672,7 +672,7 @@ describe InsertRecurringDonation do
       end
     end
 
-    
+
   end
 
   describe '.convert_donation_to_recurring_donation' do

--- a/spec/legacy_lib/insert/insert_refunds_spec.rb
+++ b/spec/legacy_lib/insert/insert_refunds_spec.rb
@@ -36,7 +36,7 @@ describe InsertRefunds do
 		trx = supporter.transactions.build(amount: 500)
 		trx.build_subtransaction(
 			subtransactable: StripeTransaction.new(amount: 500),
-			subtransaction_payments: [
+			payments: [
 				build(:subtransaction_payment, paymentable: create(:stripe_charge, payment: payment))
 			]
 		)
@@ -186,7 +186,7 @@ describe InsertRefunds do
 										'object' => 'stripe_transaction',
 										'type' => 'subtransaction'
 									},
-									'subtransaction_payments' => [
+									'payments' => [
 										{
 											'id' => match_houid('stripechrg'),
 											'object' => 'stripe_transaction_charge',
@@ -253,7 +253,7 @@ describe InsertRefunds do
 									'transaction' => match_houid('trx'),
 									'type' => 'subtransaction'
 								},
-								'subtransaction_payments' => [
+								'payments' => [
 									{
 										'created' => kind_of(Numeric),
 										'fee_total' => {

--- a/spec/models/campaign_gift_purchase_spec.rb
+++ b/spec/models/campaign_gift_purchase_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
   let(:campaign_gift_option) { create(:campaign_gift_option, amount_one_time: 400, campaign: campaign)}
   let(:campaign_gift) { campaign_gift_purchase.campaign_gifts.first}
 
-  let(:campaign_builder_expanded) do 
+  let(:campaign_builder_expanded) do
     {
       'id' => kind_of(Numeric),
       'name' => campaign.name,
@@ -28,7 +28,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
     }
   end
 
-  let(:cgo_builder_expanded) do 
+  let(:cgo_builder_expanded) do
     {
       'id' => kind_of(Numeric),
       'name' => campaign_gift_option.name,
@@ -49,7 +49,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
     }
   end
 
-  let(:np_builder_expanded) do 
+  let(:np_builder_expanded) do
     {
       'id' => nonprofit.id,
       'name' => nonprofit.name,
@@ -57,12 +57,12 @@ RSpec.describe CampaignGiftPurchase, type: :model do
     }
   end
 
-  let(:supporter_builder_expanded) do 
+  let(:supporter_builder_expanded) do
     supporter_to_builder_base.merge({'name'=> 'Fake Supporter Name'})
   end
 
-  let(:transaction_builder_expanded) do 
-    { 
+  let(:transaction_builder_expanded) do
+    {
       'id' => match_houid('trx'),
       'object' => 'transaction',
       'amount' => {
@@ -73,23 +73,23 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'supporter' => supporter.id,
       'nonprofit' => nonprofit.id,
       'subtransaction' => nil,
-      'subtransaction_payments' => [],
+      'payments' => [],
       'transaction_assignments' => [
         cgp_builder_to_id
       ]
     }
   end
 
-  let(:cgp_builder_to_id) do 
+  let(:cgp_builder_to_id) do
     {
       'id' => match_houid('cgpur'),
       'object' => 'campaign_gift_purchase',
       'type' => 'trx_assignment'
     }
   end
-  
+
   let(:cgp_builder_expanded) do
-    { 
+    {
       'id' => match_houid('cgpur'),
       'campaign' => kind_of(Numeric),
       'object' => 'campaign_gift_purchase',
@@ -104,7 +104,7 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'deleted' => false
     }
   end
-  
+
   let(:modern_campaign_gift_builder) {
     {
       'amount' => {
@@ -122,9 +122,9 @@ RSpec.describe CampaignGiftPurchase, type: :model do
       'transaction' => match_houid('trx')
     }
   }
-  
 
-  
+
+
 
   it 'announces created properly when called' do
     allow(Houdini.event_publisher).to receive(:announce)

--- a/spec/models/modern_campaign_gift_spec.rb
+++ b/spec/models/modern_campaign_gift_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe ModernCampaignGift, type: :model do
   let(:campaign_gift_option) { create(:campaign_gift_option, amount_one_time: 400, campaign: campaign)}
   let(:campaign_gift) { campaign_gift_purchase.campaign_gifts.first}
 
-  let(:campaign_builder_expanded) do 
+  let(:campaign_builder_expanded) do
     {
       'id' => kind_of(Numeric),
       'name' => campaign.name,
@@ -28,7 +28,7 @@ RSpec.describe ModernCampaignGift, type: :model do
     }
   end
 
-  let(:cgo_builder_expanded) do 
+  let(:cgo_builder_expanded) do
     {
       'id' => kind_of(Numeric),
       'name' => campaign_gift_option.name,
@@ -50,7 +50,7 @@ RSpec.describe ModernCampaignGift, type: :model do
     }
   end
 
-  let(:np_builder_expanded) do 
+  let(:np_builder_expanded) do
     {
       'id' => nonprofit.id,
       'name' => nonprofit.name,
@@ -58,12 +58,12 @@ RSpec.describe ModernCampaignGift, type: :model do
     }
   end
 
-  let(:supporter_builder_expanded) do 
+  let(:supporter_builder_expanded) do
     supporter_to_builder_base.merge({'name'=> 'Fake Supporter Name'})
   end
 
-  let(:transaction_builder_expanded) do 
-    { 
+  let(:transaction_builder_expanded) do
+    {
       'id' => match_houid('trx'),
       'object' => 'transaction',
       'amount' => {
@@ -74,21 +74,21 @@ RSpec.describe ModernCampaignGift, type: :model do
       'supporter' => kind_of(Numeric),
       'nonprofit' => kind_of(Numeric),
       'subtransaction' => nil,
-      'subtransaction_payments' => [],
+      'payments' => [],
       'transaction_assignments' => [cgp_builder_to_id]
     }
   end
 
-  let(:cgp_builder_to_id) do 
+  let(:cgp_builder_to_id) do
     {
       'id' => match_houid('cgpur'),
       'object' => 'campaign_gift_purchase',
       'type' => 'trx_assignment'
     }
   end
-  
+
   let(:cgp_builder_expanded) do
-    { 
+    {
       'id' => match_houid('cgpur'),
       'campaign' => kind_of(Numeric),
       'object' => 'campaign_gift_purchase',

--- a/spec/models/offline_transaction_dispute_spec.rb
+++ b/spec/models/offline_transaction_dispute_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OfflineTransactionDispute, type: :model do
 		trx = supporter.transactions.build(amount: 500)
 		trx.build_subtransaction(
 			subtransactable: OfflineTransaction.new(amount: 500),
-			subtransaction_payments: [
+			payments: [
 				build(:subtransaction_payment, paymentable: offline_transaction_dispute),
 				build(:subtransaction_payment, paymentable: offline_transaction_charge)
 			]
@@ -115,7 +115,7 @@ RSpec.describe OfflineTransactionDispute, type: :model do
 							'object' => 'offline_transaction',
 							'type' => 'subtransaction'
 						},
-						'subtransaction_payments' => [
+						'payments' => [
 							{
 								'id' => match_houid('offtrxdspt'),
 								'object' => 'offline_transaction_dispute',

--- a/spec/models/offline_transaction_refund_spec.rb
+++ b/spec/models/offline_transaction_refund_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe OfflineTransactionRefund, type: :model do
 		trx = supporter.transactions.build(amount: 500)
 		trx.build_subtransaction(
 			subtransactable: OfflineTransaction.new(amount: 500),
-			subtransaction_payments: [
+			payments: [
 				build(:subtransaction_payment, paymentable: offline_transaction_refund),
 				build(:subtransaction_payment, paymentable: offline_transaction_charge)
 			]
@@ -115,7 +115,7 @@ RSpec.describe OfflineTransactionRefund, type: :model do
 							'object' => 'offline_transaction',
 							'type' => 'subtransaction'
 						},
-						'subtransaction_payments' => [
+						'payments' => [
 							{
 								'id' => match_houid('offtrxrfnd'),
 								'object' => 'offline_transaction_refund',

--- a/spec/models/stripe_dispute_spec.rb
+++ b/spec/models/stripe_dispute_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe StripeDispute, type: :model do
 		trx = supporter.transactions.build(amount: 500)
 		trx.build_subtransaction(
 			subtransactable: StripeTransaction.new(amount: 500),
-			subtransaction_payments: [
+			payments: [
 				build(:subtransaction_payment, paymentable: stripe_transaction_charge),
 				build(:subtransaction_payment, paymentable: stripe_transaction_dispute)
 			]
@@ -119,7 +119,7 @@ RSpec.describe StripeDispute, type: :model do
 							'object' => 'stripe_transaction',
 							'type' => 'subtransaction'
 						},
-						'subtransaction_payments' => [
+						'payments' => [
 							{
 								'id' => match_houid('stripechrg'),
 								'object' => 'stripe_transaction_charge',

--- a/spec/models/stripe_refund_spec.rb
+++ b/spec/models/stripe_refund_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe StripeRefund, type: :model do
 		trx = supporter.transactions.build(amount: 500)
 		trx.build_subtransaction(
 			subtransactable: StripeTransaction.new(amount: 500),
-			subtransaction_payments: [
+			payments: [
 				build(:subtransaction_payment, paymentable: stripe_charge),
 				build(:subtransaction_payment, paymentable: stripe_transaction_refund)
 			]
@@ -119,7 +119,7 @@ RSpec.describe StripeRefund, type: :model do
 							'object' => 'stripe_transaction',
 							'type' => 'subtransaction'
 						},
-						'subtransaction_payments' => [
+						'payments' => [
 							{
 								'id' => match_houid('stripechrg'),
 								'object' => 'stripe_transaction_charge',

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -6,17 +6,17 @@ require 'rails_helper'
 
 RSpec.describe Transaction, type: :model do
   include_context :shared_donation_charge_context
-  
+
   describe 'validation' do
     it {is_expected.to validate_presence_of(:supporter)}
   end
 
-  describe 'to_builder' do 
+  describe 'to_builder' do
     subject { supporter.transactions.create(
         amount: 1000,
         transaction_assignments: [TransactionAssignment.new(assignable:ModernDonation.new(amount: 1000))]
     ).to_builder.attributes!}
-    it 'will create a proper builder result' do 
+    it 'will create a proper builder result' do
       is_expected.to match({
         'id' => match_houid('trx'),
         'nonprofit' => nonprofit.id,
@@ -28,7 +28,7 @@ RSpec.describe Transaction, type: :model do
           'currency' => 'usd'
         },
         'subtransaction' => nil,
-        'subtransaction_payments' => [],
+        'payments' => [],
         'transaction_assignments' => [
           {
             'object' => 'donation',

--- a/spec/requests/api/payments_controller_request_spec.rb
+++ b/spec/requests/api/payments_controller_request_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Api::PaymentsController, type: :request do
 
 	describe 'GET /:id' do
 		let(:transaction) { transaction_for_donation }
-		let(:payment) { transaction.subtransaction.subtransaction_payments.first }
+		let(:payment) { transaction.subtransaction.payments.first }
 
 		def base_path(nonprofit_id, transaction_id, payment_id)
 			index_base_path(nonprofit_id, transaction_id) + "/#{payment_id}"
@@ -116,7 +116,7 @@ RSpec.describe Api::PaymentsController, type: :request do
 					index_base_path(nonprofit_id, transaction_id) + "/#{payment_id}"
 				end
 
-				let(:payment) { transaction.subtransaction.subtransaction_payments.first }
+				let(:payment) { transaction.subtransaction.payments.first }
 				let(:transaction) { transaction_for_donation }
 
 				def payment_url(nonprofit_id, transaction_id, payment_id)

--- a/spec/support/contexts/payment_context.rb
+++ b/spec/support/contexts/payment_context.rb
@@ -73,7 +73,7 @@ shared_context 'with json results for first payment on transaction_for_donation'
 				payment_url(
 					nonprofit.id,
 					transaction.id,
-					transaction.subtransaction.subtransaction_payments.first.paymentable.id
+					transaction.subtransaction.payments.first.paymentable.id
 				)
 		)
 	}

--- a/spec/support/contexts/subtransaction_context.rb
+++ b/spec/support/contexts/subtransaction_context.rb
@@ -127,7 +127,7 @@ shared_context 'with json results for subtransaction on transaction_for_donation
 					payment_url(
 						nonprofit.id,
 						transaction.id,
-						transaction.subtransaction.subtransaction_payments.first.paymentable.id
+						transaction.subtransaction.payments.first.paymentable.id
 					)
 				)
 			}

--- a/spec/views/api/payments/show.json.jbuilder_spec.rb
+++ b/spec/views/api/payments/show.json.jbuilder_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'api/payments/show.json.jbuilder', type: :view do
 
 	let(:transaction) { create(:transaction_for_donation) }
 	let(:subtransaction) { transaction.subtransaction }
-	let(:payment) { subtransaction.subtransaction_payments.first }
+	let(:payment) { subtransaction.payments.first }
 	let(:supporter) { payment.supporter }
 	let(:nonprofit) { payment.nonprofit }
 


### PR DESCRIPTION
### Description:
It solves an ambiguity in the name of `subtransaction_payments` entity.

Closes: #967 
Co-authored-by: @alan-ms <alan.sousa@protonmail.com>

### Motivation for implementing it:
This name is redundant and only really exists because we have a legacy entity already called Payment.

### Solution summary:
In the solution was implemented an alias that makes possible to refer to `subtransaction_payments` entity as `payments`.