### PR TITLE
Configurations page "organization users" improve accessibility

### DIFF
--- a/app/assets/stylesheets/components/modals.css.scss
+++ b/app/assets/stylesheets/components/modals.css.scss
@@ -81,6 +81,8 @@ Full license explanation at https://github.com/houdiniproject/houdini/blob/main/
 	top: 10px;
 	right: 10px;
 	width: 24px;
+	background-color: transparent;
+	padding: 0;
 }
 
 .modal-body {

--- a/app/views/common/_modal_close.html.erb
+++ b/app/views/common/_modal_close.html.erb
@@ -2,7 +2,7 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE -%>
 <!-- partial: common/modal_close -->
 
-<img class='closeButton'  src="<%= asset_path 'ui_components/close.svg' %>">
+<input type="image" class='closeButton' aria-label="close" src="<%= asset_path 'ui_components/close.svg' %>">
 	<!--= on 'click' close_modal -->
 
 <!-- end partial: common/modal_close -->

--- a/app/views/settings/_users.html.erb
+++ b/app/views/settings/_users.html.erb
@@ -44,13 +44,13 @@
 	</table>
 
 	<% if current_role?([:nonprofit_admin,:super_admin]) %>
-		<a class='button u-marginTop--5' open-modal='newRole'><i class='fa fa-plus'></i> New User</a>
+		<button class='button u-marginTop--5' type='submit' class='button u-marginTop--5' open-modal='newRole'><i class='fa fa-plus'></i> New User</button>
 	<% end %>
 
 	<hr>
 
 	<div>
-		<a open-modal='roleInfoModal'>
+		<a href="#" open-modal='roleInfoModal'>
 			What's the difference between an Associate and an Admin?
 		</a>
 	</div>


### PR DESCRIPTION
Issue https://github.com/houdiniproject/houdini/issues/8

Some elements from configurations page "organization users" are not fully accessible. For example, clickable elements not being focusable and lack of aria-label for images.
This PR focus on solving these issues.