### PR TITLE
Use nonprofit currency symbol on donation queries

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,9 +15,9 @@ module ApplicationHelper
     @devise_mapping ||= Devise.mappings[:user]
   end
 
-  def print_currency(cents, unit = 'EUR', sign = true)
+  def print_currency(cents, unit = 'EUR', sign = true, use_precision = false)
     dollars = cents.to_f / 100.0
-    dollars = number_to_currency(dollars, unit: unit.to_s, precision: dollars.round == dollars ? 0 : 2)
+    dollars = number_to_currency(dollars, unit: unit.to_s, precision: !use_precision && dollars.round == dollars ? 0 : 2)
     dollars = dollars[1..-1] unless sign
     dollars
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -16,10 +16,7 @@ module ApplicationHelper
   end
 
   def print_currency(cents, unit = 'EUR', sign = true, use_precision = false)
-    dollars = cents.to_f / 100.0
-    dollars = number_to_currency(dollars, unit: unit.to_s, precision: !use_precision && dollars.round == dollars ? 0 : 2)
-    dollars = dollars[1..-1] unless sign
-    dollars
+    Format::Currency.print_currency(cents, unit, sign, use_precision)
   end
 
   def print_percent(rate)

--- a/app/legacy_lib/format/currency.rb
+++ b/app/legacy_lib/format/currency.rb
@@ -23,6 +23,12 @@ module Format
                              .gsub(/^(\d+)\.(\d)$/, '\1.\20') # add a second zero if single decimal (eg. "9.9" -> "9.90")
     end
 
+    # Print money based on informed currency
+    # @param [Integer] cents the amount of money to be printed
+    # @param [String] unit the currency that will be used to print
+    # @param [Boolean] sign whether it should show the sign of the amount
+    # @param [Boolean] use_precision whether it should have two decimal cases
+    # @return [String] the text with the amount of money in the informed currency (Ex.: $10.00)
     def self.print_currency(cents, unit = 'EUR', sign = true, use_precision = false)
       dollars = cents.to_f / 100.0
       dollars = number_to_currency(dollars, unit: unit.to_s, precision: !use_precision && dollars.round == dollars ? 0 : 2)

--- a/app/legacy_lib/format/currency.rb
+++ b/app/legacy_lib/format/currency.rb
@@ -4,6 +4,9 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
 module Format
   module Currency
+    class << self
+      include ActiveSupport::NumberHelper
+    end
     # Converts currency units into subunits.
     # @param [String] units
     # @return [Integer]
@@ -18,5 +21,12 @@ module Format
       (subunits.to_f / 100.0).to_s
                              .gsub(/^(\d+)\.0$/, '\1') # remove trailing zero if no decimals (eg. "1.0" -> "1")
                              .gsub(/^(\d+)\.(\d)$/, '\1.\20') # add a second zero if single decimal (eg. "9.9" -> "9.90")
+    end
+
+    def self.print_currency(cents, unit = 'EUR', sign = true, use_precision = false)
+      dollars = cents.to_f / 100.0
+      dollars = number_to_currency(dollars, unit: unit.to_s, precision: !use_precision && dollars.round == dollars ? 0 : 2)
+      dollars = dollars[1..-1] unless sign
+      dollars
     end
 end; end

--- a/app/legacy_lib/format/currency.rb
+++ b/app/legacy_lib/format/currency.rb
@@ -4,9 +4,6 @@
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
 module Format
   module Currency
-    class << self
-      include ActiveSupport::NumberHelper
-    end
     # Converts currency units into subunits.
     # @param [String] units
     # @return [Integer]
@@ -31,7 +28,7 @@ module Format
     # @return [String] the text with the amount of money in the informed currency (Ex.: $10.00)
     def self.print_currency(cents, unit = 'EUR', sign = true, use_precision = false)
       dollars = cents.to_f / 100.0
-      dollars = number_to_currency(dollars, unit: unit.to_s, precision: !use_precision && dollars.round == dollars ? 0 : 2)
+      dollars = ActiveSupport::NumberHelper.number_to_currency(dollars, unit: unit.to_s, precision: !use_precision && dollars.round == dollars ? 0 : 2)
       dollars = dollars[1..-1] unless sign
       dollars
     end

--- a/app/legacy_lib/query_donations.rb
+++ b/app/legacy_lib/query_donations.rb
@@ -5,10 +5,8 @@
 
 module QueryDonations
   # Export all donation data for a given campaign
