### PR TITLE
Change Cron job rake name

### DIFF
--- a/app/legacy_lib/scheduled_jobs.rb
+++ b/app/legacy_lib/scheduled_jobs.rb
@@ -6,7 +6,7 @@
 module ScheduledJobs
   # Each of these functions should return an Enumerator
   # Each value in the enumerator should be a lambda
-  # That way the heroku_scheduled_job task can iterate over each lambda
+  # That way the cron_job_runner task can iterate over each lambda
   # and wrap each call in begin/rescue/end blocks
   # and it can continue to execute all the parts of the job without bailing early, even if one part of the job fails
   # And it will aggregate success/failure messages from all the lambdas in the enum

--- a/docs/payments.md
+++ b/docs/payments.md
@@ -13,7 +13,7 @@ as seen under the details of a payment within the "Payments" section.
 
 Payment statuses in Houdini are updated by the batch job
 `update_np_balances`. This can be called from the command-line with `bin/rails
-heroku_scheduled_job[update_np_balances]`, though is best configured to run once
+cron_job_runner[update_np_balances]`, though is best configured to run once
 daily through a scheduling system such as cron.
 
 *Note*: Currently the `update_np_balances` job will fail silently unless you

--- a/lib/tasks/legacy_scheduler.rake
+++ b/lib/tasks/legacy_scheduler.rake
@@ -1,0 +1,8 @@
+desc "This task is deprecated and serve only as an alias for cron_job_runner"
+
+# This task exists only for legacy reasons, use cron_job_runner to run ScheduledJobs instead
+
+task :heroku_scheduled_job, [:name] => :environment do |_t, args|
+    job_name = args[:name]
+    Rake::Task["cron_job_runner"].invoke(job_name)
+end

--- a/lib/tasks/legacy_scheduler.rake
+++ b/lib/tasks/legacy_scheduler.rake
@@ -1,8 +1,10 @@
-desc "This task is deprecated and serve only as an alias for cron_job_runner"
+# frozen_string_literal: true
+
+desc 'This task is deprecated and serve only as an alias for cron_job_runner'
 
 # This task exists only for legacy reasons, use cron_job_runner to run ScheduledJobs instead
 
 task :heroku_scheduled_job, [:name] => :environment do |_t, args|
-    job_name = args[:name]
-    Rake::Task["cron_job_runner"].invoke(job_name)
+	job_name = args[:name]
+	Rake::Task['cron_job_runner'].invoke(job_name)
 end

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -3,10 +3,10 @@
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
 
-desc "For use with Heroku's Scheduler add-on"
+desc "Task used to run any ScheduledJob"
 
 # We use a single rake call so we can catch and send any errors that happen in the job
-task :heroku_scheduled_job, [:name] => :environment do |_t, args|
+task :cron_job_runner, [:name] => :environment do |_t, args|
   job_name = args[:name]
   # Fetch all the super admin emails so we can send a report
   enum = ScheduledJobs.send(job_name)

--- a/script/crontab.sh
+++ b/script/crontab.sh
@@ -3,4 +3,4 @@ echo "TEST"
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )" ## root folder of the CC install
 source "$HOME/.rvm/scripts/rvm" # $HOME is the user that runs the rail app... and rake
 cd $DIR
-bin/rails heroku_scheduled_job[pay_recurring_donations]
+bin/rails cron_job_runner[pay_recurring_donations]


### PR DESCRIPTION
## Description
Change cron job runner name to a more generic one.

Closes #123 
Co-authored-by: Giuulob89 giulialobo89@gmail.com

## Motivation for implementing it
The name used to be ```heroku_scheduled_job``` due to historical reasons and should be more generic.

## Solution summary:
* We changed the name from ```heroku_scheduled_job``` to ```cron_job_runner``` and updated all old references of it:

```rb
task :cron_job_runner, [:name] => :environment do |_t, args|
```

* Now to run the task the command is (using pay_recurring_donations job as example):
```sh
$ bin/rails cron_job_runner[pay_recurring_donations]
```
