### PR TITLE
Lock concurrent-ruby

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -41,7 +41,7 @@ jobs:
           wait-for-processing: true
   rubocop:
     name: Run rubocop
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/single-matrix-pr.yml
+++ b/.github/workflows/single-matrix-pr.yml
@@ -41,7 +41,7 @@ jobs:
     name: Lint markdown code
     needs: changes
     if: ${{ contains(needs.changes.outputs.filters, 'markdown')}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Run markdownlint

--- a/Gemfile
+++ b/Gemfile
@@ -106,3 +106,5 @@ gem 'http_accept_language'
 gem "js-routes"
 
 gem "csv"
+
+gem "concurrent-ruby", "1.3.4" # work around a regression fixed in Rails 7.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,6 +511,7 @@ DEPENDENCIES
   bootsnap (~> 1.18)
   chronic (~> 0.10.2)
   colorize (~> 0.8.1)
+  concurrent-ruby (= 1.3.4)
   countries (~> 4.2)
   csv
   database_cleaner-active_record

--- a/gems/bess/bess.gemspec
+++ b/gems/bess/bess.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rspec', '~> 3.13.0'
   spec.add_development_dependency 'rspec-rails', '~> 4.0.0'
+  spec.add_development_dependency "concurrent-ruby", "1.3.4" # until Rails 7.1 becuase of the regression in concurrent-ruby
 
 
 end


### PR DESCRIPTION
- **Use standard rubocop config**
- **Update the code-scanning**
- **Switch to using ubuntu-latest**
- **Try again**
- **Lock concurrent-ruby to 1.3.4**
