### PR TITLE
Add lodash to babel-plugin-transform-imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -84,7 +84,7 @@ module.exports = function(api) {
           removeImport: true,
         },
       ],
-      isDevelopmentEnv && [
+      isProductionEnv && [
         'babel-plugin-transform-imports',
         {
           '@material-ui/core': {

--- a/babel.config.js
+++ b/babel.config.js
@@ -94,6 +94,10 @@ module.exports = function(api) {
           '@material-ui/icons': {
             'transform': '@material-ui/icons/esm/${member}',
             'preventFullImport': true
+          },
+          "lodash": {
+            "transform": "lodash/${member}",
+            "preventFullImport": true
           }
         }
       ]


### PR DESCRIPTION
This change will convert:

```typescript
import {merge} from 'lodash;
```

...to:

```typescript
import merge from 'lodash/merge';
```

This prevents all of lodash from being loaded on a build and instead imports just the merge module.
