### PR TITLE
Update docs on building JS in development

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,7 +80,7 @@ bundle exec rails server
 
 ```bash
 # Console two (2)
-yarn watch
+yarn webpack --watch
 # #### Notes ####
 # If you get errors from running this command.
 # You'll need to manually run the following commands.
@@ -88,7 +88,7 @@ npm run export-button-config
 npm run export-i18n
 npm run generate-api-js
 # Now we're able to watch!
-npx webpack --watch
+yarn webpack --watch
 ```
 
 ## Testing

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,6 +80,11 @@ reloading, run `bin/webpack-dev-server` in a second console. Now after making a
 change to the JavaScript code you should see Webpack immediately rebuild the
 assets and perform a full page reload.
 
+In development, it's **important** to access the Houdini at
+`http://localhost:5000`, rather than the `http://127.0.0.1:5000` that Rails
+suggests in the console. This ensures that the hard-coded callbacks in the
+JavaScript code will work, such as during donation payment.
+
 It's worth noting that the in-process build, the one-off `bin/webpack` build and
 `bin/webpack-dev-server` build all set `NODE_ENV=development` which skips some
 optimisation steps. The `bin/rake assets:precompile` task sets

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -67,29 +67,18 @@ Qx.config(type_map: PG::BasicTypeMapForResults.new(ActiveRecord::Base.connection
 Qx.execute("SET TIME ZONE utc")
 ```
 
-### How to run
+### Running in development
 
-You'll need 2 consoles to run the project. One for the rails env and another
-one to run the asset pipeline through [webpack](https://webpack.js.org),
-since it's _not incorporated yet_ into the rails asset pipeline.
+Run the development server with:
 
-```bash
-# Console one (1)
-bundle exec rails server
-```
+`bin/rails server`
 
-```bash
-# Console two (2)
-yarn webpack --watch
-# #### Notes ####
-# If you get errors from running this command.
-# You'll need to manually run the following commands.
-npm run export-button-config
-npm run export-i18n
-npm run generate-api-js
-# Now we're able to watch!
-yarn webpack --watch
-```
+The development server will periodically check for changes in CSS and JavaScript
+assets and rebuild them in-process. If you are doing significant JavaScript
+development and would like faster feedback on build errors and automatic
+reloading, run `bin/webpack-dev-server` in a second console. Now after making a
+change to the JavaScript code you should see Webpack immediately rebuild the
+assets and perform a full page reload.
 
 ## Testing
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,6 +80,17 @@ reloading, run `bin/webpack-dev-server` in a second console. Now after making a
 change to the JavaScript code you should see Webpack immediately rebuild the
 assets and perform a full page reload.
 
+It's worth noting that the in-process, the one-off `bin/webpack` and
+`bin/webpack-dev-server` builds all set `NODE_ENV=development` by default which
+skips some optimisation steps. The `bin/rake assets:precompile` task sets
+`NODE_ENV=production` by default. Any of these can be overridden as required by
+setting the `NODE_ENV` environment variable, for example:
+
+`NODE_ENV=development bin/rake assets:precompile`
+
+That's not something you'll need often, but can help when troubleshooting
+differences between development and production asset builds.
+
 ## Testing
 
 ---

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -80,16 +80,14 @@ reloading, run `bin/webpack-dev-server` in a second console. Now after making a
 change to the JavaScript code you should see Webpack immediately rebuild the
 assets and perform a full page reload.
 
-It's worth noting that the in-process, the one-off `bin/webpack` and
-`bin/webpack-dev-server` builds all set `NODE_ENV=development` by default which
-skips some optimisation steps. The `bin/rake assets:precompile` task sets
-`NODE_ENV=production` by default. Any of these can be overridden as required by
-setting the `NODE_ENV` environment variable, for example:
+It's worth noting that the in-process build, the one-off `bin/webpack` build and
+`bin/webpack-dev-server` build all set `NODE_ENV=development` which skips some
+optimisation steps. The `bin/rake assets:precompile` task sets
+`NODE_ENV=production`. When troubleshooting differences between development and
+production builds, it may help to explicitly override the `NODE_ENV` environment
+variable. For example:
 
 `NODE_ENV=development bin/rake assets:precompile`
-
-That's not something you'll need often, but can help when troubleshooting
-differences between development and production asset builds.
 
 ## Testing
 


### PR DESCRIPTION
When I run `yarn watch` I get:

```
$ yarn watch
yarn run v1.22.17
$ /home/ben/houdini/node_modules/.bin/watch
Usage: watch <command> [...directory] [--wait=<seconds>] [--filter=<file>] [--interval=<seconds>] [--ignoreDotFiles] [--ignoreUnreadable] [--ignoreDirectoryPattern]
Done in 0.17s.
```

Should it be `yarn webpack --watch` instead?