### PR TITLE
Fix syntax error in create_stripe_account.rb

### DIFF
--- a/app/legacy_lib/create_stripe_account.rb
+++ b/app/legacy_lib/create_stripe_account.rb
@@ -6,7 +6,7 @@ require 'stripe'
 
 module CreateStripeAccount
   def self.for_nonprofit(user, params)
-    fst_name, lst_name = Format::Name.split_full(user&.profile&.name))
+    fst_name, lst_name = Format::Name.split_full(user&.profile&.name)
     Stripe::Account.create(
       managed: true,
       email: params[:email],


### PR DESCRIPTION
I'm just dusting off a demo production install of Houdini after 8 months or so and ran into the following error after doing a `git pull` and starting up the production instance (`source .env && bin/rails server --log-to-stdout`). Appears to be just a syntax error from a change back in August 2022, which is fixed in this merge request.

I'm curious as to how the syntax error managed to survive this long though. Am I missing something?

```
Jun 20 00:59:57 donationtest systemd[1]: Started Houdini.
Jun 20 00:59:58 donationtest bash[2248081]: => Booting Puma
Jun 20 00:59:58 donationtest bash[2248081]: => Rails 6.1.7.3 application starting in production
Jun 20 00:59:58 donationtest bash[2248081]: => Run `bin/rails server --help` for more startup options
Jun 20 00:59:58 donationtest bash[2248081]: /srv/houdini/.gems/gems/net-protocol-0.2.1/lib/net/protocol.rb:68: warning: already initialized constant Net::ProtocRetryError
Jun 20 00:59:58 donationtest bash[2248081]: /usr/lib/ruby/2.7.0/net/protocol.rb:66: warning: previous definition of ProtocRetryError was here
Jun 20 00:59:58 donationtest bash[2248081]: /srv/houdini/.gems/gems/net-protocol-0.2.1/lib/net/protocol.rb:214: warning: already initialized constant Net::BufferedIO::BUFSIZE
Jun 20 00:59:58 donationtest bash[2248081]: /usr/lib/ruby/2.7.0/net/protocol.rb:206: warning: previous definition of BUFSIZE was here
Jun 20 00:59:58 donationtest bash[2248081]: /srv/houdini/.gems/gems/net-protocol-0.2.1/lib/net/protocol.rb:541: warning: already initialized constant Net::NetPrivate::Socket
Jun 20 00:59:58 donationtest bash[2248081]: /usr/lib/ruby/2.7.0/net/protocol.rb:503: warning: previous definition of Socket was here
Jun 20 00:59:59 donationtest bash[2248081]: Exiting
Jun 20 00:59:59 donationtest bash[2248081]: /srv/houdini/.gems/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require': /srv/houdini/app/legacy_lib/create_stripe_account.rb:9: syntax error, unexpected ')', expecting `end' (SyntaxError)
Jun 20 00:59:59 donationtest bash[2248081]: ...plit_full(user&.profile&.name))
Jun 20 00:59:59 donationtest bash[2248081]: ...                              ^
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/kernel.rb:30:in `require'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:135:in `const_get'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:135:in `cget'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:169:in `block in actual_eager_load_dir'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:40:in `block in ls'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:25:in `each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/helpers.rb:25:in `ls'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:164:in `actual_eager_load_dir'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:16:in `each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader.rb:329:in `block in eager_load_all'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader.rb:327:in `each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/zeitwerk-2.6.8/lib/zeitwerk/loader.rb:327:in `eager_load_all'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/application/finisher.rb:133:in `block in <module:Finisher>'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/initializable.rb:32:in `instance_exec'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/initializable.rb:32:in `run'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/initializable.rb:61:in `block in run_initializers'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:347:in `each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:347:in `call'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /usr/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/initializable.rb:60:in `run_initializers'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/application.rb:391:in `initialize!'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/config/environment.rb:12:in `<main>'
Jun 20 00:59:59 donationtest bash[2248081]:         from config.ru:5:in `require_relative'
Jun 20 00:59:59 donationtest bash[2248081]:         from config.ru:5:in `block in <main>'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/builder.rb:116:in `eval'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/builder.rb:116:in `new_from_string'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/builder.rb:105:in `load_file'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/builder.rb:66:in `parse_file'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/server.rb:349:in `build_app_and_options_from_config'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/server.rb:249:in `app'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/rack-2.2.7/lib/rack/server.rb:422:in `wrapped_app'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/commands/server/server_command.rb:77:in `log_to_stdout'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/commands/server/server_command.rb:37:in `start'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/commands/server/server_command.rb:144:in `block in perform'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/commands/server/server_command.rb:135:in `tap'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/commands/server/server_command.rb:135:in `perform'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/thor-1.2.2/lib/thor/command.rb:27:in `run'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/thor-1.2.2/lib/thor/invocation.rb:127:in `invoke_command'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/thor-1.2.2/lib/thor.rb:392:in `dispatch'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/command/base.rb:69:in `perform'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/command.rb:48:in `invoke'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/railties-6.1.7.3/lib/rails/commands.rb:18:in `<main>'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
Jun 20 00:59:59 donationtest bash[2248081]:         from /srv/houdini/.gems/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require'
Jun 20 00:59:59 donationtest bash[2248081]:         from bin/rails:9:in `<main>'
Jun 20 00:59:59 donationtest systemd[1]: houdini.service: Main process exited, code=exited, status=1/FAILURE
Jun 20 00:59:59 donationtest systemd[1]: houdini.service: Failed with result 'exit-code'.
Jun 20 00:59:59 donationtest systemd[1]: houdini.service: Consumed 1.603s CPU time.
```