### PR TITLE
Add limited types for flyd which aren't included in version we use

### DIFF
--- a/types/flyd/index.d.ts
+++ b/types/flyd/index.d.ts
@@ -1,0 +1,32 @@
+// License: MIT
+// from https://github.com/paldepind/flyd/blob/master/index.d.ts
+
+/* eslint-disable @typescript-eslint/member-ordering */
+
+declare namespace flyd {
+	interface Stream<T> {
+    (): T;
+    (value: T): Stream<T>;
+    (value: Promise<T> | PromiseLike<T>): Stream<T>;
+
+    end: Stream<boolean>;
+  }
+
+	interface CreateStream {
+    <T>(): Stream<T>;
+    <T>(value: T): Stream<T>;
+    <T>(value: Promise<T> | PromiseLike<T>): Stream<T>;
+    (): Stream<void>;
+  }
+
+	interface Static {
+		stream: CreateStream;
+	}
+}
+
+
+declare module 'flyd' {
+  const f: flyd.Static;
+  export = f;
+}
+


### PR DESCRIPTION
To date, we haven't had any types for `flyd` which prevents us from using it in Typescript. flyd has types in later versions. We could upgrade flyd BUT long term, we don't want to use it. At the same time, there are advantages to having some types for flyd.

This PR backports a subset of the flyd typings from later version of flyd. I wouldn't rely on these too heavily but they're better than nothing.
