### PR TITLE
Switch add_houid to run just before_save

### DIFF
--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -23,32 +23,32 @@ module Model::Houidable
 		# @param houid_attribute {string|Symbol}: the attribute on this model to assign the Houid to. Defaults to :id.
 		###
 		def setup_houid(prefix, houid_attribute = :id)
-			
+
 			######
 			# 					define_model_callbacks :houid_set
 			# 					after_initialize :add_houid
-								
+
 			# 					# The HouID prefix as a symbol
 			# 					def houid_prefix
 			# 						:supp
 			# 					end
-								
+
 			# 					# Generates a HouID using the provided houid_prefix
 			# 					def generate_houid
 			# 						houid_prefix.to_s + "_" + SecureRandom.alphanumeric(22)
 			# 					end
-								
-			# 					private 
+
+			# 					private
 			# 					def add_houid
 			# 						run_callbacks(:houid_set) do
 			# 							write_attribute(:id, self.generate_houid) unless read_attribute(:id)
 			# 						end
 			# 					end
 			#####
-			class_eval <<-RUBY, __FILE__, __LINE__ + 1 # rubocop:disable Style/DocumentDynamicEvalDefinition 
+			class_eval <<-RUBY, __FILE__, __LINE__ + 1 # rubocop:disable Style/DocumentDynamicEvalDefinition
 								define_model_callbacks :houid_set
 								after_initialize :add_houid
-								
+
 								# The HouID prefix as a symbol
 								# def houid_prefix
 								#		:supp
@@ -58,15 +58,15 @@ module Model::Houidable
 								end
 
 								def houid_attribute
-									:#{houid_attribute} 
+									:#{houid_attribute}
 								end
-								
+
 								# Generates a HouID using the provided houid_prefix
 								def generate_houid
 									houid_prefix.to_s + "_" + SecureRandom.alphanumeric(22)
 								end
-								
-								private 
+
+								private
 								def add_houid
 									run_callbacks(:houid_set) do
 										write_attribute(self.houid_attribute, self.generate_houid) unless read_attribute(self.houid_attribute)

--- a/app/models/concerns/model/houidable.rb
+++ b/app/models/concerns/model/houidable.rb
@@ -3,30 +3,41 @@
 # License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
 # Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE
 
-# rubocop:disable Layout/TrailingWhitespace  # we do this becuase rubocop is bizarrely crashing on this file
+##
+# Provides support for Stripe-like string ids consisting of an short alphabetic string and underscore and then
+# 22 random base-62 characters (a-z, A-Z and 0-9). To use in a class, include this module and use {.setup_houid}
+# @see .setup_houid
 module Model::Houidable
 	extend ActiveSupport::Concern
 	class_methods do
 		###
-		# @description: Simplifies using HouIDs for an ActiveRecord class. HouIDs have the format of:
+		# Simplifies using HouIDs for an ActiveRecord class. HouIDs have the format of:
 		# prefix_{22 alphanumeric characters}. Prefixes must be unique across an Houdini instance.
 		# Given a prefix, adds the following features to a ActiveRecord class:
-		# - Sets a HouID to the id after object initialization (on "after_initialize" callback) if
+		# - Sets a HouID to the id before save (on "before_save" callback) if
 		#		it hasn't already been set
 		# - Adds a "before_houid_set" and "after_houid_set" callbacks in case you want do
-		#   somethings before or after that happens
+		#   some things before or after that happens
 		# - Adds  "before_houid_set" and "after_houid_set" callbacks if you want to take actions around
 		# - Adds two new public methods:
