### PR TITLE
Update Gems for June 20, 2022

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :development, :ci, :test do
   gem 'table_print', '~> 1.5', '>= 1.5.6' # giuNice table printing of data for the console
   gem 'colorize', '~> 0.8.1' # Print colorized text in debugger/console
   gem 'rubocop', '~> 1.30.1'
-  gem 'rubocop-rails', '~> 2.14'
+  gem 'rubocop-rails', '~> 2.15'
   gem 'rubocop-rake', '~> 0.6.0'
   gem 'rubocop-rspec', '~> 2.11'
   gem 'shoulda-matchers', '~> 5.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'premailer-rails', '~> 1.11' # for styling of email
 gem 'money', '~> 6.16'
 
 # Database and Events
-gem 'pg', '~> 1.3'
+gem 'pg', '~> 1.4'
 
 gem 'param_validation', path: 'gems/ruby-param-validation'
 gem 'qx', path: 'gems/ruby-qx'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -262,7 +262,7 @@ GEM
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
-    pg (1.3.5)
+    pg (1.4.0)
     power_assert (2.0.1)
     premailer (1.15.0)
       addressable
@@ -486,7 +486,7 @@ DEPENDENCIES
   lograge (~> 0.12.0)
   money (~> 6.16)
   param_validation!
-  pg (~> 1.3)
+  pg (~> 1.4)
   premailer-rails (~> 1.11)
   puma (~> 5.6)
   qx!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    minitest (5.15.0)
+    minitest (5.16.0)
     money (6.16.0)
       i18n (>= 0.6.4, <= 2)
     msgpack (1.5.2)
@@ -373,7 +373,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
-    rubocop-rails (2.14.2)
+    rubocop-rails (2.15.0)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
@@ -452,7 +452,7 @@ GEM
       activejob (>= 4.0.0)
       wisper
     wisper-rspec (1.1.0)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
@@ -500,7 +500,7 @@ DEPENDENCIES
   rspec (~> 3.11.0)
   rspec-rails (~> 4.1.2)
   rubocop (~> 1.30.1)
-  rubocop-rails (~> 2.14)
+  rubocop-rails (~> 2.15)
   rubocop-rake (~> 0.6.0)
   rubocop-rspec (~> 2.11)
   sassc (~> 2.0, >= 2.0.1)

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -429,7 +429,7 @@ limitations under the License.
 
 ------
 
-** pg; version 1.3.5 -- 
+** pg; version 1.4.0 -- 
 Copyright (c) 1997-2019 by the
 Portions copyright LAIKA, Inc.
 Copyright (c) 1993-2013 Yukihiro Matsumoto
@@ -1829,9 +1829,9 @@ THE SOFTWARE.
 
 ------
 
-** zeitwerk; version 2.5.4 -- 
-License, Copyright (c) 2019
+** zeitwerk; version 2.6.0 -- 
 Copyright (c) 2019-o Xavier Noria
+Copyright (c) 2019- <i> o </i> Xavier Noria
 
 Copyright (c) 2019–ω Xavier Noria
 
@@ -2543,7 +2543,7 @@ Copyright (c) 2015 Mikko Kokkonen
 Copyright (c) 2012-22 Bozhidar Batsov
 Copyright (c) 2012-2022 Bozhidar Batsov
 AutocorrectNotice Copyright (c) 2015 Yahoo! Inc.
-** rubocop-rails; version 2.14.2 -- 
+** rubocop-rails; version 2.15.0 -- 
 Copyright (c) 2012-22 Bozhidar Batsov
 
 Copyright (c) 2012-22 Bozhidar Batsov
@@ -3089,7 +3089,7 @@ Copyright (c) 2010-2015, The Dojo Foundation
 ** mime-types; version 3.3.1 -- 
 Copyright 2003-2019 Austin Ziegler and contributors.
 ** mime-types-data; version 3.2021.0901 -- 
-** minitest; version 5.15.0 -- 
+** minitest; version 5.16.0 -- 
 Copyright (c) Ryan Davis, seattle.rb
 ** nio4r; version 2.5.8 -- 
 (c) 2011 Emanuele Giaquinta


### PR DESCRIPTION
- Bump pg from 1.3.5 to 1.4.0
- Bump rubocop-rails from 2.14.2 to 2.15.0
