### PR TITLE
Ran `sass-migrator division app/**/*.scss`

### DIFF
--- a/app/assets/stylesheets/components/wizard_index.css.scss
+++ b/app/assets/stylesheets/components/wizard_index.css.scss
@@ -30,7 +30,7 @@ $chevron_height: 34px;
 	float: left;
 	text-align: center;
 	position: relative;
-	padding-right: $chevron_height/2;
+	padding-right: $chevron_height*0.5;
 	@include gradient(left, $fog, darken($fog, 6));
 }
 
@@ -39,13 +39,13 @@ $chevron_height: 34px;
 .wizard-index-label:before {
 	content: '';
 	position: absolute;
-	border-left: $chevron_height/2 solid transparent;
+	border-left: $chevron_height*0.5 solid transparent;
 	height: 0;
 	cursor: default;
 	width: 0;
-	border-top: ($chevron_height/2) solid $fog;
-	border-bottom: $chevron_height/2 solid $fog;
-	left: -$chevron_height/2;
+	border-top: ($chevron_height*0.5) solid $fog;
+	border-bottom: $chevron_height*0.5 solid $fog;
+	left: -$chevron_height*0.5;
 	top: 0;
 }
 

--- a/app/assets/stylesheets/nonprofits/donation_form/show/index.css.scss
+++ b/app/assets/stylesheets/nonprofits/donation_form/show/index.css.scss
@@ -13,7 +13,7 @@ $width: 400px; // same as .modal.skinny
 	top: 100px;
 	left: 50%;
 	margin: 0;
-	margin-left: -$width / 2;
+	margin-left: -$width * 0.5;
 	background-color: white;
 	border: 1px solid #ddd;
 	@include border-radius(4px);


### PR DESCRIPTION
Sass gives us some warnings about using an old style of division. This corrects it in our codebase.