-		#    - houid_prefix - returns the prefix as a symbol
-		#    - generate_houid - creates a new HouID with given prefix
-		# @param prefix {string|Symbol}: the prefix for the HouIDs on this model
-		# @param houid_attribute {string|Symbol}: the attribute on this model to assign the Houid to. Defaults to :id.
+		#    - {#houid_prefix} - returns the prefix as a symbol
+		#    - {#generate_houid} - creates a new HouID with given prefix
+		# @param prefix [string, Symbol] the prefix for the HouIDs on this model
+		# @param houid_attribute [string, Symbol] the attribute on this model to assign the Houid to. Defaults to :id.
+		# @example  HouIDs for this class, on the :id attribute, will start with 'supp_'
+		#		class CustomSupporter
+		#   	setup_houid(:supp)
+		#		end
+		# @example HouIDs for this class, on the :houid attribute, will start with 'supp_'
+		#		class CustomSupporter
+		#   	setup_houid(:supp, :houid)
+		#		end
+		#
 		###
 		def setup_houid(prefix, houid_attribute = :id)
-
 			######
 			# 					define_model_callbacks :houid_set
-			# 					after_initialize :add_houid
+			# 					before_save :add_houid
 
 			# 					# The HouID prefix as a symbol
 			# 					def houid_prefix
@@ -47,7 +58,7 @@ module Model::Houidable
 			#####
 			class_eval <<-RUBY, __FILE__, __LINE__ + 1 # rubocop:disable Style/DocumentDynamicEvalDefinition
 								define_model_callbacks :houid_set
-								after_initialize :add_houid
+								before_save :add_houid
 
 								# The HouID prefix as a symbol
 								# def houid_prefix
@@ -76,5 +87,3 @@ module Model::Houidable
 		end
 	end
 end
-
-# rubocop:enable Layout/TrailingWhitespace

--- a/spec/models/concerns/model/houidable_spec.rb
+++ b/spec/models/concerns/model/houidable_spec.rb
@@ -15,9 +15,16 @@ RSpec.describe Model::Houidable do
 			attr_accessor :id, :houid_id
 
 			define_model_callbacks :initialize
+			define_model_callbacks :save
 			def initialize(attributes = {})
 				run_callbacks :initialize do
 					assign_attributes(attributes)
+				end
+			end
+
+			def save
+				run_callbacks :save do
+					# run save
 				end
 			end
 
@@ -68,28 +75,54 @@ RSpec.describe Model::Houidable do
 			expect(default_trxassign.generate_houid).to match_houid(prefix)
 		end
 
-		it 'sets a valid houid as id' do
-			expect(default_trxassign.id).to match_houid(prefix)
+		context 'when only initialized' do
+			it 'doesnt set a houid' do
+				expect(default_trxassign.id).to be_nil
+			end
+
+			it 'will not override an id if already set' do
+				expect(already_set_houid.id).to eq preset_houid
+			end
+
+			it 'will not fire the before_houid_set callback' do
+				with_before_set_callback.callback_handler = double('Before Callback Handler')
+				expect(with_before_set_callback.callback_handler).to_not receive(:before_houid_set_callback)
+				with_before_set_callback.new
+			end
+
+			it 'will not fire the after_houid_set callback' do
+				with_after_set_callback.callback_handler = double('After Callback Handler')
+				expect(with_after_set_callback.callback_handler).to_not receive(:after_houid_set_callback)
+				with_after_set_callback.new
+			end
 		end
 
-		it 'will not override an id if already set' do
-			expect(already_set_houid.id).to eq preset_houid
-		end
+		context 'when saved' do
+			it 'generates a valid houid' do
+				default_trxassign.save
+				expect(default_trxassign.id).to match_houid(prefix)
+			end
 
-		it 'fires the before_houid_set callback' do
-			with_before_set_callback.callback_handler = double('Before Callback Handler')
-			expect(with_before_set_callback.callback_handler).to receive(:before_houid_set_callback).with(
-				having_attributes(id: nil)
-			)
-			with_before_set_callback.new
-		end
+			it 'will not override an id if already set' do
+				already_set_houid.save
+				expect(already_set_houid.id).to eq preset_houid
+			end
 
