### PR TITLE
Remove unused functions in application_view

### DIFF
--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -111,12 +111,6 @@ appl.def('readable_date_time_to_iso', date => {
     .toISOString()
 })
 
-// Get the month number (eg 01,02...) for the given date string (or moment obj)
-appl.def('get_month', function(date) {
-  var monthNum = moment(date).month()
-  return moment().month(monthNum).format('MMM')
-})
-
 // Get the year (eg 2017) for the given date string (or moment obj)
 appl.def('get_year', function(date) {
 	return moment(date).year()

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -327,10 +327,6 @@ appl.def('number_with_commas', function(n){
 	return utils.number_with_commas(n)
 })
 
-appl.def('remove_commas', function(s) {
-  return s.replace(/,/g, '')
-})
-
 appl.def('percentage', function(x, y, number_of_decimals){
   if(!x || !y) return 0
   number_of_decimals = number_of_decimals || 2

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -278,8 +278,6 @@ appl.transform = function(name, fn) {
 	return result
 }
 
-// Return the current URL path
-appl.def('pathname', function() { return window.location.pathname })
 // Return the root url
 appl.def('root_url', function() { return window.location.origin })
 

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -111,12 +111,6 @@ appl.def('readable_date_time_to_iso', date => {
     .toISOString()
 })
 
-// Get the year (eg 2017) for the given date string (or moment obj)
-appl.def('get_year', function(date) {
-	return moment(date).year()
-})
-
-
 // Get the percentage of x over y
 // eg: appl.percentage(34, 69) -> "49.28%"
 appl.def('percentage', function(x, y) {

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -116,11 +116,6 @@ appl.def('get_year', function(date) {
 	return moment(date).year()
 })
 
-// Get the day (number in the month) for the given date string (or moment obj)
-appl.def('get_day', function(date) {
-	return moment(date).date()
-})
-
 
 // Get the percentage of x over y
 // eg: appl.percentage(34, 69) -> "49.28%"

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -310,20 +310,6 @@ appl.def('head', function(arr) {
 	return arr[0]
 })
 
-appl.def('select_drop_down', function(node) {
-	var $li = $(node).parent()
-	var $dropDown = $li.parents('.dropDown')
-	$dropDown.find('li').removeClass('is-selected')
-	$dropDown.find('.dropDown-toggle').removeClass('is-droppedDown')
-	$li.addClass('is-selected')
-})
-
-appl.def('clear_drop_down', function(node){
-	var $dropDown = $(node).parents('.dropDown')
-	$dropDown.find('li').removeClass('is-selected')
-	$dropDown.find('.dropDown-toggle').removeClass('is-droppedDown')
-})
-
 appl.def('strip_tags', function(html){
 	if(!html) return
 	return html.replace(/(<([^>]+)>)/ig," ")

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -288,11 +288,6 @@ appl.def('trigger_update', function(prop) {
 	return appl.def(prop, appl.vs(prop))
 })
 
-
-appl.def('snake_case', function(string) {
-	return string.replace(/ /g,'_')
-})
-
 appl.def('sort_arr_of_objs_by_key', function(arr_of_objs, key) {
 	return arr_of_objs.sort(function(a, b) {
   	return a[key].localeCompare(b[key]);

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -155,19 +155,6 @@ appl.def('concat', function(arr1_key, arr2, node) {
 })
 
 
-// Merge all key/vals from set_obj into all objects in the array given by the property 'arr_key'
-// eg:
-// appl.def('arr_of_objs', [{id: 1, name: 'Bob'}, {id: 2, name: 'Holga'}]
-// appl.update_all('arr_of_objs', {name: 'Morty'})
-// appl.arr_of_objs == [{id: 1, name: 'Morty'}, {id: 2, name: 'Morty'}]
-appl.def('update_all', function(arr_key, set_obj, node) {
-	appl.def(arr_key, appl.vs(arr_key).map(function(obj) {
-		for(var key in set_obj) obj[key] = set_obj[key]
-		return obj
-	}))
-})
-
-
 // Given an array of objects in the view state (with property name 'arr_key'),
 // and given an object to match on ('obj_matcher'),
 // and given an object with values to set ('set_obj'),

--- a/app/javascript/legacy/common/application_view.js
+++ b/app/javascript/legacy/common/application_view.js
@@ -124,12 +124,6 @@ appl.def('percentage', function(x, y) {
 // appl.pluralize(1, 'donors') -> "1 donor"
 appl.def('pluralize', pluralize)
 
-// Truncate a text and add ellipsis to the end
-appl.def('append_ellipsis', function(text, length) {
-	if(text.length <= length) return text
-	return text.slice(0,length).replace(/ [^ ]+$/, ' ...')
-})
-
 
 // General viewscript utilities
 // All of these are to be added to the actual viewscript package in the future


### PR DESCRIPTION
This is legacy code that we don't want to use long term. To simplify migration, we eliminate things from it that we don't use.

- Remove appl.snake_case
- Remove appl.pathname
- Remove appl.select_drop_down and .clear_drop_down
- Remove appl.remove_commas
- Remove appl.get_month
- Remove appl.get_day
- Remove appl.get_year
- Remove appl.remove_ellipsis
- Remove appl.update_all
