### PR TITLE
Update Typescript target to es2018

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "jsx": "react",
     "experimentalDecorators": true,
     "baseUrl": "./",
-    "lib": ["dom", "scripthost", "ES2018"],
+    "lib": ["dom", "ES2018"],
     "paths": { "*": [ "./types/*"], "@rails/activestorage": ["./types/rails__activestorage"] },
     "typeRoots" : [
       "node_modules/@types",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,11 @@
     "skipLibCheck": true,
     "noImplicitAny": true,
     "module": "commonjs",
-    "target": "es5",
+    "target": "ES2018",
     "jsx": "react",
     "experimentalDecorators": true,
     "baseUrl": "./",
-    "lib": ["dom","es5", "scripthost", "es2015.promise"],
+    "lib": ["dom", "scripthost", "ES2018"],
     "paths": { "*": [ "./types/*"], "@rails/activestorage": ["./types/rails__activestorage"] },
     "typeRoots" : [
       "node_modules/@types",


### PR DESCRIPTION
IE is now so deprecated that I think we can drop support for it. Given that, let's move to a newer ES version. We can probably go higher than ES2018 but it's a good step up.

- Targeting ES2018 from Typescript
- Remove scripthost lib from tsconfig.json
