### PR TITLE
Fix conflict with `acct` variable renaming

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -8,9 +8,7 @@ class CardsController < ApplicationController
   # post /cards
   def create
     account = Supporter.find(card_params[:holder_id]).nonprofit.stripe_account_id
-
-    @source_token = InsertCard.with_stripe(card_params, acct, params[:event_id], current_user)
-    
+    @source_token = InsertCard.with_stripe(card_params, account, params[:event_id], current_user)
   end
 
   private


### PR DESCRIPTION
The `acct` variable wasn't resolved properly when conflicts in this method were merged. One called it `acct` the other renamed to `account`.