### PR TITLE
 Change contrast ratios login page accessibility

### DIFF
--- a/app/javascript/components/users/SignInComponent.tsx
+++ b/app/javascript/components/users/SignInComponent.tsx
@@ -189,6 +189,14 @@ function SignInComponent(props: SignInComponentProps): JSX.Element {
 
 	//Styling - Material-UI
 	const useStyles = makeStyles((theme: Theme) => createStyles({
+		root: {
+			'& .MuiFormHelperText-root.Mui-error': {
+				color: "#dd1a0c",
+			},
+			'& .MuiFormLabel-root.Mui-error': {
+				color: "#dd1a0c",
+			},
+		},
 		textField: {
 			'& .MuiTextField-root': {
 				margin: theme.spacing(1),
@@ -215,6 +223,9 @@ function SignInComponent(props: SignInComponentProps): JSX.Element {
 		},
 		submitButton: {
 			height: 40,
+			"&:disabled": {
+				color: "rgba(0,0,0,0.6)",
+			},
 		},
 		checkmark: {
 			color: theme.palette.success.main,
@@ -260,7 +271,7 @@ function SignInComponent(props: SignInComponentProps): JSX.Element {
 
 
 function InnerFormComponent<TFieldValues>(props: {
-	classes: ClassNameMap<"textField" | "paper" | "backdrop" | "box" | "buttonProgress" | "submitButton" | "checkmark">;
+	classes: ClassNameMap<"root" | "textField" | "paper" | "backdrop" | "box" | "buttonProgress" | "submitButton" | "checkmark">;
 	emailLabel: string;
 	failed: boolean;
 	form: UseFormReturn<TFieldValues>;
@@ -317,7 +328,7 @@ function InnerFormComponent<TFieldValues>(props: {
 			<Box display="flex" justifyContent="center" alignItems="center">
 				{!isSuccessful ?
 					<Box p={1.5}>
-						<TextField control={control} id={emailId} name="email" data-testid="emailTest"
+						<TextField className={classes.root} control={control} id={emailId} name="email" data-testid="emailTest"
 							label={emailLabel}
 							InputProps={{
 								startAdornment: (
@@ -333,6 +344,7 @@ function InnerFormComponent<TFieldValues>(props: {
 				{!isSuccessful ?
 					<Box p={1.5}>
 						<TextField control={control}
+							className={classes.root}
 							id={passwordId}
 							name="password"
 							label={passwordLabel}


### PR DESCRIPTION
Issue #8 

Some colors were not following the recommended contrast ratios from the WCAG guidelines.
So this pr adjust the text colors from the login page to improve legibility and accessibility for all sighted users.

[Link](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast) for more information about it.

