### PR TITLE
Deprecate the use of querystring in app/javascript/legacy/nonprofits/supporters/index/sidepanel/index.js

### DIFF
--- a/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.spec.ts
+++ b/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.spec.ts
@@ -7,12 +7,20 @@ describe("backport-query-string url", () => {
 	describe('has sid', () => {
 		const qs = "?sid=w12&other=w";
 
-		it("getSidFromNodeUrl finds w12", () => {
+		it("getSidFromNodeUrl finds w12 using NodeUrl", () => {
 			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBe("w12");
 		});
 
-		it("getSidFromNodeUrlQS finds w12", () => {
+		it("getSidFromNodeUrlQS finds w12 using NodeUrl", () => {
 			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBe("w12");
+		});
+
+		it("getSidFromNodeUrl finds w12 using URL", () => {
+			expect(getSidFromNodeUrl(new URL(`http://s${qs}`))).toBe("w12");
+		});
+
+		it("getSidFromNodeUrlQS finds w12 using URL", () => {
+			expect(getSidFromNodeUrlQS(new URL(`http://s${qs}`))).toBe("w12");
 		});
 	});
 
@@ -20,36 +28,61 @@ describe("backport-query-string url", () => {
 	describe('has qs but with no sid', () => {
 		const qs = "?other=w";
 
-		it("getSidFromNodeUrl finds w12", () => {
+		it("getSidFromNodeUrl finds undefined using NodeUrl", () => {
 			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBeUndefined();
 		});
 
-		it("getSidFromNodeUrlQS finds w12", () => {
+		it("getSidFromNodeUrlQS finds undefined using NodeUrl", () => {
 			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBeUndefined();
+		});
+
+
+		it("getSidFromNodeUrl finds undefined using URL", () => {
+			expect(getSidFromNodeUrl(new URL(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrlQS finds undefined using URL", () => {
+			expect(getSidFromNodeUrlQS(new URL(`http://s${qs}`))).toBeUndefined();
 		});
 	});
 
 	describe('has totally empty qs', () => {
 		const qs = "?";
 
-		it("getSidFromNodeUrl finds w12", () => {
+		it("getSidFromNodeUrl finds undefined using NodeURL", () => {
 			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBeUndefined();
 		});
 
-		it("getSidFromNodeUrlQS finds w12", () => {
+		it("getSidFromNodeUrlQS finds undefined using NodeURL", () => {
 			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrl finds undefined using URL", () => {
+			expect(getSidFromNodeUrl(new URL(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrlQS finds undefined using URL", () => {
+			expect(getSidFromNodeUrlQS(new URL(`http://s${qs}`))).toBeUndefined();
 		});
 	});
 
 	describe('has no qs', () => {
 		const qs = "";
 
-		it("getSidFromNodeUrl finds w12", () => {
+		it("getSidFromNodeUrl finds undefined using NodeURL", () => {
 			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBeUndefined();
 		});
 
-		it("getSidFromNodeUrlQS finds w12", () => {
+		it("getSidFromNodeUrlQS finds undefined using NodeURL", () => {
 			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrl finds undefined using URL", () => {
+			expect(getSidFromNodeUrl(new URL(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrlQS finds undefined using URL", () => {
+			expect(getSidFromNodeUrlQS(new URL(`http://s${qs}`))).toBeUndefined();
 		});
 	});
 });

--- a/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.spec.ts
+++ b/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.spec.ts
@@ -1,0 +1,56 @@
+// License: LGPL-3.0-or-later
+import {parse} from 'url';
+import {getSidFromNodeUrl, getSidFromNodeUrlQS} from './backport-query-string';
+
+
+describe("backport-query-string url", () => {
+	describe('has sid', () => {
+		const qs = "?sid=w12&other=w";
+
+		it("getSidFromNodeUrl finds w12", () => {
+			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBe("w12");
+		});
+
+		it("getSidFromNodeUrlQS finds w12", () => {
+			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBe("w12");
+		});
+	});
+
+
+	describe('has qs but with no sid', () => {
+		const qs = "?other=w";
+
+		it("getSidFromNodeUrl finds w12", () => {
+			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrlQS finds w12", () => {
+			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBeUndefined();
+		});
+	});
+
+	describe('has totally empty qs', () => {
+		const qs = "?";
+
+		it("getSidFromNodeUrl finds w12", () => {
+			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrlQS finds w12", () => {
+			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBeUndefined();
+		});
+	});
+
+	describe('has no qs', () => {
+		const qs = "";
+
+		it("getSidFromNodeUrl finds w12", () => {
+			expect(getSidFromNodeUrl(parse(`http://s${qs}`))).toBeUndefined();
+		});
+
+		it("getSidFromNodeUrlQS finds w12", () => {
+			expect(getSidFromNodeUrlQS(parse(`http://s${qs}`))).toBeUndefined();
+		});
+	});
+});
+

--- a/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.ts
+++ b/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.ts
@@ -1,0 +1,25 @@
+// License: LGPL-3.0-or-later
+import {UrlWithStringQuery as NodeUrl} from 'url';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const queryString = require('query-string');
+
+/**
+ * @deprecated
+ */
+
+export function getSidFromNodeUrlQS(url:NodeUrl): string | undefined {
+	return queryString.parse(url.search).sid as string | undefined;
+}
+
+/**
+ *
+ * @param url
+ * @return The value if it exists or undefined (to be consistent with the previous implementation)
+ */
+export function getSidFromNodeUrl(url:NodeUrl): string | undefined {
+	const result = new URLSearchParams(url.search).get("sid");
+	return result === null ? undefined : result;
+}
+
+export default getSidFromNodeUrl;

--- a/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.ts
+++ b/app/javascript/legacy/nonprofits/supporters/index/sidepanel/backport-query-string.ts
@@ -8,7 +8,7 @@ const queryString = require('query-string');
  * @deprecated
  */
 
-export function getSidFromNodeUrlQS(url:NodeUrl): string | undefined {
+export function getSidFromNodeUrlQS(url:NodeUrl| URL): string | undefined {
 	return queryString.parse(url.search).sid as string | undefined;
 }
 
@@ -17,7 +17,7 @@ export function getSidFromNodeUrlQS(url:NodeUrl): string | undefined {
  * @param url
  * @return The value if it exists or undefined (to be consistent with the previous implementation)
  */
-export function getSidFromNodeUrl(url:NodeUrl): string | undefined {
+export function getSidFromNodeUrl(url:NodeUrl | URL ): string | undefined {
 	const result = new URLSearchParams(url.search).get("sid");
 	return result === null ? undefined : result;
 }

--- a/app/javascript/legacy/nonprofits/supporters/index/sidepanel/index.js
+++ b/app/javascript/legacy/nonprofits/supporters/index/sidepanel/index.js
@@ -8,7 +8,6 @@ const filter = require('flyd/module/filter')
 const snabbdom = require('snabbdom')
 const mergeAll = require('flyd/module/mergeall')
 const sampleOn = require('flyd/module/sampleon')
-const queryString = require('query-string')
 const notification = require('ff-core/notification')
 
 const request = require('../../../../common/request')
@@ -20,6 +19,8 @@ const offsiteDonationForm = require('./offsite-donation-form')
 const supporterNoteForm = require('./supporter-note-form')
 
 const flatMap = R.curry(require('flyd/module/flatmap'))
+
+const getSidFromNodeUrl = require('./backport-query-string').default;
 
 const init = _ => {
   var state = {
@@ -33,7 +34,7 @@ const init = _ => {
 
   const supporterID$ = R.compose(
     filter(Boolean )
-  , flyd.map(url => queryString.parse(url.search).sid)
+  , flyd.map(url => getSidFromNodeUrl(url))
   )(url$)
 
   state.pathPrefix$ = flyd.map(constructPathPrefix, supporterID$)


### PR DESCRIPTION
querystring isn't needed anymore as `URLSearchParams` exists. I've created an and added an implementation using USP and created specs for verifying it's actually compatible.
