### PR TITLE
Add erb-lint

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,7 +1,7 @@
 ---
 exclude:
   - '**/.github/**/*'
-  - '**/.stotybook/**/*'
+  - '**/.storybook/**/*'
   - '**/node_modules/**/*'
 linters:
   Rubocop:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,11 @@
+---
+exclude:
+  - '**/.github/**/*'
+  - '**/.stotybook/**/*'
+  - '**/node_modules/**/*'
+linters:
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml

--- a/Gemfile
+++ b/Gemfile
@@ -72,6 +72,7 @@ group :development, :ci, :test do
   gem 'rubocop-rspec', '~> 2.12'
   gem 'shoulda-matchers', '~> 5.1.0'
   gem 'turbo_test'
+  gem 'erb_lint', require: false
 end
 
 group :ci, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,14 @@ GEM
     async-io (1.32.2)
       async
     bcrypt (3.1.16)
+    better_html (1.0.16)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     bootsnap (1.12.0)
       msgpack (~> 1.2)
     builder (3.2.4)
@@ -164,6 +172,14 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
+    erb_lint (0.1.3)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.10.0)
     et-orbi (1.2.5)
       tzinfo
@@ -192,6 +208,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashdiff (1.0.1)
+    html_tokenizer (0.0.7)
     htmlentities (4.3.4)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -403,6 +420,7 @@ GEM
       activesupport (>= 5.2.0)
     simple_po_parser (1.1.6)
     sixarm_ruby_unaccent (1.2.0)
+    smart_properties (1.17.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -473,6 +491,7 @@ DEPENDENCIES
   devise (~> 4.8)
   devise-async (~> 1.0)
   dotenv-rails (~> 2.7, >= 2.7.5)
+  erb_lint
   factory_bot (~> 6.2)
   factory_bot_rails (~> 6.2)
   fast_blank

--- a/NOTICE-ruby
+++ b/NOTICE-ruby
@@ -1798,6 +1798,34 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
+** html_tokenizer; version 0.0.7 -- 
+Copyright (c) 2016 Francois Chagnon
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Francois Chagnon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+------
+
 ** loofah; version 2.18.0 -- 
 Copyright (c) 2006-2008 The Authors
 Copyright (c) 2009 2018 by Mike Dalessio, Bryan Helmkamp
@@ -3125,6 +3153,7 @@ Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
 Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
 Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
 Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+** better_html; version 1.0.16 -- 
 ** console; version 1.13.1 -- 
 Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
 Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
@@ -3133,6 +3162,8 @@ Copyright (c) 2004-2008 David Heinemeier Hansson
 ** css_parser; version 1.9.0 -- 
 Copyright (c) 2007-11 Alex Dunae
 ** database_cleaner; version 1.99.0 -- 
+** erb_lint; version 0.1.3 -- 
+Copyright (c) 2012-18 Bozhidar Batsov
 ** fiber-local; version 1.0.0 -- 
 Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
 ** http_accept_language; version 2.1.1 -- 
@@ -3554,6 +3585,34 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
+
+------
+
+** smart_properties; version 1.17.0 -- 
+Copyright (c) 2012 Konstantin Tennhard
+
+Copyright (c) 2012 Konstantin Tennhard
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 


### PR DESCRIPTION
### Description:
Add erb-lin to help lint ERB or HTML files.

Closes https://github.com/houdiniproject/houdini/issues/510
Co-authored-by: luisgfmarques [luisgustavomarques@outlook.com](luisgustavomarques@outlook.com)

### Motivation for implementing it:
This tool will help lint using the included linters or by writing your own.

### Solution summary:
* Added the  following to the `Gemfile` and run `bundle install`:
```bash
gem 'erb_lint', require: false
```
* Created a `.erb-lint.yml` file, with the following structure:
```bash
---
exclude:
  - '**/.github/**/*'
  - '**/.stotybook/**/*'
  - '**/node_modules/**/*'
linters:
  Rubocop:
    enabled: true
    rubocop_config:
      inherit_from:
        - .rubocop.yml
 ```
### How to run it:
* At the first time run `bundle install` for install the dependencies specified in the Gemfile.
* Run `bundle exec erblint --lint-all --enable-all-linters` to run all available linters on all ERB files in the current directory or its descendants.