### PR TITLE
Switch to using javascript_packs_with_chunks_tag

### DIFF
--- a/app/views/campaigns/peer_to_peer.html.erb
+++ b/app/views/campaigns/peer_to_peer.html.erb
@@ -11,7 +11,7 @@
 
 <% content_for :javascripts do %>
 
-  <%= javascript_pack_tag 'i18n', 'page__campaigns__peer_to_peer' %>
+  <%= javascript_packs_with_chunks_tag 'i18n', 'page__campaigns__peer_to_peer' %>
 
   	<script>
     <% if @nonprofit %>

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -24,7 +24,7 @@
 
   <%= render 'schema', campaign: @campaign, url: @url %>
   <%= render 'common/froala' if current_campaign_editor? %>
-<%= javascript_pack_tag 'i18n', 'page__campaigns__show' %>
+<%= javascript_packs_with_chunks_tag 'i18n', 'page__campaigns__show' %>
 <script>
   appl.def('campaign_is_deleted', <%= @campaign.deleted || false %>)
     appl.def('has_main_image', <%= @campaign.main_image.attached? %>)

--- a/app/views/campaigns/supporters/index.html.erb
+++ b/app/views/campaigns/supporters/index.html.erb
@@ -5,7 +5,7 @@
 
 <%= content_for :javascripts do %>
   <script>ENV.campaignID = <%= @campaign.id %></script>
-  <%= javascript_pack_tag 'i18n', 'page__campaigns__supporters__index' %>
+  <%= javascript_packs_with_chunks_tag 'i18n', 'page__campaigns__supporters__index' %>
 <% end %>
 
 <% content_for :head do %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -10,7 +10,7 @@
   <script>
 		app.current_nonprofit_user = <%= current_nonprofit_user? %>
   </script>
-	<%= javascript_pack_tag 'i18n', 'page__events__index' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__events__index' %>
 <% end %>
 
 <%= render 'components/header',

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -30,7 +30,7 @@
 
 	<%= render 'common/froala' if current_event_editor? %>
   <%= render 'schema', event: @event, url: @url %>
-	<%= javascript_pack_tag 'i18n', 'page__events__show' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__events__show' %>
 	<script>
 		appl.def('event_id', <%= @event.id %>)
 		appl.def('event_is_deleted', <%= @event.deleted || false %>)

--- a/app/views/events/stats.html.erb
+++ b/app/views/events/stats.html.erb
@@ -24,7 +24,7 @@
     app.hide_activities = <%= @event.hide_activity_feed %>
     app.event_background_image = '<%= @event_background_image %>'
   </script>
-  <%= javascript_pack_tag 'i18n', 'page__events__stats' %>
+  <%= javascript_packs_with_chunks_tag 'i18n', 'page__events__stats' %>
   <script>
 		appl.def('event_id', <%= @event.id %>)
 		appl.def('event_is_deleted', <%= @event.deleted || false %>)

--- a/app/views/layouts/_javascripts.html.erb
+++ b/app/views/layouts/_javascripts.html.erb
@@ -5,7 +5,7 @@
 <% if Houdini.payment_providers.stripe.proprietary_v2_js %>
   <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
 <% else %>
-  <%= javascript_pack_tag "page__stripe_wrapper" %>
+  <%= javascript_packs_with_chunks_tag "page__stripe_wrapper" %>
 <% end %>
 
 <script>

--- a/app/views/nonprofits/bank_accounts/confirmation.html.erb
+++ b/app/views/nonprofits/bank_accounts/confirmation.html.erb
@@ -9,7 +9,7 @@
 		}
 	</script>
 
-	<%= javascript_pack_tag 'i18n', 'page__bank_accounts__confirm' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__bank_accounts__confirm' %>
 <% end %>
 
 <div class='backgroundColor'>

--- a/app/views/nonprofits/btn.html.erb
+++ b/app/views/nonprofits/btn.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__btn' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__btn' %>
 <% end %>
 
 <div class='u-centered'>

--- a/app/views/nonprofits/button/advanced.html.erb
+++ b/app/views/nonprofits/button/advanced.html.erb
@@ -6,7 +6,7 @@
 <% content_for(:footer_hidden) {'hidden'} %>
 
 <% content_for :javascripts do %>
- <%= javascript_pack_tag 'i18n', 'page__nonprofits__button' %>
+ <%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__button' %>
 <% end %>
 
 <header class='header'>

--- a/app/views/nonprofits/button/basic.html.erb
+++ b/app/views/nonprofits/button/basic.html.erb
@@ -4,7 +4,7 @@
 	<%= stylesheet_link_tag 'nonprofits/button/page' %>
 <% end %>
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__button'%>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__button'%>
 <% end %>
 <% content_for(:footer_hidden) {'hidden'} %>
 

--- a/app/views/nonprofits/button/guided.html.erb
+++ b/app/views/nonprofits/button/guided.html.erb
@@ -6,7 +6,7 @@
 <% content_for(:footer_hidden) {'hidden'} %>
 
 <% content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__button' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__button' %>
 <% end %>
 
 <header class='header'>

--- a/app/views/nonprofits/dashboard.html.erb
+++ b/app/views/nonprofits/dashboard.html.erb
@@ -6,7 +6,7 @@
 
 <%= content_for :javascripts do %>
 	
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__dashboard'%>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__dashboard'%>
 	<script>
 		appl.def('nonprofit_path', '<%= nonprofit_path(@nonprofit) %>')
 	</script>

--- a/app/views/nonprofits/donate.html.erb
+++ b/app/views/nonprofits/donate.html.erb
@@ -8,7 +8,7 @@
 
 
 <% content_for :javascripts do %>