-
   def self.campaign_export(campaign_id)
-    nonprofit_id = Campaign.find(campaign_id).nonprofit_id
-    currency = Nonprofit.find(nonprofit_id).currency_symbol
+    currency = Campaign.find(campaign_id).nonprofit.currency_symbol
 
     result = Psql.execute_vectors(
       Qexpr.new.select([
@@ -103,6 +101,7 @@ module QueryDonations
   end
 
   def self.update_amount_with_currency(query_row, currency)
+    # Skip header row
     if query_row[1].to_s.downcase != 'amount'
       query_row[1] = Format::Currency.print_currency(query_row[1], currency, true, true)
     end

--- a/app/legacy_lib/query_donations.rb
+++ b/app/legacy_lib/query_donations.rb
@@ -5,10 +5,6 @@
 
 module QueryDonations
   # Export all donation data for a given campaign
-  class << self
-    include ApplicationHelper
-    include ActionView::Helpers::NumberHelper
-  end
 
   def self.campaign_export(campaign_id)
     nonprofit_id = Campaign.find(campaign_id).nonprofit_id
@@ -108,7 +104,7 @@ module QueryDonations
 
   def self.update_amount_with_currency(query_row, currency)
     if query_row[1].to_s.downcase != 'amount'
-      query_row[1] = print_currency(query_row[1], currency, true, true)
+      query_row[1] = Format::Currency.print_currency(query_row[1], currency, true, true)
     end
     query_row
   end

--- a/app/legacy_lib/query_recurring_donations.rb
+++ b/app/legacy_lib/query_recurring_donations.rb
@@ -5,11 +5,6 @@
 
 module QueryRecurringDonations
   # Calculate a nonprofit's total recurring donations
-  class << self
-    include ApplicationHelper
-    include ActionView::Helpers::NumberHelper
-  end 
-
   def self.calculate_monthly_donation_total(np_id)
     Qx.select('coalesce(sum(amount), 0) AS sum')
       .from('recurring_donations')
@@ -311,7 +306,7 @@ module QueryRecurringDonations
 
   def self.update_amount_with_currency(query_row, currency)
     if query_row[1] != 'Amount'
-      query_row[1] = print_currency(query_row[1], currency, true, true)
+      query_row[1] = Format::Currency.print_currency(query_row[1], currency, true, true)
     end
     query_row
   end

--- a/app/legacy_lib/query_recurring_donations.rb
+++ b/app/legacy_lib/query_recurring_donations.rb
@@ -305,6 +305,7 @@ module QueryRecurringDonations
   end
 
   def self.update_amount_with_currency(query_row, currency)
+    # Skip header row
     if query_row[1] != 'Amount'
       query_row[1] = Format::Currency.print_currency(query_row[1], currency, true, true)
     end


### PR DESCRIPTION
## Description
Uses the nonprofit currency symbol to display the amount of money on donation queries

Closes #1235
Co-authored-by: Giulia Lobo <giulialobo89@gmail.com>

## Motivation to implement it
The amount of money was being displayed based on the currency configured on postgres by using postgres type cast to money:

```ruby
 Qexpr.new.select([
        'donations.created_at',
        '(payments.gross_amount/100.00)::money::text AS amount',
        'COUNT(recurring_donations.id) > 0 AS recurring',
        "STRING_AGG(campaign_gift_options.name, ',') AS campaign_gift_names"
      ]...
```

Because of this, the `rails spec` command ended up failing in systems with different currency from USD, the right behavior in this cases is to use the nonprofit currency symbol instead of postgres type cast.

## Solution summary
Instead of using postgres type cast, we decided to use the `print_currency` existing function from ApplicationHelper, for that we used map based on the query results to change the amount to the currency string displayed.

```ruby
result = QexprQueryChunker.get_chunk_of_query(offset, limit, skip_header) do
      full_search_expr(npo_id, query).select(
        'recurring_donations.created_at',
        'recurring_donations.amount AS amount',
        "concat('Every ', recurring_donations.interval, ' ', recurring_donations.time_unit, '(s)') AS interval",
        '(SUM(paid_charges.amount) / 100.0)::money::text AS total_contributed',
        ...
end
result.map { |r| update_amount_with_currency(r, currency) }
```
update_amount_with_currency function:
```ruby
def self.update_amount_with_currency(query_row, currency)
    if query_row[1] != 'Amount'
      query_row[1] = print_currency(query_row[1], currency, true, true)
    end
    query_row
  end
```
