### PR TITLE
Correct name of job step in .github/workflows/dependabot-notice-ruby-update.yml

### DIFF
--- a/.github/workflows/dependabot-notice-ruby-update.yml
+++ b/.github/workflows/dependabot-notice-ruby-update.yml
@@ -14,7 +14,7 @@ env:
   ruby: '2.7.6'
 jobs:
   update-NOTICE-ruby:
-    runs-on: ${{ env.os }}
+    runs-on: ubuntu-20.04
     if: |
       github.actor == 'dependabot[bot]' &&
       contains(github.event.pull_request.head.ref, 'dependabot/bundler/')
@@ -27,7 +27,7 @@ jobs:
           # See: https://github.community/t/push-from-action-does-not-trigger-subsequent-action/16854/2
           token: ${{ secrets.DEPENDABOT_PAT }}
           ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 2notice
+          fetch-depth: 2
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
- NOTICE-ruby is now automagically updated in Dependabot PRs
- Correct name of job step in .github/workflows/dependabot-notice-ruby-update.yml
