### PR TITLE
feat: create router for roles nonprofit

### DIFF
--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+class Api::RolesController < Api::ApiController
+	include Controllers::Nonprofit::Current
+	include Controllers::Nonprofit::Authorization
+
+	# before_action :authenticate_nonprofit_user!, except: %i[new create]
+
+	# get /nonprofit/:nonprofit_id/roles
+	def index
+		@roles = current_nonprofit.roles
+	end
+end

--- a/app/views/api/roles/index.json.jbuilder
+++ b/app/views/api/roles/index.json.jbuilder
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+json.data @roles, partial: '/api/roles/role', as: :role

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   defaults format: :json do # they're APIs, you have to use JSON
     namespace :api do
       resources :nonprofits, only: [:create, :show] do
+        resources(:roles, only: [:index])
         resources :campaigns, only: [:show] do
           resources :campaign_gift_options, only: [:index, :show]
         end
@@ -80,7 +81,6 @@ Rails.application.routes.draw do
       put(:followup, on: :member)
       post(:create_offsite, on: :collection)
     end
-
     resources(:charges, only: [:index]) do
       resources(:refunds, only: %i[create index])
     end


### PR DESCRIPTION
### Description:
Currently there's no way to see what roles and users that are associated with a nonprofit.

Closes: #964
Co-authored-by: alan-ms <alan.sousa@protonmail.com>
Co-authored-by: JoaoVitorFarias <jvlopesfarias@gmail.com>

### Motivation for implementing it:
Currently, there's no way to know what roles a particular nonprofit has and it causes impacts on daily operations.


### Solution summary:
The endpoint "/api/nonprofit/:nonprofit_id/roles" was created, which returns the roles of a nonprofit through its id, now it is possible to know which roles a nonprofit has.

![Screenshot from 2022-02-22 21-54-33](https://user-images.githubusercontent.com/44823367/155244988-1478daef-2cca-4a96-a665-6cd6693949f4.png)