-  <%= javascript_pack_tag 'i18n', 'page__nonprofits__donate' %>
+  <%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__donate' %>
   <script>
     app.referer_url = "<%= @referer %>"
     app.campaign = <%= raw (@campaign || {}).to_json %>

--- a/app/views/nonprofits/payments/index.html.erb
+++ b/app/views/nonprofits/payments/index.html.erb
@@ -10,7 +10,7 @@
 <% content_for :javascripts do %>
 
 
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__payments__index', 'edit_payment_pane' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__payments__index', 'edit_payment_pane' %>
 	<script>
 		appl.def('has_bank', <%= !!@nonprofit.bank_account %>)
 	</script>

--- a/app/views/nonprofits/payouts/index.html.erb
+++ b/app/views/nonprofits/payouts/index.html.erb
@@ -6,7 +6,7 @@
 <% content_for(:footer_hidden) {'hidden'} %>
 
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__payouts__index' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__payouts__index' %>
 	<script>
 		appl.def('has_bank', <%= !!@nonprofit.bank_account %>)
 	</script>

--- a/app/views/nonprofits/recurring_donations/index.html.erb
+++ b/app/views/nonprofits/recurring_donations/index.html.erb
@@ -7,7 +7,7 @@
 <% content_for(:footer_hidden) {'hidden'} %>
 
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__recurring_donations__index' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__recurring_donations__index' %>
 <% end %>
 
 <%= render 'nonprofits/transaction_title',

--- a/app/views/nonprofits/show.html.erb
+++ b/app/views/nonprofits/show.html.erb
@@ -21,7 +21,7 @@
 <% end %>
 
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__show', 'page__nonprofits__edit' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__show', 'page__nonprofits__edit' %>
 	<script>
 		app.header_image_url = '<%= @nonprofit_background_image %>'
 		app.current_nonprofit_user = <%= current_nonprofit_user? %>

--- a/app/views/nonprofits/supporter_form.html.erb
+++ b/app/views/nonprofits/supporter_form.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <% content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__supporter_form' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__supporter_form' %>
 <% end %>
 
 <div class='u-centered'>

--- a/app/views/nonprofits/supporters/index.html.erb
+++ b/app/views/nonprofits/supporters/index.html.erb
@@ -7,7 +7,7 @@
   <%= stylesheet_link_tag 'nonprofits/supporters/index/page' %>
 <% end %>
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__supporters__index', 'create_new_offsite_payment_pane' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__supporters__index', 'create_new_offsite_payment_pane' %>
 	<%= render 'common/froala' %>
 
   <script>

--- a/app/views/nonprofits/supporters/new.html.erb
+++ b/app/views/nonprofits/supporters/new.html.erb
@@ -1,7 +1,7 @@
 <%- # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE -%>
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__nonprofits__supporters__new' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__nonprofits__supporters__new' %>
 <% end %>
 
 <div class='container'>

--- a/app/views/profiles/donations_history.html.erb
+++ b/app/views/profiles/donations_history.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__profiles__donations_history'%>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__profiles__donations_history'%>
 <% end %>
 
 <% content_for(:footer_hidden) {'hidden'} %>

--- a/app/views/profiles/fundraisers.html.erb
+++ b/app/views/profiles/fundraisers.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__profiles__fundraisers'%>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__profiles__fundraisers'%>
 <% end %>
 
 <% content_for(:footer_hidden) {'hidden'} %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -4,7 +4,7 @@
    - Donor Profile
 <% end %>
 <%= content_for :javascripts do %>
-	<%= javascript_pack_tag 'i18n', 'page__profiles__show'%>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__profiles__show'%>
 <% end %>
 <% content_for :stylesheets do %>
 	<%= stylesheet_link_tag 'profiles/show/page' %>

--- a/app/views/recurring_donations/edit.html.erb
+++ b/app/views/recurring_donations/edit.html.erb
@@ -4,7 +4,7 @@
 	<script>
 		app.pageLoadData = <%= raw @data.to_json %>
 	</script>
-	<%= javascript_pack_tag 'i18n', 'page__recurring_donations__edit' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__recurring_donations__edit' %>
 <% end %>
 
 <% content_for :stylesheets do %>

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -12,7 +12,7 @@
     app.current_user_id = <%= @user.id %>
   </script>
 	<%= render 'common/froala' if current_nonprofit_user? %>
-	<%= javascript_pack_tag 'i18n', 'page__settings__index' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__settings__index' %>
 <% end %>
 
 <header class='header stripe--mosaic'>

--- a/app/views/super_admins/index.html.erb
+++ b/app/views/super_admins/index.html.erb
@@ -1,7 +1,7 @@
 <%- # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE -%>
 <%= content_for :javascripts do %>
-  <%= javascript_pack_tag 'i18n', 'page__super-admin' %>
+  <%= javascript_packs_with_chunks_tag 'i18n', 'page__super-admin' %>
 <% end %>
 
 <% content_for(:hide_nav_beacon) {'true'} %>

--- a/app/views/tickets/index.html.erb
+++ b/app/views/tickets/index.html.erb
@@ -12,7 +12,7 @@
 	</script>
 
 
-	<%= javascript_pack_tag 'i18n', 'page__tickets__index' %>
+	<%= javascript_packs_with_chunks_tag 'i18n', 'page__tickets__index' %>
   <script>
 		appl.def("event_id", <%= @event.id %>)
 		appl.def("event_name", '<%= @event.name %>')


### PR DESCRIPTION
We were incorrectly using javascript_pack_tag in places where javascript files were being split into chunks by webpacker. In that case, we should use javascript_pack_with_chunk_tags. This change does so.﻿

Closes #1060
