### PR TITLE
Fixed issue of sidebar overlap

### DIFF
--- a/app/assets/stylesheets/components/side_nav.css.scss
+++ b/app/assets/stylesheets/components/side_nav.css.scss
@@ -8,6 +8,7 @@ $sideNav-spacing: 8px 15px;
 
 .sideNav {
 	background: $charcoal;
+	z-index: 9999;
 	height: 100%;
 	left: 0;
 	top: 0;


### PR DESCRIPTION
Added the z-index property to the .sideNav selector to ensure that the sidebar stays above other elements on the page when the mouse is hovered over it.

Title: Fix for Issue 1587: Sidebar Overlap

Description:
This pull request addresses Issue 1587, resolving the problem of sidebar overlap. We have made the necessary CSS adjustments and updated relevant HTML elements to ensure that the sidebar no longer overlaps with other page elements. Thorough testing has been performed to validate the solution.

Contributors:
- José Luís
- Abraão Alves 
- Lucas Ramon

Please review and merge at your convenience. Thank you! 