### PR TITLE
Remove font_assets dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org'
 gem 'rails', '6.1.5'
 gem 'jbuilder', '~> 2.11'
 gem 'bootsnap', '~> 1.11', require: false # Large rails application booting enhancer
-gem 'font_assets', '~> 0.1.14' # for serving fonts on cdn https://github.com/ericallam/font_assets
 gem 'hamster', '~> 3.0' # Thread-safe collection classes for Ruby
 gem 'puma', '~> 5.6'
 gem 'rake', '~> 12.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,8 +176,6 @@ GEM
     fast_blank (1.0.1)
     ffi (1.15.5)
     fiber-local (1.0.0)
-    font_assets (0.1.14)
-      rack
     fugit (1.5.2)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
@@ -478,7 +476,6 @@ DEPENDENCIES
   factory_bot (~> 6.2)
   factory_bot_rails (~> 6.2)
   fast_blank
-  font_assets (~> 0.1.14)
   good_job
   hamster (~> 3.0)
   houdini_full_contact!


### PR DESCRIPTION
From discussion in #524. May potentially break fonts, but is more important that the application can start up in production mode.