### PR TITLE
Run babel-plugin-transform-imports on production, not development

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -84,7 +84,7 @@ module.exports = function(api) {
           removeImport: true,
         },
       ],
-      isDevelopmentEnv && [
+      isProductionEnv && [
         'babel-plugin-transform-imports',
         {
           '@material-ui/core': {


### PR DESCRIPTION
[babel-plugin-transform-imports](https://www.npmjs.com/package/babel-plugin-transform-imports) converts inputs like:

Transforms member style imports:

```typescript
import { Row, Grid as MyGrid } from 'react-bootstrap';
import { merge } from 'lodash';
```

...into default style imports:

```typescript
import Row from 'react-bootstrap/lib/Row';
import MyGrid from 'react-bootstrap/lib/Grid';
import merge from 'lodash/merge';
```

This prevents the full library being loaded which would happen when you import by member.

This should have been only running on production but it was actually only running on development. This addresses that issue.
