### PR TITLE
Mention that we're XHR in postSignIn so Devise doesn't start the browser based login

### DIFF
--- a/app/javascript/api/users.ts
+++ b/app/javascript/api/users.ts
@@ -11,17 +11,19 @@ export async function postSignIn(loginInfo: WebLoginModel, init: RequestInit = {
 		credentials: 'include',
 		headers: {
 			'Accept': 'application/json',
+			'Content-Type': 'application/json',
+			'X-Requested-With': 'XMLHttpRequest',
 		},
 	} as const;
 
-	const data = new FormData();
-	data.set("user[email]", loginInfo.email);
-	data.set("user[password]", loginInfo.password);
+	const data = {
+		user: loginInfo,
+	};
 
 	const response = await fetch(userRoutes.userSession.url(), {
 		...defaultConfig,
 		...init,
-		body: data,
+		body: JSON.stringify(data),
 	});
 
 	if (response.ok) {


### PR DESCRIPTION
Devise has an bad behavior where if you have http_authenticatable set to true, then it responds with the WWW-Authenticate header. This triggers the browser to popup the native Username and Password login modal. We correct this by adding the X-Requested-With header to our POST to user sign request.
