### PR TITLE
Correct bugs in houdini:nonprofit:create and flip the meaning of confirm_admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ There are available arguments that add configurations on the nonprofit's creatio
 
 ```bash
   -s, [--super-admin], [--no-super-admin]     # Make the nonprofit admin a super user (they can access any nonprofit's dashboards)
-      [--confirm-admin], [--no-confirm-admin]  # Require the nonprofit admin to be confirmed via email
+      [--confirm-admin], [--no-confirm-admin]  # Autoconfirm the admin instead of waiting for them to click the email link
                                                # Default: true
 ```
 

--- a/commands/rails/commands/houdini/nonprofit/create/create_command.rb
+++ b/commands/rails/commands/houdini/nonprofit/create/create_command.rb
@@ -13,7 +13,8 @@ module Houdini # rubocop:disable Style/ClassAndModuleChildren -- can't combine b
 			desc 'Create a new nonprofit on your Houdini instance'
 			option :super_admin, aliases: '-s', default: false, type: :boolean,
 																								desc: "Make the nonprofit admin a super user (they can access any nonprofit's dashboards)"
-			option :confirm_admin, default: true, type: :boolean, desc: 'Require the nonprofit admin to be confirmed via email'
+			option :confirm_admin, default: true, type: :boolean,
+																										desc: 'Autoconfirm the admin instead of waiting for them to click the email link'
 
 			option :nonprofit_name, default: nil, desc: "Provide the nonprofit's name"
 			option :state_code, default: nil, desc: "Provide the nonprofit's state code, e.g. WI for Wisconsin"
@@ -23,8 +24,9 @@ module Houdini # rubocop:disable Style/ClassAndModuleChildren -- can't combine b
 			option :nonprofit_phone, default: nil, desc: "[OPTIONAL] Provide the nonprofit's public phone number"
 
 			option :user_name, default: nil, desc: "Provide the nonprofit's admin's name"
-			option :user_email, default: nil,
-																							desc: "Provide the nonprofit's admin's email address (It'll be used for logging in)"
+			option :user_email,
+										default: nil,
+										desc: "Provide the nonprofit's admin's email address (It'll be used for logging in)"
 			option :user_password, default: nil, desc: "Provide the nonprofit's admin's password"
 
 			def perform

--- a/spec/legacy_lib/nonprofit_creation_spec.rb
+++ b/spec/legacy_lib/nonprofit_creation_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe NonprofitCreation do
 		end
 
 		it { is_expected.to_not be_super_admin }
-		it { is_expected.to_not be_confirmed }
+		it { is_expected.to be_confirmed }
 
 		it { is_expected.to have_attributes(name: 'User Name') }
 	end
@@ -72,7 +72,7 @@ RSpec.describe NonprofitCreation do
 			result[:user][:email] = 'anotherusername@email.com'
 		end
 
-		let(:options) { { super_admin: true } }
+		let(:options) { { super_admin: true, confirm_user: false } }
 
 		it { is_expected.to be_super_admin }
 		it { is_expected.to_not be_confirmed }


### PR DESCRIPTION
Closes #1079

@BenStrumfels and @WeillerFernandes noticed that the documentation for houdini:nonprofit:create doesn't match the behavior.

The change does the following:

* Correctly sets super_admin status of the admin when `--super-admin` is used
* Changes the meaning of `--confirm-user` to autoconfirm the user on creation and sets it to true by default
* Correct the autoconfirmation of the user on creation