-		it 'fires the after_houid_set callback' do
-			with_after_set_callback.callback_handler = double('After Callback Handler')
-			expect(with_after_set_callback.callback_handler).to receive(:after_houid_set_callback).with(
-				having_attributes(id: match_houid(:trxassign))
-			)
-			with_after_set_callback.new
+			it 'fires the before_houid_set callback' do
+				with_before_set_callback.callback_handler = double('Before Callback Handler')
+				expect(with_before_set_callback.callback_handler).to receive(:before_houid_set_callback).with(
+					having_attributes(id: nil)
+				)
+				with_before_set_callback.new.save
+			end
+
+			it 'fires the after_houid_set callback' do
+				with_after_set_callback.callback_handler = double('After Callback Handler')
+				expect(with_after_set_callback.callback_handler).to receive(:after_houid_set_callback).with(
+					having_attributes(id: match_houid(:trxassign))
+				)
+				with_after_set_callback.new.save
+			end
 		end
 	end
 
@@ -129,28 +162,54 @@ RSpec.describe Model::Houidable do
 			expect(default_trxassign.generate_houid).to match_houid(prefix)
 		end
 
-		it 'sets a valid houid as id' do
-			expect(default_trxassign.houid_id).to match_houid(prefix)
+		context 'when only initialized' do
+			it 'does not set a houid' do
+				expect(default_trxassign.houid_id).to be_nil
+			end
+
+			it 'will not override an id if already set' do
+				expect(already_set_houid.houid_id).to eq preset_houid
+			end
+
+			it 'will not fire the before_houid_set callback' do
+				with_before_set_callback.callback_handler = double('Before Callback Handler') # rubocop:disable RSpec/VerifiedDoubles
+				expect(with_before_set_callback.callback_handler).to_not receive(:before_houid_set_callback)
+				with_before_set_callback.new
+			end
+
+			it 'will not fire the after_houid_set callback' do
+				with_after_set_callback.callback_handler = double('After Callback Handler') # rubocop:disable RSpec/VerifiedDoubles
+				expect(with_after_set_callback.callback_handler).to_not receive(:after_houid_set_callback)
+				with_after_set_callback.new
+			end
 		end
 
-		it 'will not override an id if already set' do
-			expect(already_set_houid.houid_id).to eq preset_houid
-		end
+		context 'when saved' do
+			it 'sets a valid houid as id' do
+				default_trxassign.save
+				expect(default_trxassign.houid_id).to match_houid(prefix)
+			end
 
-		it 'fires the before_houid_set callback' do
-			with_before_set_callback.callback_handler = double('Before Callback Handler') # rubocop:disable RSpec/VerifiedDoubles
-			expect(with_before_set_callback.callback_handler).to receive(:before_houid_set_callback).with(
-				having_attributes(houid_id: nil)
-			)
-			with_before_set_callback.new
-		end
+			it 'will not override an id if already set' do
+				already_set_houid.save
+				expect(already_set_houid.houid_id).to eq preset_houid
+			end
 
-		it 'fires the after_houid_set callback' do
-			with_after_set_callback.callback_handler = double('After Callback Handler') # rubocop:disable RSpec/VerifiedDoubles
-			expect(with_after_set_callback.callback_handler).to receive(:after_houid_set_callback).with(
-				having_attributes(houid_id: match_houid(:trxassign))
-			)
-			with_after_set_callback.new
+			it 'fires the before_houid_set callback' do
+				with_before_set_callback.callback_handler = double('Before Callback Handler') # rubocop:disable RSpec/VerifiedDoubles
+				expect(with_before_set_callback.callback_handler).to receive(:before_houid_set_callback).with(
+					having_attributes(houid_id: nil)
+				)
+				with_before_set_callback.new.save
+			end
+
+			it 'fires the after_houid_set callback' do
+				with_after_set_callback.callback_handler = double('After Callback Handler') # rubocop:disable RSpec/VerifiedDoubles
+				expect(with_after_set_callback.callback_handler).to receive(:after_houid_set_callback).with(
+					having_attributes(houid_id: match_houid(:trxassign))
+				)
+				with_after_set_callback.new.save
+			end
 		end
 	end
 end


### PR DESCRIPTION
Currently, add_houid runs right after initialize on models. That's annoying becuase it's inconsistent with how integer autocreated IDs are added. This changes the behavior so a Houid is generated just before save.
