### PR TITLE
Switch to test:js

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -52,8 +52,8 @@ jobs:
       - run: bin/setup ci
       - name: Generate JS routes
         run: bin/rails js:routes:typescript
-      - name: run jest
-        run: yarn jest
+      - name: run test:js
+        run: yarn test:js
   webpack:
     needs: package-download
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ failures is zero.
 We also recommend you run through the javascript test cases by running:
 
 ```bash
-yarn jest
+yarn test:js
 ```
 
 Lastly, you can use [Storybook](https://storybook.js.org/) to experiment with

--- a/docs/getting_started_wsl2.md
+++ b/docs/getting_started_wsl2.md
@@ -197,7 +197,7 @@ The important thing to look for is that the number of failures is zero.
 We also recommend you run through the JavaScript test cases by running:
 
 ```bash
-yarn jest
+yarn test:js
 ```
 
 Lastly, you can use [Storybook](https://storybook.js.org/) to experiment with

--- a/package.json
+++ b/package.json
@@ -8,9 +8,8 @@
   "scripts": {
     "build-all": "yarn install --frozen-lockfile && script/compile-assets.sh && yarn build",
     "ci-build-all": "script/compile-assets.sh && yarn build",
-    "test": "bin/rails spec  && yarn jest",
-    "jest": "bin/rails js:generate && jest",
-    "jest_only": "jest",
+    "test": "bin/rails spec  && yarn test:js",
+    "test:js": "bin/rails js:generate && jest",
     "eslint": "eslint . --ext .ts,.js,.tsx",
     "storybook": "bin/rails js:generate && start-storybook -p 6006 -c .storybook/react --no-version-updates --no-release-notes",
     "build-storybook": "bin/rails js:generate && build-storybook -c .storybook/react",
@@ -18,7 +17,7 @@
     "build-html-storybook": "bin/build-html-storybook -c .storybook/html",
     "markdownlint": "npx markdownlint-cli '**/*.md' --ignore node_modules",
     "prepare-for-push": "yarn test && yarn eslint --fix && yarn markdownlint --fix && bin/rails notice:update",
-    "prepare-for-push-js": "yarn jest && yarn eslint --fix && yarn markdownlint --fix && bin/rails notice:js:update",
+    "prepare-for-push-js": "yarn test:js && yarn eslint --fix && yarn markdownlint --fix && bin/rails notice:js:update",
     "notice:js": "npx @houdiniproject/noticeme@^1.1.0-pre1 -f NOTICE-js -i included.json -s 250",
     "webpack": "bin/webpack"
   },

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-yarn ci && bin/rails db:create db:schema:load db:migrate && RAILS_ENV=test bin/rails db:create db:schema:load test:prepare && bin/rails spec && yarn run build-all && yarn jest
+yarn ci && bin/rails db:create db:schema:load db:migrate && RAILS_ENV=test bin/rails db:create db:schema:load test:prepare && bin/rails spec && yarn run build-all && yarn test:js


### PR DESCRIPTION
`yarn jest` often caused conflict with other tools many of them expect `yarn jest` to not run anytbing other than the Jest command. This renames that NPM script to `test:js`
