### PR TITLE
Update Gems for April 4, 2022

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'sprockets', '~> 3.7'
 gem 'chronic', '~> 0.10.2' # For nat lang parsing of dates
 gem 'countries', '~> 4.2'
 gem 'i18n-js', '~> 3.8', git: 'https://github.com/houdiniproject/i18n-js.git', branch: 'houdini-tweaks'
-gem 'lograge', '~> 0.11.2' # make logging less terrible in rails
+gem 'lograge', '~> 0.12.0' # make logging less terrible in rails
 gem 'rails-i18n', '~> 6.0.0', '~> 6'
 gem 'premailer-rails', '~> 1.11' # for styling of email
 gem 'money', '~> 6.16'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
       activerecord
       database_cleaner (~> 1.99.0)
     date (3.0.3)
-    debug (1.4.0)
+    debug (1.5.0)
       irb (>= 1.3.6)
       reline (>= 0.2.7)
     devise (4.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.1.0)
       ast (~> 2.4.1)
-    pg (1.3.4)
+    pg (1.3.5)
     power_assert (2.0.1)
     premailer (1.15.0)
       addressable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     builder (3.2.4)
     chronic (0.10.2)
     colorize (0.8.1)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
     console (1.13.1)
       fiber-local
@@ -229,12 +229,12 @@ GEM
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    lograge (0.11.2)
+    lograge (0.12.0)
       actionpack (>= 4)
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.14.0)
+    loofah (2.16.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -333,7 +333,7 @@ GEM
     regexp_parser (2.2.1)
     reline (0.3.1)
       io-console (~> 0.5)
-    request_store (1.5.0)
+    request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -486,7 +486,7 @@ DEPENDENCIES
   jbuilder (~> 2.11)
   kaminari
   listen
-  lograge (~> 0.11.2)
+  lograge (~> 0.12.0)
   mini_racer
   money (~> 6.16)
   param_validation!

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -429,7 +429,7 @@ limitations under the License.
 
 ------
 
-** pg; version 1.3.4 -- 
+** pg; version 1.3.5 -- 
 Copyright (c) 1997-2019 by the
 Portions copyright LAIKA, Inc.
 Copyright (c) 1993-2013 Yukihiro Matsumoto
@@ -1838,7 +1838,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** loofah; version 2.14.0 -- 
+** loofah; version 2.16.0 -- 
 Copyright (c) 2006-2008 The Authors
 Copyright (c) 2009 2018 by Mike Dalessio, Bryan Helmkamp
 
@@ -2630,10 +2630,10 @@ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 
 ------
 
-** concurrent-ruby; version 1.1.9 -- 
+** concurrent-ruby; version 1.1.10 -- 
 Copyright Concurrent Ruby
 Copyright (c) Jerry D'Antonio
-Copyright (c) 2014 Jerry D'Antonio (https://twitter.com/jerrydantonio).
+Copyright (c) 2014 Jerry D'Antonio (https://twitter.com/jerrydantonio)
 
 Copyright (c) Jerry D'Antonio -- released under the MIT license.
 
@@ -3768,7 +3768,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** request_store; version 1.5.0 -- 
+** request_store; version 1.5.1 -- 
 Copyright (c) 2012 Steve Klabnik
 
 Copyright (c) 2012 Steve Klabnik
@@ -3949,7 +3949,7 @@ SOFTWARE.
 
 ------
 
-** lograge; version 0.11.2 -- 
+** lograge; version 0.12.0 -- 
 Copyright (c) 2016 Mathias Meyer
 
 The MIT License (MIT)
@@ -4539,8 +4539,8 @@ Apache-2.0 OR (Artistic-2.0 OR (BSD-3-Clause OR (GPL-3.0 OR (MIT OR MPL-2.0))))
 
 ------
 
-** debug; version 1.4.0 -- 
-Copyright (c) 1993-2013 Yukihiro Matsumoto.
+** debug; version 1.5.0 -- 
+Copyright (c) 1993-2013 Yukihiro Matsumoto
 ** io-console; version 0.5.11 -- 
 Copyright (c) 1993-2013 Yukihiro Matsumoto.
 ** irb; version 1.4.1 -- 


### PR DESCRIPTION
- Bump pg from 1.3.4 to 1.3.5
- Bump lograge from 0.11.2 to 0.12.0
- Bump debug from 1.4.0 to 1.5.0

