### PR TITLE
Entire bounding box of a Side Nav link is clickable

### DIFF
--- a/app/assets/stylesheets/components/side_nav.css.scss
+++ b/app/assets/stylesheets/components/side_nav.css.scss
@@ -46,8 +46,7 @@ $sideNav-spacing: 8px 15px;
 	color: white;
 	font-weight: bold;
 	cursor: pointer;
-	display: table;
-	table-layout: fixed;
+	display: block;
 	@include transform(translateZ(0));
 	@include transition(color 0.2s ease-out);
 }


### PR DESCRIPTION
Previously, the background of the bounding box for links in the side nav wasn't clickable. This mean you have to be pointing at the icon or text. That's annoying as h*ck.

This changes the layout for side nav links to "block". Now, the entire bounding box if clickable.
