### PR TITLE
Allow semver updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"] # we don't want to have semver-major changes
     
 
 


### PR DESCRIPTION
I think it makes sense to allow semver updates for Github actions in dependabot. We do need to be careful but I think it would save us some time.