### PR TITLE
Remove unused NonprofitsController#create

### DIFF
--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -51,11 +51,6 @@ class NonprofitsController < ApplicationController
     render json: FetchTodoStatus.for_dashboard(current_nonprofit)
   end
 
-  def create
-    current_user ||= User.find(params[:user_id])
-    json_saved Nonprofit.register(current_user, nonprofit_params)
-  end
-
   def update
     flash[:notice] = 'Update successful!'
     current_nonprofit.update nonprofit_params.except(:verification_status)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
           resources :ticket_levels, only: [:index, :show]
         end
         resources :supporters, only: [:index, :show] do 
-          resources :supporter_addresses, only: [:index, :show]
+          resources :supporter_addresses, only: [:index, :show]s
           resources :supporter_notes, only: [:index, :show]
         end
         resources :tag_definitions, only: [:index, :show]
@@ -141,7 +141,7 @@ Rails.application.routes.draw do
     resources(:campaign_gift_options, only: [:index])
   end
 
-  resources(:nonprofits, only: %i[show create update destroy]) do
+  resources(:nonprofits, only: %i[show update destroy]) do
     get(:profile_todos, on: :member)
     get(:recurring_donation_stats, on: :member)
     get(:search, on: :collection)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
           resources :ticket_levels, only: [:index, :show]
         end
         resources :supporters, only: [:index, :show] do 
-          resources :supporter_addresses, only: [:index, :show]s
+          resources :supporter_addresses, only: [:index, :show]
           resources :supporter_notes, only: [:index, :show]
         end
         resources :tag_definitions, only: [:index, :show]

--- a/spec/controllers/nonprofits_spec.rb
+++ b/spec/controllers/nonprofits_spec.rb
@@ -51,10 +51,6 @@ describe NonprofitsController, type: :controller do
         include_context :open_to_all, :get, :show, id: :__our_np, without_json_view: true
       end
 
-      describe 'create' do
-        include_context :open_to_all, :post, :create, nonprofit_id: :__our_np
-      end
-
       describe 'btn' do
         include_context :open_to_all, :get, :btn, id: :__our_np, without_json_view: true
       end


### PR DESCRIPTION
We only allow Nonprofits to be created via CLI so we shouldn't be allowing people to register a nonprofit via an API.
