### PR TITLE
Add StripeMockHelper

### DIFF
--- a/spec/legacy_lib/insert/insert_card_spec.rb
+++ b/spec/legacy_lib/insert/insert_card_spec.rb
@@ -5,9 +5,9 @@
 require 'rails_helper'
 describe InsertCard do
   describe '.with_stripe' do
-    let(:stripe_helper) { StripeMock.create_test_helper }
+    let(:stripe_helper) { StripeMockHelper.default_helper}
 
-    let(:stripe_card_token) { StripeMock.generate_card_token(last4: '9191', exp_year: 2011) }
+    let(:stripe_card_token) { StripeMockHelper.generate_card_token(last4: '9191', exp_year: 2011) }
     let(:default_card_attribs) do
       {
         created_at: Time.now,
@@ -32,9 +32,9 @@ describe InsertCard do
 
     around(:each) do |example|
       Timecop.freeze(2025, 5, 4) do
-        StripeMock.start
-        example.run
-        StripeMock.stop
+        StripeMockHelper.mock do
+          example.run
+        end
       end
     end
 

--- a/spec/legacy_lib/insert/insert_charge_spec.rb
+++ b/spec/legacy_lib/insert/insert_charge_spec.rb
@@ -136,7 +136,7 @@ describe InsertCharge do
 
     describe 'handle StripeAccount Find and Create failure' do
       before(:each)  do
-        StripeMock.prepare_error(Stripe::StripeError.new('chaos'), :new_account)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new('chaos'), :new_account)
       end
       it 'does it fail properly' do
         expect do
@@ -160,7 +160,7 @@ describe InsertCharge do
         nonprofit.save!
         card.stripe_customer_id = 'some other id'
         card.save!
-        StripeMock.prepare_error(Stripe::StripeError.new('chaos'), :get_customer)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new('chaos'), :get_customer)
       end
 
       it 'handles card error' do
@@ -171,7 +171,7 @@ describe InsertCharge do
                                                           description: 'our statement<> blah-no-way',
                                                           statement_descriptor: 'our statement blah-n',
                                                           metadata: nil }, stripe_account: nonprofit.stripe_account_id).and_wrap_original { |m, *args| m.call(*args) }
-        StripeMock.prepare_card_error(:card_declined)
+        StripeMockHelper.prepare_card_error(:card_declined)
 
         finished_result = InsertCharge.with_stripe(amount: 100,
                                                    nonprofit_id: nonprofit.id,
@@ -197,7 +197,7 @@ describe InsertCharge do
                                                           description: 'our statement<> blah-no-way',
                                                           statement_descriptor: 'our statement blah-n',
                                                           metadata: nil }, stripe_account: nonprofit.stripe_account_id).and_wrap_original { |m, *args| m.call(*args) }
