### PR TITLE
Correct specs broken by fastener and not caught by turbo_test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -66,7 +66,7 @@ jobs:
           bundle exec rake spec
       - run: bin/setup ci
       - name: run spec
-        run: bundle exec turbo_test -n 2
+        run: bundle exec rake spec
   rubocop:
     needs: package-download
     runs-on: ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ group :development, :ci, :test do
   gem 'rubocop-rspec', '~> 2.8'
   gem 'shoulda-matchers', '~> 5.1.0'
   gem 'turbo_test'
-  gem 'fasterer'
 end
 
 group :ci, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,9 +173,6 @@ GEM
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
     fast_blank (1.0.1)
-    fasterer (0.9.0)
-      colorize (~> 0.7)
-      ruby_parser (>= 3.14.1)
     ffi (1.15.5)
     fiber-local (1.0.0)
     font_assets (0.1.14)
@@ -389,8 +386,6 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.3)
       ffi (~> 1.12)
-    ruby_parser (3.18.1)
-      sexp_processor (~> 4.16)
     samovar (2.1.4)
       console (~> 1.0)
       mapping (~> 1.0)
@@ -403,7 +398,6 @@ GEM
       sprockets-rails
       tilt
     semantic_range (3.0.0)
-    sexp_processor (4.16.0)
     shoulda-matchers (5.1.0)
       activesupport (>= 5.2.0)
     simple_po_parser (1.1.5)
@@ -481,7 +475,6 @@ DEPENDENCIES
   factory_bot (~> 6.2)
   factory_bot_rails (~> 6.2)
   fast_blank
-  fasterer
   font_assets (~> 0.1.14)
   good_job
   hamster (~> 3.0)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -2021,34 +2021,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** fasterer; version 0.9.0 -- 
-
-Copyright (c) 2015 Damir Svrtan
-
-MIT License
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-------
-
 ** httparty; version 0.20.0 -- 
 Copyright (c) 2007, Yahoo! Inc.
 Copyright (c) 2008 John Nunemaker
@@ -3244,14 +3216,10 @@ Copyright Kickstarter, PBC.
 Copyright (c) 2013-2015 Kasper Timm Hansen
 ** rails-html-sanitizer; version 1.4.2 -- 
 Copyright (c) 2013-2015 Rafael Mendonca Franca, Kasper Timm Hansen
-** ruby_parser; version 3.18.1 -- 
-Copyright (c) Ryan Davis, seattle.rb
 ** samovar; version 2.1.4 -- 
 Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
 Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
 Copyright, 2016, by Samuel G. D. Williams (http://www.codeotaku.com/samuel-williams).
-** sexp_processor; version 4.16.0 -- 
-Copyright (c) Ryan Davis, seattle.rb
 ** timers; version 4.3.3 -- 
 Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
 ** turbo_test; version 0.1.2 -- 

--- a/app/controllers/image_attachments_controller.rb
+++ b/app/controllers/image_attachments_controller.rb
@@ -16,7 +16,7 @@ class ImageAttachmentsController < ApplicationController
   end
 
   def remove
-    @image = ImageAttachment.detect{ |img| url_for(img.file) == clean_params_remove[:src] }
+    @image = ImageAttachment.select { |img| url_for(img.file) == clean_params_remove[:src] }.first
     if @image
       @image.destroy
       render json: @image

--- a/app/legacy_lib/import_civicrm_payments.rb
+++ b/app/legacy_lib/import_civicrm_payments.rb
@@ -32,7 +32,7 @@ module ImportCivicrmPayments
         known_fields = ['Date Received', 'Total Amount']
 
         notes = ''
-        r.except(known_fields).each_key do |k|
+        r.except(known_fields).keys.each do |k|
           notes += "#{k}: #{r[k]}\n"
         end
 

--- a/app/models/concerns/model/jbuilder.rb
+++ b/app/models/concerns/model/jbuilder.rb
@@ -141,11 +141,11 @@ module Model::Jbuilder
 		end
 
 		def keys
-			map(&:key)
+			map{|i| i.key}
 		end
 
 		def get_by_key(key) 
-			detect{|i| i.key == key}
+			select{|i| i.key == key}.first
 		end
 	end
 
@@ -233,7 +233,7 @@ module Model::Jbuilder
 		def add_builder_expansion( ... )
 			builder_expansions = BuilderExpansionSet.new
 			builder_expansions.add_builder_expansion( ... )
-			builder_expansions.each do |k|
+			builder_expansions.keys.each do |k|
 				if expand.include? k
 					set! builder_expansions.get_by_key(k).json_attribute, builder_expansions.get_by_key(k).to_builder.(model)
 				else

--- a/app/models/concerns/model/subtransactable.rb
+++ b/app/models/concerns/model/subtransactable.rb
@@ -15,6 +15,6 @@ module Model::Subtransactable
 		has_one :supporter, through: :trx
 		has_one :nonprofit, through: :trx
 
-		has_many :subtransaction_payments, through: :subtransaction
+		has_many :payments, through: :subtransaction, as: 'SubtransactionPayment'
 	end
 end

--- a/app/views/api/payments/show.json.jbuilder
+++ b/app/views/api/payments/show.json.jbuilder
@@ -2,4 +2,4 @@
 
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
-json.partial! @subtransaction_payment, as: :subtransaction_payment
+json.partial! @payment, as: :subtransaction_payment

--- a/spec/requests/users/sessions_controller_request_spec.rb
+++ b/spec/requests/users/sessions_controller_request_spec.rb
@@ -25,7 +25,8 @@ describe Users::SessionsController, type: :request do
 			it {
 				expect(json).to eq({
 																								'id' => user.id,
-																								'object' => 'user'
+																								'object' => 'user',
+																								'roles' => []
 																							})
 			}
 		end

--- a/spec/views/api/payments/show.json.jbuilder_spec.rb
+++ b/spec/views/api/payments/show.json.jbuilder_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'api/payments/show.json.jbuilder', type: :view do
 
 	subject(:json) do
 		view.lookup_context.prefixes = view.lookup_context.prefixes.drop(2)
-		assign(:subtransaction_payment, payment)
+		assign(:payment, payment)
 		render
 		JSON.parse(rendered)
 	end


### PR DESCRIPTION
Two bugs caused us to think tests were passing when they weren't. The problem was that we were using turbo_test which doesn't always return a non-zero error code. The intent
of using turbo_test is that we could go faster on a multicore machine but the github runners aren't multicore so it's pointless.


Additionally, the use of fastener in #975 broke some code that we didn't catch. This reverts most of the changes from that PR.


- Correct some bugs which weren't caught due to using turbo_test
- Use the correct 'rake spec' instead of turbo_test
