### PR TITLE
Remove second_image and third_image from Nonprofit

### DIFF
--- a/app/controllers/nonprofits_controller.rb
+++ b/app/controllers/nonprofits_controller.rb
@@ -142,8 +142,6 @@ class NonprofitsController < ApplicationController
       :email,
       :phone,
       :main_image,
-      :second_image,
-      :third_image,
       :background_image,
       :remove_background_image,
       :logo,

--- a/app/models/nonprofit.rb
+++ b/app/models/nonprofit.rb
@@ -15,8 +15,6 @@ class Nonprofit < ApplicationRecord
   # :email, # str: public organization contact email
   # :phone, # str: public org contact phone
   # :main_image, # str: url of featured image - first image in profile carousel
-  # :second_image, # str: url of 2nd image in carousel
-  # :third_image, # str: url of 3rd image in carousel
   # :background_image,  # str: url of large profile background
   # :remove_background_image, #bool carrierwave
   # :logo, # str: small logo image url for searching
@@ -114,8 +112,6 @@ class Nonprofit < ApplicationRecord
   scope :published, -> { where(published: true) }
 
   has_one_attached :main_image
-  has_one_attached :second_image
-  has_one_attached :third_image
   has_one_attached :background_image
   has_one_attached :logo
  
@@ -123,8 +119,7 @@ class Nonprofit < ApplicationRecord
   has_one_attached_with_sizes(:logo, {small: 30, normal: 100, large: 180})
   has_one_attached_with_sizes(:background_image, {normal: [1000,600]})
   has_one_attached_with_sizes(:main_image, {nonprofit_carousel: [590, 338], thumb: [188, 120], thumb_explore: [100, 100]})
-  has_one_attached_with_sizes(:second_image, {nonprofit_carousel: [590, 338], thumb: [188, 120], thumb_explore: [100, 100]})
-  has_one_attached_with_sizes(:third_image, {nonprofit_carousel: [590, 338], thumb: [188, 120], thumb_explore: [100, 100]})
+
 
   has_one_attached_with_default(:logo, Houdini.defaults.image.profile, 
     filename: "logo_#{SecureRandom.uuid}#{Pathname.new(Houdini.defaults.image.profile).extname}")
@@ -132,11 +127,6 @@ class Nonprofit < ApplicationRecord
       filename: "background_image_#{SecureRandom.uuid}#{Pathname.new(Houdini.defaults.image.nonprofit).extname}")
   has_one_attached_with_default(:main_image, Houdini.defaults.image.profile, 
       filename: "main_image_#{SecureRandom.uuid}#{Pathname.new(Houdini.defaults.image.profile).extname}")
-  has_one_attached_with_default(:second_image, Houdini.defaults.image.profile, 
-    filename: "second_image_#{SecureRandom.uuid}#{Pathname.new(Houdini.defaults.image.profile).extname}")
-  has_one_attached_with_default(:third_image, Houdini.defaults.image.profile, 
-    filename: "third_image_#{SecureRandom.uuid}#{Pathname.new(Houdini.defaults.image.profile).extname}")
-
 
 
   before_validation(on: :create) do

--- a/db/migrate/20220822211046_remove_second_and_third_images_from_nonprofit.rb
+++ b/db/migrate/20220822211046_remove_second_and_third_images_from_nonprofit.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+# Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
+class RemoveSecondAndThirdImagesFromNonprofit < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :nonprofits, :second_image
+    remove_column :nonprofits, :third_image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_05_212524) do
+ActiveRecord::Schema.define(version: 2022_08_22_211046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -561,8 +561,6 @@ ActiveRecord::Schema.define(version: 2022_08_05_212524) do
     t.string "phone", limit: 255
     t.string "email", limit: 255
     t.string "main_image", limit: 255
-    t.string "second_image", limit: 255
-    t.string "third_image", limit: 255
     t.string "website", limit: 255
     t.string "background_image", limit: 255
     t.string "logo", limit: 255


### PR DESCRIPTION
second_image and third_image were used in a legacy carousel UI. It doesn't exist anymore so let's remove them.