-        StripeMock.prepare_error(Stripe::StripeError.new('blah'), :new_charge)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new('blah'), :new_charge)
 
         finished_result = InsertCharge.with_stripe(amount: 100,
                                                    nonprofit_id: nonprofit.id,
@@ -329,7 +329,7 @@ describe InsertCharge do
         new_cust = Stripe::Customer.create
         card_for_other_supporter.stripe_customer_id = new_cust['id']
         card_for_other_supporter.save!
-        # StripeMock.prepare_error(Stripe::StripeError.new("chaos"), :get_customer)
+        # StripeMockHelper.prepare_error(Stripe::StripeError.new("chaos"), :get_customer)
       end
 
       def create_expected_charge_args(expected_card)
@@ -345,7 +345,7 @@ describe InsertCharge do
 
       it 'handles card error' do
         expect(Stripe::Charge).to receive(:create).with(*create_expected_charge_args(card)).and_wrap_original { |m, *args| m.call(*args) }
-        StripeMock.prepare_card_error(:card_declined)
+        StripeMockHelper.prepare_card_error(:card_declined)
 
         finished_result = InsertCharge.with_stripe(amount: 100,
                                                    nonprofit_id: nonprofit.id,
@@ -365,7 +365,7 @@ describe InsertCharge do
 
       it 'handles general Stripe error' do
         expect(Stripe::Charge).to receive(:create).with(*create_expected_charge_args(card)).and_wrap_original { |m, *args| m.call(*args) }
-        StripeMock.prepare_error(Stripe::StripeError.new('blah'), :new_charge)
+        StripeMockHelper.prepare_error(Stripe::StripeError.new('blah'), :new_charge)
 
         finished_result = InsertCharge.with_stripe(amount: 100,
                                                    nonprofit_id: nonprofit.id,

--- a/spec/legacy_lib/stripe_account_spec.rb
+++ b/spec/legacy_lib/stripe_account_spec.rb
@@ -7,9 +7,13 @@ require 'stripe'
 require 'stripe_mock'
 
 describe StripeAccount do
-  let(:stripe_helper) { StripeMock.create_test_helper }
-  before(:each) { StripeMock.start }
-  after(:each) { StripeMock.stop }
+  let(:stripe_helper) { StripeMockHelper.default_helper }
+  around(:each) do |example|
+    StripeMockHelper.mock do 
+      example.run
+    end
+  end
+
   let(:nonprofit) { force_create(:nm_justice) }
 
   describe '.find_or_create' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require 'action_mailer_matchers'
 require 'active_job'
 require 'wisper/rspec/matchers'
 require 'validate_url/rspec_matcher'
+require 'support/stripe_mock_helper'
 include ActiveJob::TestHelper
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
@@ -120,4 +121,8 @@ RSpec.configure do |config|
   config.include(Wisper::RSpec::BroadcastMatcher)
 
   config.example_status_persistence_file_path = 'tmp/example_status_persistence_file_path.txt'
+
+  config.after(:each) do
+    StripeMockHelper.stop
+  end
 end

--- a/spec/support/contexts/shared_donation_charge_context.rb
+++ b/spec/support/contexts/shared_donation_charge_context.rb
@@ -38,7 +38,7 @@ RSpec.shared_context :shared_donation_charge_context do
   let(:recurring_donation) { force_create(:recurring_donation, donation: donation_for_rd, nonprofit: nonprofit, supporter: supporter, start_date: Time.now, interval: 1, time_unit: 'month') }
   let(:recurrence) { force_create(:recurrence, recurring_donation: recurring_donation, supporter: supporter, amount: 500, start_date: Time.now)}
 
-  let(:stripe_helper) { StripeMock.create_test_helper }
+  let(:stripe_helper) { StripeMockHelper.default_helper }
 
   let(:supporter_name) {'Fake Supporter Name'}
 
@@ -83,9 +83,9 @@ RSpec.shared_context :shared_donation_charge_context do
 
   around(:each) do |example|
     Timecop.freeze(2020, 5, 4) do
-      StripeMock.start
-      example.run
-      StripeMock.stop
+      StripeMockHelper.mock do 
+        example.run
+      end
     end
   end
 end

--- a/spec/support/stripe_mock_helper.rb
+++ b/spec/support/stripe_mock_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH Web-Template-Output-Additional-Permission-3.0-or-later
+
+# StripeMockHelper wraps the StripeMock to simplify creating a single test helper as part of
+# a test session. Generally, you can use StripeMockHelper like StripeMock except it adds a "default_helper"
+# to get the StripeTestHelper for the session.
+# @see StripeMock
+StripeMockHelper = Class.new do
+	delegate_missing_to :StripeMock
+
+	# Most StripeMock sessions only need a single test helper so you can get it here
+	# @return a Stripe test helper or nil if none is set
+	def default_helper
+		@default_helper if defined? @default_helper
+	end
+
+	alias_method :stripe_helper, :default_helper
+
+	# sets up a StripeMock session and sets up StripeMock::default_helper
+	# note: Rspec is set up to autostop a StripeMock session when an example finishes
+	def start
+		return if default_helper
+
+		StripeMock.start
+		create_default_helper
+	end
+
+	# stops a StripeMock session and clears StripeMock::default_helper
+	def stop
+		clear_default_helper
+		StripeMock.stop
+	end
+
+	# wraps a block in a StripeMock session and sets up StripeMock::default_helper
+	def mock(&block)
+		start
+
+		block.call
+
+		stop
+	end
+
+	private
+
+	# Clears the default test helper for the current StripeMock session
+	def clear_default_helper
+		remove_instance_variable :@default_helper if defined? @default_helper
+	end
+
+	# Creates a default test helper for the current StripeMock session
+	def create_default_helper
+		@default_helper ||= StripeMock.create_test_helper  # rubocop:disable Naming/MemoizedInstanceVariableName
+	end
+end.new

--- a/spec/support/test/stripe_mock_helper_spec.rb
+++ b/spec/support/test/stripe_mock_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+
+describe StripeMockHelper do
+	describe '#stripe_helper' do
+		it 'starts unset' do
+			expect(described_class.stripe_helper).to be_falsy
+		end
+
+		it 'is set on start' do
+			described_class.mock do
+				expect(described_class.stripe_helper).to be_truthy
+			end
+		end
+
+		it 'clears stripe_helper when finished' do
+			described_class.mock do # rubocop:disable Lint/EmptyBlock
+			end
+			expect(described_class.stripe_helper).to be_falsy
+		end
+	end
+
+	describe '#start' do
+		it 'is safely reentrant' do
+			described_class.mock do
+				# create a plan
+				described_class.stripe_helper.create_plan(id: 'test_str_plan', amount: 0, currency: 'usd', interval: 'year',
+																																														name: 'test PLan')
+				described_class.start
+				expect { Stripe::Plan.retrieve('test_str_plan') }.to_not(raise_error, "If this object is not available, \
+          then the StripeMockHelper.start is incorrectly creating a new StripeMock session")
+			end
+		end
+	end
+end


### PR DESCRIPTION
StripeMockHelper wraps StripeMock so you can easily get a common test helper for your test run at any time. Additionally, it delegates any missing methods so you can use it as a drop-in replacement for StripeMock.
