### PR TITLE
Remove unused vjf rules

### DIFF
--- a/app/javascript/legacy_react/src/lib/vjf_rules.ts
+++ b/app/javascript/legacy_react/src/lib/vjf_rules.ts
@@ -19,14 +19,10 @@ interface Validation {
 
 
 export class Validations  {
-  static isEmail({field}:ValidationInput) : StringBoolTuple {
-    return [field.value.match(Regex.Email) !== null,
-      `${field.label} is not a valid email`]
-  }
 
   static isGreaterThanOrEqualTo(value:number) : ({field, validator}:ValidationInput) => StringBoolTuple
   {
-    return ({field, validator}:ValidationInput) => {
+    return ({field}:ValidationInput) => {
       return [
         parseFloat(field.get('value')) >= value,
         `${field.label} must be at least ${value}`
@@ -36,7 +32,7 @@ export class Validations  {
 
   static isLessThanOrEqualTo(value:number, flip:boolean=false) : ({field, validator}:ValidationInput) => StringBoolTuple
   {
-    return ({field, validator}:ValidationInput) => {
+    return ({field}:ValidationInput) => {
       let float = field.get('value')
       return [
         (flip ? -1 * float : float) <= value,
@@ -55,9 +51,12 @@ export class Validations  {
       }
     };
   }
-
+  static isEmail({field}:ValidationInput) : StringBoolTuple {
+    return [field.value.match(Regex.Email) !== null,
+      `${field.label} is not a valid email`]
+  }
   static isDate(format:string): ({field, validator}:ValidationInput) => StringBoolTuple  {
-    return ({field, validator}:ValidationInput) => {
+    return ({field}:ValidationInput) => {
       let m = moment(field.value, format, true);
       return [
         m.isValid(),

--- a/app/javascript/legacy_react/src/lib/vjf_rules.ts
+++ b/app/javascript/legacy_react/src/lib/vjf_rules.ts
@@ -24,11 +24,6 @@ export class Validations  {
       `${field.label} is not a valid email`]
   }
 
-  static isUrl({field, validator}:ValidationInput):StringBoolTuple {
-    return [validator.isURL(field.value),
-    `${field.label} must be a valid URL`]
-  }
-
   static isFilled({field, validator}:ValidationInput) :StringBoolTuple {
     return [
         !validator.isEmpty(field.value),

--- a/app/javascript/legacy_react/src/lib/vjf_rules.ts
+++ b/app/javascript/legacy_react/src/lib/vjf_rules.ts
@@ -31,14 +31,6 @@ export class Validations  {
     ]
   }
 
-  static isNumber({field, validator}:ValidationInput):StringBoolTuple {
-    return [
-      !isNaN(parseFloat(field.value)),
-      `${field.label} must be a number`
-    ]
-  }
-
-
   static isGreaterThanOrEqualTo(value:number) : ({field, validator}:ValidationInput) => StringBoolTuple
   {
     return ({field, validator}:ValidationInput) => {

--- a/app/javascript/legacy_react/src/lib/vjf_rules.ts
+++ b/app/javascript/legacy_react/src/lib/vjf_rules.ts
@@ -24,13 +24,6 @@ export class Validations  {
       `${field.label} is not a valid email`]
   }
 
-  static shouldBeEqualTo (targetPath: string): Validation {
-    return ({field, form}:ValidationInput) => {
-      const fieldsAreEquals = (form.$(targetPath).value === field.value);
-      return [fieldsAreEquals, `${field.label} and ${form.$(targetPath).label} must be the same`]
-  }
-  }
-
   static isUrl({field, validator}:ValidationInput):StringBoolTuple {
     return [validator.isURL(field.value),
     `${field.label} must be a valid URL`]

--- a/app/javascript/legacy_react/src/lib/vjf_rules.ts
+++ b/app/javascript/legacy_react/src/lib/vjf_rules.ts
@@ -24,13 +24,6 @@ export class Validations  {
       `${field.label} is not a valid email`]
   }
 
-  static isFilled({field, validator}:ValidationInput) :StringBoolTuple {
-    return [
-        !validator.isEmpty(field.value),
-      `${field.label} must be filled out`
-    ]
-  }
-
   static isGreaterThanOrEqualTo(value:number) : ({field, validator}:ValidationInput) => StringBoolTuple
   {
     return ({field, validator}:ValidationInput) => {


### PR DESCRIPTION
A number of validations aren't actually used. This removes them.

- Remove shouldBeEqualTo validation
- Remove unused isURL validation
- Remove unused isNumber validation
- Remove unused isFilled validation
- Remove some unused property expansions
