### PR TITLE
Correct double loading bug

### DIFF
--- a/app/views/layouts/embed.html.erb
+++ b/app/views/layouts/embed.html.erb
@@ -21,9 +21,6 @@
 <%= yield %>
 
 <%= render 'layouts/javascripts' %>
-<%= yield :javascripts %>
-
-<span data-parsley-namespace='parsley-'></span>
 
 
 </body>

--- a/app/views/nonprofits/donate.html.erb
+++ b/app/views/nonprofits/donate.html.erb
@@ -48,5 +48,3 @@
   <div class='donate-popup donationWizard'>
     <div class='js-donateForm'> </div>
   </div>
-<%= render 'layouts/javascripts' %>
-<%= yield :javascripts %>


### PR DESCRIPTION
There's a bug in Houdini on the donate page where the javascript is added twice. This is not useful and can cause bugs. This corrects this.
