### PR TITLE
Bump moment from 2.29.1 to 2.29.2

### DIFF
--- a/NOTICE-js
+++ b/NOTICE-js
@@ -22346,7 +22346,7 @@ THE SOFTWARE.
 
 ------
 
-** moment; version 2.29.1 -- https://momentjs.com
+** moment; version 2.29.2 -- https://momentjs.com
 Copyright (c) JS Foundation and other contributors
 
 Copyright (c) JS Foundation and other contributors

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "mobx": "^4.3.1",
     "mobx-react": "^5.4.3",
     "mobx-react-form": "github:houdiniproject/mobx-react-form#our_fix",
-    "moment": "^2.22.2",
+    "moment": "^2.29.2",
     "moment-range": "2.2.0",
     "moment-timezone": "^0.5.21",
     "no-scroll": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10988,10 +10988,10 @@ moment-timezone@^0.5.21:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.x, "moment@>= 2.9.0", moment@>=2.14.0, moment@^2.10.2, moment@^2.22.2:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
-  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+moment@2.x, "moment@>= 2.9.0", moment@>=2.14.0, moment@^2.10.2, moment@^2.29.2:
+  version "2.29.2"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.2.tgz#00910c60b20843bcba52d37d58c628b47b1f20e4"
+  integrity sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==
 
 moo@^0.5.0:
   version "0.5.1"


### PR DESCRIPTION
Moment has a CVE which can only be exploited when running on a server with access to a filesystem. Since we don't use moment like that, this bug would never be exploited. But it doesn't hurt to upgrade anyway.

Bumps [moment](https://github.com/moment/moment) from 2.29.1 to 2.29.2.
- [Release notes](https://github.com/moment/moment/releases)
- [Changelog](https://github.com/moment/moment/blob/develop/CHANGELOG.md)
- [Commits](https://github.com/moment/moment/compare/2.29.1...2.29.2)

---
updated-dependencies:
- dependency-name: moment
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>
