### PR TITLE
Revert "Remove unused event_preview_small.css.scss"

### DIFF
--- a/app/assets/stylesheets/components/event_preview_small.css.scss
+++ b/app/assets/stylesheets/components/event_preview_small.css.scss
@@ -1,0 +1,40 @@
+/* License: AGPL-3.0-or-later WITH WTO-AP-3.0-or-later
+Full license explanation at https://github.com/houdiniproject/houdini/blob/main/LICENSE */
+@import 'mixins';
+
+.eventPreview--small {
+  position: relative;
+	overflow: hidden;
+	border-bottom: 1px solid rgba($grey, 0.2);
+}
+.eventPreview--small:nth-of-type(2n -1){
+	background: rgba($sky, 0.02);
+}
+.eventPreview--small-cal {
+	width: 55px;
+  position: absolute;
+  top: 0;
+  left: 0;
+	text-align: center;
+	background: white;
+	border-left: 1px solid rgba($grey, 0.05);
+	border-right: 1px solid rgba($grey, 0.05);
+	font-size: 15px;
+	font-weight: bold;
+	@include open-sans-condensed;
+}
+.eventPreview--small-month {
+	text-transform: uppercase;
+	background: rgba($charcoal, 0.5);
+	display: inline-block;
+	width: 100%;
+	line-height: 28px;
+	color: white;
+}
+.eventPreview--small-day {
+	line-height: 42px;
+	color: rgba($charcoal, 0.7);
+}
+.eventPreview--small-text {
+  padding: 5px 5px 10px 65px;
+}


### PR DESCRIPTION
This reverts commit c1660b61fe938860bad9a2e3c215ffd498ba9bb4.

Fixes #1582. The file "event_preview_small.css.scss" is required by "app/assets/stylesheets/nonprofits/dashboard/page.css.scss".