### PR TITLE
Remove unneed jest imports

### DIFF
--- a/app/javascript/legacy_react/src/components/common/LabeledFieldComponent.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/LabeledFieldComponent.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import {shallow} from 'enzyme'
 import toJson from 'enzyme-to-json'
 import LabeledFieldComponent from './LabeledFieldComponent'

--- a/app/javascript/legacy_react/src/components/common/Modal.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/Modal.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import Modal, {ModalProps} from './Modal'
 import {shallow, mount, ReactWrapper} from "enzyme";
 import toJson from "enzyme-to-json";

--- a/app/javascript/legacy_react/src/components/common/ProgressableButton.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/ProgressableButton.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import ProgressableButton from './ProgressableButton'
 import toJson from 'enzyme-to-json';
 import {mount, shallow} from 'enzyme';

--- a/app/javascript/legacy_react/src/components/common/StandardFieldComponent.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/StandardFieldComponent.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import {shallow} from 'enzyme'
 import StandardFieldComponent from './StandardFieldComponent'
 import toJson from 'enzyme-to-json';

--- a/app/javascript/legacy_react/src/components/common/form/ReactInput.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/form/ReactInput.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import ReactInput from './ReactInput'
 import {Form} from "mobx-react-form";
 import {mount} from 'enzyme';

--- a/app/javascript/legacy_react/src/components/common/form/ReactSelect.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/form/ReactSelect.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import {Form} from "mobx-react-form";
 import ReactInput from "./ReactInput";
 import {ReactForm} from "./ReactForm";

--- a/app/javascript/legacy_react/src/components/common/form/ReactTextarea.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/form/ReactTextarea.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import {Form} from "mobx-react-form";
 import {ReactForm} from "./ReactForm";
 import {action, observable, toJS} from 'mobx';

--- a/app/javascript/legacy_react/src/components/common/layout.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/layout.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import Modal, { ModalProps } from './Modal'
 import { shallow, mount, ReactWrapper } from "enzyme";
 import toJson from "enzyme-to-json";

--- a/app/javascript/legacy_react/src/components/common/selectable_table_row/SelectableTableRow.spec.tsx
+++ b/app/javascript/legacy_react/src/components/common/selectable_table_row/SelectableTableRow.spec.tsx
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as React from 'react';
-import 'jest';
 import SelectableTableRow from './SelectableTableRow'
 import { ReactWrapper, mount } from 'enzyme';
 import { connectTableRowSelectHandler, TableRowSelectHandlerContext } from './connect';

--- a/app/javascript/legacy_react/src/lib/api_manager.spec.ts
+++ b/app/javascript/legacy_react/src/lib/api_manager.spec.ts
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import {ApiManager, ApiMissingException} from "./api_manager";
-import 'jest';
 
 describe('ApiManager', () => {
 

--- a/app/javascript/legacy_react/src/lib/format.spec.ts
+++ b/app/javascript/legacy_react/src/lib/format.spec.ts
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as Format from './format'
-import 'jest';
 
 
 describe('Format.dollarsToCents', () => {

--- a/app/javascript/legacy_react/src/lib/payments/credit_card.spec.ts
+++ b/app/javascript/legacy_react/src/lib/payments/credit_card.spec.ts
@@ -1,7 +1,6 @@
 // License: LGPL-3.0-or-later
 // based on https://github.com/stripe/jquery.payment/blob/master/test/specs.coffee
 import { CreditCardTypeManager, defaultFormat } from './credit_card'
-import 'jest';
 import _ from 'lodash';
 
 describe('CreditCardTypeManager', () => {

--- a/app/javascript/legacy_react/src/lib/regex.spec.ts
+++ b/app/javascript/legacy_react/src/lib/regex.spec.ts
@@ -1,6 +1,5 @@
 // License: LGPL-3.0-or-later
 import * as Regex from './regex'
-import 'jest';
 
 
 describe('Regex.Email', () => {


### PR DESCRIPTION
A number of jest tests have a jest import. This isn't needed because jest automatically imports itself on run. This removes those imports.

Depends on #1267