### PR TITLE
Convert nonprofits.achievements and .categories to jsonb

### DIFF
--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -137,9 +137,6 @@ class Nonprofit < ApplicationRecord
   has_one_attached_with_default(:third_image, Houdini.defaults.image.profile, 
     filename: "third_image_#{SecureRandom.uuid}#{Pathname.new(Houdini.defaults.image.profile).extname}")
 
-  serialize :achievements, Array
-  serialize :categories, Array
-
 
 
   before_validation(on: :create) do

--- a/db/migrate/20220713192154_add_modern_achievements.rb
+++ b/db/migrate/20220713192154_add_modern_achievements.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+class AddModernAchievements < ActiveRecord::Migration[6.1]
+  module TemporaryConcern
+    extend ActiveSupport::Concern
+
+	  included do
+      serialize :achievements, Array
+      serialize :categories, Array
+    end
+  end
+  def change
+
+    add_column :nonprofits, :achievements_json, :jsonb
+    add_column :nonprofits, :categories_json, :jsonb
+
+    reversible do |dir|
+      dir.up do
+        Nonprofit.include(::AddModernAchievements::TemporaryConcern)
+        Nonprofit.find_each do |np|
+          np.achievements_json = np.achievements
+          unless np.save
+            puts "NP ##{np.id} could not be saved"
+            np.save(validate:false)
+          end
+          np.reload
+          
+          raise "NP ##{np.id} does not have identical values" if np.achievements_json != np.achievements
+        end
+      end
+    end
+    
+    rename_column :nonprofits, :achievements, :achievements_legacy
+    rename_column :nonprofits, :categories, :categories_legacy
+
+    rename_column :nonprofits, :achievements_json, :achievements
+    rename_column :nonprofits, :categories_json, :categories
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -557,10 +557,10 @@ ActiveRecord::Schema.define(version: 2022_07_13_204458) do
     t.string "background_image", limit: 255
     t.string "logo", limit: 255
     t.text "summary"
-    t.text "categories"
+    t.text "categories_legacy"
     t.string "ein", limit: 255
     t.text "full_description"
-    t.text "achievements"
+    t.text "achievements_legacy"
     t.string "state_code", limit: 255
     t.string "city", limit: 255
     t.string "slug", limit: 255
@@ -592,6 +592,8 @@ ActiveRecord::Schema.define(version: 2022_07_13_204458) do
     t.text "fields_needed"
     t.boolean "autocomplete_supporter_address", default: false
     t.string "currency", limit: 255, default: "usd"
+    t.jsonb "achievements"
+    t.jsonb "categories"
   end
 
   create_table "object_event_hook_configs", force: :cascade do |t|


### PR DESCRIPTION
After CVE-2022-32224, I looked at where we use `.serialize`. We used it in a few places in `Nonprofit`. Serialize is kind of unnecessary; if we use jsonb columns then we get serialization for "free". That makes the most sense I think so this change migrates to using jsonb for those columns.
