### PR TITLE
Rename -su option to -s

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ To create a nonprofit, use the command line to run the following command and fil
 bin/rails houdini:nonprofit:create
 ```
 
-There are available arguments that add congirugrations on the nonprofit's creation:
+There are available arguments that add configurations on the nonprofit's creation:
 
 ```bash
-  -su, [--super-admin], [--no-super-admin]     # Make the nonprofit admin a super user (they can access any nonprofit's dashboards)
+  -s, [--super-admin], [--no-super-admin]     # Make the nonprofit admin a super user (they can access any nonprofit's dashboards)
       [--confirm-admin], [--no-confirm-admin]  # Require the nonprofit admin to be confirmed via email
                                                # Default: true
 ```

--- a/commands/rails/commands/houdini/nonprofit/create/create_command.rb
+++ b/commands/rails/commands/houdini/nonprofit/create/create_command.rb
@@ -11,7 +11,7 @@ module Houdini # rubocop:disable Style/ClassAndModuleChildren -- can't combine b
 		# Used for creating nonprofits at the command line
 		class CreateCommand < Rails::Command::Base
 			desc 'Create a new nonprofit on your Houdini instance'
-			option :super_admin, aliases: '-su', default: false, type: :boolean,
+			option :super_admin, aliases: '-s', default: false, type: :boolean,
 																								desc: "Make the nonprofit admin a super user (they can access any nonprofit's dashboards)"
 			option :confirm_admin, default: true, type: :boolean, desc: 'Require the nonprofit admin to be confirmed via email'
 


### PR DESCRIPTION
Running `bin/rails houdini:nonprofit:create -su` as per README.md and the built in command help gives `ERROR: "rails create" was called with arguments ["-su"]`. It appears that short arguments need to be a single character, so updating to `-s` as discussed in #1032.