### PR TITLE
Remove unused `Campaign#recurring_fund`

### DIFF
--- a/app/controllers/campaigns_controller.rb
+++ b/app/controllers/campaigns_controller.rb
@@ -154,7 +154,6 @@ class CampaignsController < ApplicationController # rubocop:disable Metrics/Clas
 			:vimeo_video_id,
 			:youtube_video_id,
 			:summary,
-			:recurring_fund,
 			:body,
 			:goal_amount_dollars,
 			:show_total_raised,

--- a/app/models/campaign.rb
+++ b/app/models/campaign.rb
@@ -23,7 +23,6 @@ class Campaign < ApplicationRecord
   # :vimeo_video_id,
   # :youtube_video_id,
   # :summary,
-  # :recurring_fund, # bool: whether this is a recurring campaign
   # :body,
   # :goal_amount_dollars, #accessor: translated into goal_amount (cents)
   # :show_total_raised, # bool

--- a/app/views/campaigns/show.html.erb
+++ b/app/views/campaigns/show.html.erb
@@ -15,7 +15,6 @@
     app.end_date_time = app.campaign_end_datetime
     app.hide_activities = <%= @campaign.hide_activity_feed %>
 		app.days_remaining = '<%= @campaign.days_left %>'
-		app.recurring_fund = <%= @campaign.recurring_fund? %>
     app.vimeo_id = "<%= @campaign.vimeo_video_id ? @campaign.vimeo_video_id : '' %>"
     app.current_campaign_editor = <%= current_campaign_editor? %>
     app.is_parent_campaign = <%= @campaign.parent_campaign? %>

--- a/db/migrate/20220608214048_remove_recurring_fund_from_campaigns.rb
+++ b/db/migrate/20220608214048_remove_recurring_fund_from_campaigns.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+class RemoveRecurringFundFromCampaigns < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :campaigns, :recurring_fund
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_27_052420) do
+ActiveRecord::Schema.define(version: 2022_06_08_214048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -149,7 +149,6 @@ ActiveRecord::Schema.define(version: 2022_04_27_052420) do
     t.boolean "published"
     t.string "background_image", limit: 255
     t.integer "total_supporters"
-    t.boolean "recurring_fund"
     t.string "slug", limit: 255
     t.string "youtube_video_id", limit: 255
     t.string "tagline", limit: 255

--- a/spec/legacy_lib/insert/insert_duplicate_spec.rb
+++ b/spec/legacy_lib/insert/insert_duplicate_spec.rb
@@ -60,7 +60,6 @@ describe InsertDuplicate do
         main_image: nil,
         published: false,
         receipt_message: nil,
-        recurring_fund: nil,
         show_recurring_amount: false,
         show_total_count: true,
         show_total_raised: true,


### PR DESCRIPTION
There's a column called `recurring_fund` on `Campaign`. I can't find any place that it's used so let's remove it.
