### PR TITLE
Remove the locale_for_supporter methods in InsertRecurringDonation and InsertDonation

### DIFF
--- a/app/legacy_lib/insert_donation.rb
+++ b/app/legacy_lib/insert_donation.rb
@@ -140,7 +140,7 @@ module InsertDonation
     result['donation'] = insert_donation(data, entities)
     update_donation_keys(result)
 
-    Houdini.event_publisher.announce(:donation_create, result['donation'], result['donation'].supporter.locale))
+    Houdini.event_publisher.announce(:donation_create, result['donation'], result['donation'].supporter.locale)
 
     # do this for making test consistent
     result['activity'] = {}

--- a/app/legacy_lib/insert_donation.rb
+++ b/app/legacy_lib/insert_donation.rb
@@ -140,7 +140,7 @@ module InsertDonation
     result['donation'] = insert_donation(data, entities)
     update_donation_keys(result)
 
-    Houdini.event_publisher.announce(:donation_create, result['donation'], locale_for_supporter(result['donation'].supporter.id))
+    Houdini.event_publisher.announce(:donation_create, result['donation'], result['donation'].supporter.locale))
 
     # do this for making test consistent
     result['activity'] = {}
@@ -230,13 +230,6 @@ module InsertDonation
   # Return either the parsed DateTime from a date in data, or right now
   def self.date_from_data(data)
     data.merge('date' => data['date'].blank? ? Time.current : Chronic.parse(data['date']))
-  end
-
-  def self.locale_for_supporter(supporter_id)
-    Psql.execute(
-      Qexpr.new.select(:locale).from(:supporters)
-        .where('id=$id', id: supporter_id)
-    ).first['locale']
   end
 
   def self.payment_provider(data)

--- a/app/legacy_lib/insert_recurring_donation.rb
+++ b/app/legacy_lib/insert_recurring_donation.rb
@@ -182,13 +182,6 @@ module InsertRecurringDonation
     Chronic.parse(data[:recurring_donation][:start_date])
         end
 
-  def self.locale_for_supporter(supporter_id)
-    Psql.execute(
-      Qexpr.new.select(:locale).from(:supporters)
-        .where('id=$id', id: supporter_id)
-    ).first['locale']
-  end
-
   def self.payment_provider(data)
     if data[:card_id]
       :credit_card


### PR DESCRIPTION
Based on https://github.com/CommitChange/houdini/pull/382

If you look at `.locale_for_supporter` in `InsertDonation` and `InsertRecurringDonation`, it's not really useful. You can do the same far more simply by taking a `Supporter` object and calling `#locale` . So we're doing that now.
