### PR TITLE
Fix charge_params used during refund

### DIFF
--- a/app/controllers/nonprofits/refunds_controller.rb
+++ b/app/controllers/nonprofits/refunds_controller.rb
@@ -11,23 +11,15 @@ module Nonprofits
 
     # post /charges/:charge_id/refunds
     def create
-      charge = Qx.select('*').from('charges').where(id: charge_params[:charge_id]).execute.first
-      render_json { InsertRefunds.with_stripe(charge, charge_params[:refund]) }
+      charge =  current_nonprofit.charges.find(params[:charge_id])
+      charge_params = params.require(:refund).permit(:amount).merge(user_id: current_user.id)
+      render_json { InsertRefunds.with_stripe(charge, charge_params) }
     end
 
     def index
       charge = current_nonprofit.charges.find(params[:charge_id])
       @refunds = charge.refunds
       render locals: {refunds: @refund}
-    end
-
-private
-
-    def charge_params
-      {
-        :charge_id => params.require(:charge_id),
-        :refund => params.require(:refund).permit(:amount)
-      }
     end
   end
 end

--- a/app/controllers/nonprofits/refunds_controller.rb
+++ b/app/controllers/nonprofits/refunds_controller.rb
@@ -12,8 +12,7 @@ module Nonprofits
     # post /charges/:charge_id/refunds
     def create
       charge = Qx.select('*').from('charges').where(id: charge_params[:charge_id]).execute.first
-      params[:refund][:user_id] = current_user.id
-      render_json { InsertRefunds.with_stripe(charge, charge_params['refund']) }
+      render_json { InsertRefunds.with_stripe(charge, charge_params[:refund]) }
     end
 
     def index
@@ -25,7 +24,10 @@ module Nonprofits
 private
 
     def charge_params
-      params.require(:charge_id, refund: [:amount])
+      {
+        :charge_id => params.require(:charge_id),
+        :refund => params.require(:refund).permit(:amount)
+      }
     end
   end
 end


### PR DESCRIPTION
This change modifies `charge_params` to fix the `ArgumentError` mentioned in #1103 and to return a hash of the shape expected by `create`. I've used a symbol for `:refund` for consistency with `:charge_id` being a symbol. Would it be better to split these out into two functions though? Seems unclear to call the same function twice.

I've also removed the line setting `:user_id` because I can't see how it it does anything, though I may be unaware of some magic here.

I'm not very familiar with Ruby/Rails, but I'm keen to learn. :)