### PR TITLE
Remove locale from email donor job

### DIFF
--- a/app/jobs/payment_notification_email_donor_job.rb
+++ b/app/jobs/payment_notification_email_donor_job.rb
@@ -1,6 +1,6 @@
 class PaymentNotificationEmailDonorJob < EmailJob
 
-  def perform(donation, locale)
-    DonationMailer.donor_payment_notification(donation.id, locale).deliver_now
+  def perform(donation)
+    DonationMailer.donor_payment_notification(donation.id).deliver_now
   end
 end


### PR DESCRIPTION
payment_mailer.rb:22 does not pass the required locale to the `PaymentNotificationEmailDonorJob`, which creates an error when GoodJob attempts to run the task. To fix this I've removed the locale argument. An alternative would be to provide the locale, but I note that `resend_admin_receipt` similarly doesn't send a locale argument to `PaymentNotificationEmailNonprofitJob`, so the current approach is consistent.

This job error mentioned is currently silently swallowed in development - the email just doesn't go out.